### PR TITLE
Enable Authentication control

### DIFF
--- a/deploy/examples/api_v1alpha1_astarte_cr.yaml
+++ b/deploy/examples/api_v1alpha1_astarte_cr.yaml
@@ -134,6 +134,7 @@ spec:
     housekeeping:
       api:
         replicas: 1
+        disableAuthentication: false
         resources:
           requests:
             cpu: 100m
@@ -153,6 +154,7 @@ spec:
     realmManagement:
       api:
         replicas: 1
+        disableAuthentication: false
         resources:
           requests:
             cpu: 100m
@@ -172,6 +174,7 @@ spec:
     pairing:
       api:
         replicas: 1
+        disableAuthentication: false
         resources:
           requests:
             cpu: 100m
@@ -199,6 +202,7 @@ spec:
           memory: 1024M
     appengineApi:
       replicas: 1
+      disableAuthentication: false
       resources:
         requests:
           cpu: 400m

--- a/playbook/deploy.yml
+++ b/playbook/deploy.yml
@@ -63,6 +63,7 @@
       tags:
         - housekeeping
       astarte_app_name: housekeeping
+      disable_authentication: "{{ astarte_housekeeping_api_k8s_disable_authentication }}"
       k8s_deployment_replicas: "{{ vars | json_query('components.housekeeping.api.replicas') | default(astarte_housekeeping_api_k8s_replicas, true) }}"
       k8s_deployment_resources_requests_cpu: "{{ vars | json_query('components.housekeeping.api.resources.requests.cpu') | default(astarte_housekeeping_api_k8s_resources_requests_cpu, true) }}"
       k8s_deployment_resources_requests_memory: "{{ vars | json_query('components.housekeeping.api.resources.requests.memory') | default(astarte_housekeeping_api_k8s_resources_requests_memory, true) }}"
@@ -93,6 +94,7 @@
       tags:
         - realm_management
       astarte_app_name: realm_management
+      disable_authentication: "{{ astarte_realm_management_api_k8s_disable_authentication }}"
       k8s_deployment_replicas: "{{ vars | json_query('components.realm_management.api.replicas') | default(astarte_realm_management_api_k8s_replicas, true) }}"
       k8s_deployment_resources_requests_cpu: "{{ vars | json_query('components.realm_management.api.resources.requests.cpu') | default(astarte_realm_management_api_k8s_resources_requests_cpu, true) }}"
       k8s_deployment_resources_requests_memory: "{{ vars | json_query('components.realm_management.api.resources.requests.memory') | default(astarte_realm_management_api_k8s_resources_requests_memory, true) }}"
@@ -119,6 +121,7 @@
       tags:
         - pairing
       astarte_app_name: pairing
+      disable_authentication: "{{ astarte_pairing_api_k8s_disable_authentication }}"
       k8s_deployment_replicas: "{{ vars | json_query('components.pairing.api.replicas') | default(astarte_pairing_api_k8s_replicas, true) }}"
       k8s_deployment_resources_requests_cpu: "{{ vars | json_query('components.pairing.api.resources.requests.cpu') | default(astarte_pairing_api_k8s_resources_requests_cpu, true) }}"
       k8s_deployment_resources_requests_memory: "{{ vars | json_query('components.pairing.api.resources.requests.memory') | default(astarte_pairing_api_k8s_resources_requests_memory, true) }}"
@@ -164,6 +167,7 @@
       tags:
         - appengine
       astarte_app_name: appengine
+      disable_authentication: "{{ astarte_appengine_api_k8s_disable_authentication }}"
       k8s_deployment_replicas: "{{ vars | json_query('components.appengine_api.replicas') | default(astarte_appengine_api_k8s_replicas, true) }}"
       k8s_deployment_resources_requests_cpu: "{{ vars | json_query('components.appengine_api.resources.requests.cpu') | default(astarte_appengine_api_k8s_resources_requests_cpu, true) }}"
       k8s_deployment_resources_requests_memory: "{{ vars | json_query('components.appengine_api.resources.requests.memory') | default(astarte_appengine_api_k8s_resources_requests_memory, true) }}"

--- a/playbook/group_vars/all
+++ b/playbook/group_vars/all
@@ -89,6 +89,7 @@ astarte_housekeeping_api_k8s_resources_requests_memory: "{{ (astarte_k8s_resourc
 astarte_housekeeping_api_k8s_resources_limits_cpu: "{{ (astarte_k8s_resources_limits_cpu_millis|float * 0.07) | round(0, 'floor') | int | string + 'm' }}"
 astarte_housekeeping_api_k8s_resources_limits_memory: "{{ (astarte_k8s_resources_limits_memory_megs|float * 0.07) | round(0, 'floor') | int | string + 'M' }}"
 astarte_housekeeping_api_k8s_replicas: 1
+astarte_housekeeping_api_k8s_disable_authentication: "{{ true if (vars | json_query('components.housekeeping.api.disable_authentication')) is sameas true else false }}"
 ## Realm Management
 astarte_realm_management_k8s_resources_requests_cpu: "{{ (astarte_k8s_resources_requests_cpu_millis|float * 0.07) | round(0, 'floor') | int | string + 'm' }}"
 astarte_realm_management_k8s_resources_requests_memory: "{{ (astarte_k8s_resources_requests_memory_megs|float * 0.07) | round(0, 'floor') | int | string + 'M' }}"
