### PR TITLE
Fix HTTP-01 Let's Encrypt challenge for AstarteVoyagerIngress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added static IP support to load balancer in AVI
 
+### Fixed
+- Ensure Let's Encrypt http-01 challenge works in AVI
+
 ## [0.10.0] - 2019-04-17
 ### Changed
 - Change Houseekeeping API secrets naming

--- a/playbook/roles/voyager-api-ingress/defaults/main.yml
+++ b/playbook/roles/voyager-api-ingress/defaults/main.yml
@@ -1,4 +1,6 @@
 voyager_tls_api_secret_name: "{{ vars | json_query('api.tls_secret') | default(None, true) }}"
+# TODO: Currently LE does not provide any alternative - still, we might want to adopt better semantics in 0.11
+voyager_letsencrypt_challenge: "{{ 'dns' if 'dns' in (vars | json_query('letsencrypt.challenge_provider')) else 'http' }}"
 
 voyager_api_ingress_config:
   type: "{{ vars | json_query('api.type') | default('LoadBalancer', true) }}"

--- a/playbook/roles/voyager-api-ingress/templates/voyager-ingress.yml
+++ b/playbook/roles/voyager-api-ingress/templates/voyager-ingress.yml
@@ -35,10 +35,22 @@ spec:
 {% if astarte_api_use_ssl or (deploy_astarte_dashboard and astarte_dashboard_use_ssl) %}
   tls:
 {% if voyager_use_letsencrypt %}
-  - secretName: tls-{{ resources_computed_prefix }}ingress-certificate
-{% else %}
-  - secretName: {{ voyager_tls_api_secret_name }}
+  - hosts:
+{% if astarte_api_use_ssl %}
+    - {{ astarte_api_host }}
 {% endif %}
+{% if astarte_dashboard_use_ssl and deploy_astarte_dashboard and astarte_dashboard_use_dedicated_host %}
+    - {{ astarte_dashboard_host }}
+{% endif %}
+    ref:
+      kind: Certificate
+{% if voyager_letsencrypt_challenge == 'dns' %}
+      name: {{ resources_computed_prefix }}ingress-certificate
+{% else %}
+      name: {{ resources_computed_prefix }}api-ingress-certificate
+{% endif %}
+{% else %}
+  - secretName: {{ voyager_tls_broker_secret_name }}
     hosts:
 {% if astarte_api_use_ssl %}
     - {{ astarte_api_host }}

--- a/playbook/roles/voyager-broker-ingress/defaults/main.yml
+++ b/playbook/roles/voyager-broker-ingress/defaults/main.yml
@@ -1,4 +1,6 @@
 voyager_tls_broker_secret_name: "{{ vars | json_query('broker.tls_secret') | default(None, true) }}"
+# TODO: Currently LE does not provide any alternative - still, we might want to adopt better semantics in 0.11
+voyager_letsencrypt_challenge: "{{ 'dns' if 'dns' in (vars | json_query('letsencrypt.challenge_provider')) else 'http' }}"
 
 voyager_broker_ingress_config:
   type: "{{ vars | json_query('broker.type') | default('LoadBalancer', true) }}"

--- a/playbook/roles/voyager-broker-ingress/templates/voyager-ingress.yml
+++ b/playbook/roles/voyager-broker-ingress/templates/voyager-ingress.yml
@@ -27,12 +27,20 @@ metadata:
 spec:
   tls:
 {% if voyager_use_letsencrypt %}
-  - secretName: tls-{{ resources_computed_prefix }}ingress-certificate
+  - hosts:
+    - {{ mqtt_broker_host }}
+    ref:
+      kind: Certificate
+{% if voyager_letsencrypt_challenge == 'dns' %}
+      name: {{ resources_computed_prefix }}ingress-certificate
+{% else %}
+      name: {{ resources_computed_prefix }}broker-ingress-certificate
+{% endif %}
 {% else %}
   - secretName: {{ voyager_tls_broker_secret_name }}
-{% endif %}
     hosts:
     - {{ mqtt_broker_host }}
+{% endif %}
   rules:
   - host: {{ mqtt_broker_host }}
     tcp:

--- a/playbook/roles/voyager-certificate-letsencrypt/defaults/main.yml
+++ b/playbook/roles/voyager-certificate-letsencrypt/defaults/main.yml
@@ -1,5 +1,6 @@
 voyager_letsencrypt_acme_email: "{{ vars | json_query('letsencrypt.acme_email') | default('none@example.com', true) }}"
