### PR TITLE
AVI: Allow specifying the static load balancer IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.10.1] - Unreleased
+### Added
+- Added static IP support to load balancer in AVI
+
 ## [0.10.0] - 2019-04-17
 ### Changed
 - Change Houseekeeping API secrets naming

--- a/deploy/examples/api_v1alpha1_astarte_voyager_ingress_cr.yaml
+++ b/deploy/examples/api_v1alpha1_astarte_voyager_ingress_cr.yaml
@@ -12,6 +12,7 @@ spec:
     cors: false
     replicas: 1
     type: LoadBalancer
+    loadBalancerIp: "203.0.113.1"
     nodeSelector: "mynodeselector"
     exposeHousekeeping: true
     tlsSecret: my-custom-broker-ssl-certificate
@@ -22,6 +23,7 @@ spec:
     deploy: true
     replicas: 1
     type: LoadBalancer
+    loadBalancerIp: "203.0.113.2"
     nodeSelector: "mynodeselector"
     maxConnections: 10000
     tlsSecret: my-custom-api-ssl-certificate

--- a/playbook/roles/voyager-api-ingress/defaults/main.yml
+++ b/playbook/roles/voyager-api-ingress/defaults/main.yml
@@ -2,5 +2,6 @@ voyager_tls_api_secret_name: "{{ vars | json_query('api.tls_secret') | default(N
 
 voyager_api_ingress_config:
   type: "{{ vars | json_query('api.type') | default('LoadBalancer', true) }}"
+  load_balancer_ip: "{{ vars | json_query('api.load_balancer_ip') | default(None, true) }}"
   replicas: "{{ vars | json_query('api.replicas') | default(1, true) }}"
   node_selector: "{{ vars | json_query('api.node_selector') | default(None, true) }}"

--- a/playbook/roles/voyager-api-ingress/templates/voyager-ingress.yml
+++ b/playbook/roles/voyager-api-ingress/templates/voyager-ingress.yml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ astarte_k8s_namespace }}
   annotations:
     ingress.appscode.com/type: {{ voyager_api_ingress_config.type }}
+{% if voyager_api_ingress_config.load_balancer_ip %}
+    ingress.appscode.com/load-balancer-ip: '{{ voyager_api_ingress_config.load_balancer_ip }}'
+{% endif %}
     # Keep source IP - we need this for a number of reasons
     ingress.appscode.com/keep-source-ip: "true"
     # Configure depending on the load

--- a/playbook/roles/voyager-broker-ingress/defaults/main.yml
+++ b/playbook/roles/voyager-broker-ingress/defaults/main.yml
@@ -2,6 +2,7 @@ voyager_tls_broker_secret_name: "{{ vars | json_query('broker.tls_secret') | def
 
 voyager_broker_ingress_config:
   type: "{{ vars | json_query('broker.type') | default('LoadBalancer', true) }}"
+  load_balancer_ip: "{{ vars | json_query('broker.load_balancer_ip') | default(None, true) }}"
   replicas: "{{ vars | json_query('broker.replicas') | default(1, true) }}"
   node_selector: "{{ vars | json_query('broker.node_selector') | default(None, true) }}"
   max_connections: "{{ vars | json_query('broker.max_connections') | default(10000, true) }}"

--- a/playbook/roles/voyager-broker-ingress/templates/voyager-ingress.yml
+++ b/playbook/roles/voyager-broker-ingress/templates/voyager-ingress.yml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ astarte_k8s_namespace }}
   annotations:
     ingress.appscode.com/type: {{ voyager_broker_ingress_config.type }}
+{% if voyager_broker_ingress_config.load_balancer_ip %}
+    ingress.appscode.com/load-balancer-ip: '{{ voyager_broker_ingress_config.load_balancer_ip }}'
+{% endif %}
     # Configure depending on the load
     ingress.appscode.com/replicas: '{{ voyager_broker_ingress_config.replicas }}'
 {% if voyager_broker_ingress_config.node_selector %}


### PR DESCRIPTION
This makes it possible to stick the AVI to a specific static IP declared in the cloud provider (e.g.: GCP).