### PR TITLE
Fix housekeeping keypair naming throughout the repo

### DIFF
--- a/playbook/deploy.yml
+++ b/playbook/deploy.yml
@@ -74,7 +74,7 @@
           value: "/jwtpubkey/public-key"
       k8s_deployment_additional_secret_volumes:
         - name: jwtpubkey
-          secretName: "{{ astarte_housekeeping_key_secret }}"
+          secretName: "{{ astarte_housekeeping_public_key_secret }}"
       k8s_deployment_additional_volume_mounts:
         - name: jwtpubkey
           mountPath: "/jwtpubkey"

--- a/playbook/group_vars/all
+++ b/playbook/group_vars/all
@@ -23,8 +23,9 @@ cfssl_url: "http://{{ resources_computed_prefix }}cfssl.{{ astarte_k8s_namespace
 
 # This weird conditional means: default to empty when running from the Operator, and to 'housekeeping.pub'
 # when running as a standard playbook.
-astarte_housekeeping_key_file: "{{ '' if vars | json_query('meta.name') else 'housekeeping.pub' }}"
-astarte_housekeeping_key_secret: "{{ resources_computed_prefix }}housekeeping-jwt"
+astarte_housekeeping_public_key_file: "{{ '' if vars | json_query('meta.name') else 'housekeeping.pub' }}"
+astarte_housekeeping_public_key_secret: "{{ resources_computed_prefix }}housekeeping-public-key"
+astarte_housekeeping_private_key_secret: "{{ resources_computed_prefix }}housekeeping-private-key"
 
 # Reasonable K8S Deployment Policies
 k8s_storage_class_name: "{{ vars | json_query('storage_class_name') | default('', true) }}"

--- a/playbook/roles/astarte-common/tasks/generate-housekeeping-key.yml
+++ b/playbook/roles/astarte-common/tasks/generate-housekeeping-key.yml
@@ -1,35 +1,35 @@
 - name: Generating RSA Housekeeping private key
   openssl_privatekey:
-    path: /tmp/astarte_housekeeping_private_key.pem
+    path: /tmp/astarte_housekeeping.key
     size: 4096
     type: RSA
     force: yes
 
 - name: Generating RSA Housekeeping public key
   openssl_publickey:
-    path: /tmp/astarte_housekeeping_private_key.pub
-    privatekey_path: /tmp/astarte_housekeeping_private_key.pem
+    path: /tmp/astarte_housekeeping.pub
+    privatekey_path: /tmp/astarte_housekeeping.key
     format: PEM
     force: yes
 
 - name: Store Housekeeping private key in dedicated K8S secret
   k8s:
     state: present
-    definition: "{{ lookup('template', 'housekeeping-jwt-private.yml') }}"
+    definition: "{{ lookup('template', 'housekeeping-private-key.yml') }}"
   ignore_errors: yes
-  register: housekeeping_public_key_installed
+  register: housekeeping_private_key_installed
 
 - name: Ensure Housekeeping public key from generated file
   k8s:
     state: present
-    definition: "{{ lookup('template', 'housekeeping-jwt-generated.yml') }}"
+    definition: "{{ lookup('template', 'housekeeping-public-key.yml') }}"
 
 - name: Delete RSA Housekeeping private key
   openssl_privatekey:
-    path: /tmp/astarte_housekeeping_private_key.pem
+    path: /tmp/astarte_housekeeping.key
     state: absent
 
 - name: Delete RSA Housekeeping public key
   openssl_publickey:
-    path: /tmp/astarte_housekeeping_private_key.pub
+    path: /tmp/astarte_housekeeping.pub
     state: absent

--- a/playbook/roles/astarte-common/tasks/main.yml
+++ b/playbook/roles/astarte-common/tasks/main.yml
@@ -24,11 +24,11 @@
 - name: Ensure Housekeeping public key from local file
   k8s:
     state: present
-    definition: "{{ lookup('template', 'housekeeping-jwt.yml') }}"
+    definition: "{{ lookup('template', 'housekeeping-public-key-from-file.yml') }}"
   when: astarte_housekeeping_key_file
 
 # If a file was not given, generate a housekeeping key only if one does not exist yet.
 - import_tasks: generate-housekeeping-key.yml
   when:
     - not astarte_housekeeping_key_file
-    - not lookup('k8s', kind='Secret', resource_name=astarte_housekeeping_key_secret, namespace=astarte_k8s_namespace)
+    - not lookup('k8s', kind='Secret', resource_name=astarte_housekeeping_public_key_secret, namespace=astarte_k8s_namespace)

--- a/playbook/roles/astarte-common/templates/housekeeping-jwt-generated.yml
+++ b/playbook/roles/astarte-common/templates/housekeeping-jwt-generated.yml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ astarte_housekeeping_key_secret }}
-  namespace: {{ astarte_k8s_namespace }}
-type: Opaque
-data:
-  public-key: {{ lookup('file', '/tmp/astarte_housekeeping_private_key.pub') | b64encode }}

--- a/playbook/roles/astarte-common/templates/housekeeping-jwt-private.yml
+++ b/playbook/roles/astarte-common/templates/housekeeping-jwt-private.yml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ astarte_housekeeping_key_secret }}-private
-  namespace: {{ astarte_k8s_namespace }}
-type: Opaque
-data:
-  private-key: {{ lookup('file', '/tmp/astarte_housekeeping_private_key.pem') | b64encode }}

--- a/playbook/roles/astarte-common/templates/housekeeping-private-key.yml
+++ b/playbook/roles/astarte-common/templates/housekeeping-private-key.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ astarte_housekeeping_private_key_secret }}
+  namespace: {{ astarte_k8s_namespace }}
+type: Opaque
+data:
+  private-key: {{ lookup('file', '/tmp/astarte_housekeeping.key') | b64encode }}

--- a/playbook/roles/astarte-common/templates/housekeeping-public-key-from-file.yml
+++ b/playbook/roles/astarte-common/templates/housekeeping-public-key-from-file.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ astarte_housekeeping_key_secret }}
+  name: {{ astarte_housekeeping_public_key_secret }}
   namespace: {{ astarte_k8s_namespace }}
 type: Opaque
 data:

--- a/playbook/roles/astarte-common/templates/housekeeping-public-key.yml
+++ b/playbook/roles/astarte-common/templates/housekeeping-public-key.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ astarte_housekeeping_public_key_secret }}
+  namespace: {{ astarte_k8s_namespace }}
+type: Opaque
+data:
+  public-key: {{ lookup('file', '/tmp/astarte_housekeeping.pub') | b64encode }}


### PR DESCRIPTION
Make it clear when we're referring to the public key and when we're
referring to the private key