-voyager_letsencrypt_challenge: "{{ 'dns' if 'dns' in (vars | json_query('letsencrypt.challenge_provider')) else None }}"
+# TODO: Currently LE does not provide any alternative - still, we might want to adopt better semantics in 0.11
+voyager_letsencrypt_challenge: "{{ 'dns' if 'dns' in (vars | json_query('letsencrypt.challenge_provider')) else 'http' }}"
 voyager_letsencrypt_challenge_provider: "{{ vars | json_query('letsencrypt.challenge_provider.dns.provider') | default(None, true) }}"
 voyager_letsencrypt_challenge_credential_secret_name: "{{ vars | json_query('letsencrypt.challenge_provider.dns.credential_secret_name') | default(None, true) }}"
 voyager_letsencrypt_domains: "{{ vars | json_query('letsencrypt.domains') | default(None, true) }}"

--- a/playbook/roles/voyager-certificate-letsencrypt/tasks/main.yml
+++ b/playbook/roles/voyager-certificate-letsencrypt/tasks/main.yml
@@ -7,3 +7,16 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'voyager-certificate.yml') }}"
+  when: voyager_letsencrypt_challenge == 'dns'
+
+- name: Ensure Voyager Let's Encrypt API Certificate
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'voyager-certificate-api-http.yml') }}"
+  when: voyager_letsencrypt_challenge == 'http'
+
+- name: Ensure Voyager Let's Encrypt Broker Certificate
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'voyager-certificate-broker-http.yml') }}"
+  when: voyager_letsencrypt_challenge == 'http'

--- a/playbook/roles/voyager-certificate-letsencrypt/templates/voyager-certificate-api-http.yml
+++ b/playbook/roles/voyager-certificate-letsencrypt/templates/voyager-certificate-api-http.yml
@@ -1,12 +1,9 @@
 apiVersion: voyager.appscode.com/v1beta1
 kind: Certificate
 metadata:
-  name: {{ resources_computed_prefix }}ingress-certificate
+  name: {{ resources_computed_prefix }}api-ingress-certificate
   namespace: {{ astarte_k8s_namespace }}
 spec:
-{% if voyager_letsencrypt_domains %}
-  domains: {{ voyager_letsencrypt_domains | to_yaml }}
-{% else %}
   domains:
 {% if astarte_dashboard_use_ssl and astarte_dashboard_use_dedicated_host and deploy_astarte_dashboard %}
     - {{ astarte_dashboard_host }}
@@ -14,12 +11,10 @@ spec:
 {% if astarte_api_use_ssl %}
     - {{ astarte_api_host }}
 {% endif %}
-    - {{ mqtt_broker_host }}
-{% endif %}
   acmeUserSecretName: {{ resources_computed_prefix }}voyager-acme-account
   challengeProvider:
-{% if voyager_letsencrypt_challenge == 'dns' %}
-    dns:
-      provider: {{ voyager_letsencrypt_challenge_provider }}
-      credentialSecretName: {{ voyager_letsencrypt_challenge_credential_secret_name }}
-{% endif %}
+    http:
+      ingress:
+        apiVersion: voyager.appscode.com/v1beta1
+        kind: Ingress
+        name: {{ resources_computed_prefix }}api-ingress

--- a/playbook/roles/voyager-certificate-letsencrypt/templates/voyager-certificate-broker-http.yml
+++ b/playbook/roles/voyager-certificate-letsencrypt/templates/voyager-certificate-broker-http.yml
@@ -1,0 +1,15 @@
+apiVersion: voyager.appscode.com/v1beta1
+kind: Certificate
+metadata:
+  name: {{ resources_computed_prefix }}broker-ingress-certificate
+  namespace: {{ astarte_k8s_namespace }}
+spec:
+  domains:
+    - {{ mqtt_broker_host }}
+  acmeUserSecretName: {{ resources_computed_prefix }}voyager-acme-account
+  challengeProvider:
+    http:
+      ingress:
+        apiVersion: voyager.appscode.com/v1beta1
+        kind: Ingress
+        name: {{ resources_computed_prefix }}vernemq-ingress


### PR DESCRIPTION
http-01 was fully broken due to lack of testing. This should fix the occurrence and ensure that both ingresses can bootstrap the certificate and generate individual certificates (only in the http-01 case).