@@ -100,6 +101,7 @@ astarte_realm_management_api_k8s_resources_requests_memory: "{{ (astarte_k8s_res
 astarte_realm_management_api_k8s_resources_limits_cpu: "{{ (astarte_k8s_resources_limits_cpu_millis|float * 0.07) | round(0, 'floor') | int | string + 'm' }}"
 astarte_realm_management_api_k8s_resources_limits_memory: "{{ (astarte_k8s_resources_limits_memory_megs|float * 0.07) | round(0, 'floor') | int | string + 'M' }}"
 astarte_realm_management_api_k8s_replicas: 1
+astarte_realm_management_api_k8s_disable_authentication: "{{ true if (vars | json_query('components.realm_management.api.disable_authentication')) is sameas true else false }}"
 ## Pairing
 astarte_pairing_k8s_resources_requests_cpu: "{{ (astarte_k8s_resources_requests_cpu_millis|float * 0.07) | round(0, 'floor') | int | string + 'm' }}"
 astarte_pairing_k8s_resources_requests_memory: "{{ (astarte_k8s_resources_requests_memory_megs|float * 0.07) | round(0, 'floor') | int | string + 'M' }}"
@@ -110,6 +112,7 @@ astarte_pairing_api_k8s_resources_requests_cpu: "{{ (astarte_k8s_resources_reque
 astarte_pairing_api_k8s_resources_requests_memory: "{{ (astarte_k8s_resources_requests_memory_megs|float * 0.07) | round(0, 'floor') | int | string + 'M' }}"
 astarte_pairing_api_k8s_resources_limits_cpu: "{{ (astarte_k8s_resources_limits_cpu_millis|float * 0.07) | round(0, 'floor') | int | string + 'm' }}"
 astarte_pairing_api_k8s_resources_limits_memory: "{{ (astarte_k8s_resources_limits_memory_megs|float * 0.07) | round(0, 'floor') | int | string + 'M' }}"
+astarte_pairing_api_k8s_disable_authentication: "{{ true if (vars | json_query('components.pairing.api.disable_authentication')) is sameas true else false }}"
 astarte_pairing_api_k8s_replicas: 1
 ## Data Updater Plant
 astarte_data_updater_plant_k8s_resources_requests_cpu: "{{ (astarte_k8s_resources_requests_cpu_millis|float * 0.22) | round(0, 'floor') | int | string + 'm' }}"
@@ -122,6 +125,7 @@ astarte_appengine_api_k8s_resources_requests_cpu: "{{ (astarte_k8s_resources_req
 astarte_appengine_api_k8s_resources_requests_memory: "{{ (astarte_k8s_resources_requests_memory_megs|float * 0.22) | round(0, 'floor') | int | string + 'M' }}"
 astarte_appengine_api_k8s_resources_limits_cpu: "{{ (astarte_k8s_resources_limits_cpu_millis|float * 0.22) | round(0, 'floor') | int | string + 'm' }}"
 astarte_appengine_api_k8s_resources_limits_memory: "{{ (astarte_k8s_resources_limits_memory_megs|float * 0.22) | round(0, 'floor') | int | string + 'M' }}"
+astarte_appengine_api_k8s_disable_authentication: "{{ true if (vars | json_query('components.appengine.api.disable_authentication')) is sameas true else false }}"
 astarte_appengine_api_k8s_replicas: 1
 ## Trigger Engine
 astarte_trigger_engine_k8s_resources_requests_cpu: "{{ (astarte_k8s_resources_requests_cpu_millis|float * 0.14) | round(0, 'floor') | int | string + 'm' }}"

--- a/playbook/roles/astarte-generic-api-service/defaults/main.yml
+++ b/playbook/roles/astarte-generic-api-service/defaults/main.yml
@@ -11,6 +11,7 @@ k8s_erlang_cookie_name: "{{ resources_computed_prefix }}{{ k8s_service_name }}-
 astarte_app_amqp_connection_host: "{{ vars | json_query('rabbitmq.connection.host') | default(rabbitmq_connection_host, true) }}"
 astarte_app_api_port: 4000
 check_api_health: true
+disable_authentication: false
 
 k8s_deployment_additional_volume_mounts:
 k8s_deployment_additional_variables:

--- a/playbook/roles/astarte-generic-api-service/templates/astarte-generic-api-deployment.yml
+++ b/playbook/roles/astarte-generic-api-service/templates/astarte-generic-api-deployment.yml
@@ -85,6 +85,10 @@ spec:
             value: "{{ astarte_app_amqp_connection_host }}"
           - name: {{ astarte_app_name | upper }}_API_PORT
             value: "{{ astarte_app_api_port }}"
+{% if disable_authentication %}
+          - name: {{ astarte_app_name | upper }}_API_DISABLE_AUTHENTICATION
+            value: "true"
+{% endif %}
 {% if k8s_deployment_additional_variables %}
 {% for variable in k8s_deployment_additional_variables %}
           - name: {{ variable.name }}


### PR DESCRIPTION
This way, the operator can expose the *_DISABLE_AUTHENTICATION variables for
each API service, allowing deployments without authentication gates.

Putting it in 0.10, as it exposes a 0.10 feature.