### PR TITLE
AVI: Enable mapping for ingress.appscode.com/annotations-service

### DIFF
--- a/deploy/examples/api_v1alpha1_astarte_voyager_ingress_cr.yaml
+++ b/deploy/examples/api_v1alpha1_astarte_voyager_ingress_cr.yaml
@@ -16,6 +16,8 @@ spec:
     nodeSelector: "mynodeselector"
     exposeHousekeeping: true
     tlsSecret: my-custom-broker-ssl-certificate
+    annotationsService:
+      service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
   dashboard:
     ssl: true
     host: "dashboard.astarte-example.com" # When not specified, dashboard will be deployed in /dashboard in the API host.
@@ -27,6 +29,8 @@ spec:
     nodeSelector: "mynodeselector"
     maxConnections: 10000
     tlsSecret: my-custom-api-ssl-certificate
+    annotationsService:
+      service.beta.kubernetes.io/aws-load-balancer-internal": "0.0.0.0/0"
   letsencrypt:
     use: true
     acmeEmail: info@example.com

--- a/playbook/roles/voyager-api-ingress/defaults/main.yml
+++ b/playbook/roles/voyager-api-ingress/defaults/main.yml
@@ -7,3 +7,4 @@ voyager_api_ingress_config:
   load_balancer_ip: "{{ vars | json_query('api.load_balancer_ip') | default(None, true) }}"
   replicas: "{{ vars | json_query('api.replicas') | default(1, true) }}"
   node_selector: "{{ vars | json_query('api.node_selector') | default(None, true) }}"
+  annotations_service: "{{ vars | json_query('api.annotations_service') | default(None, true) }}"

--- a/playbook/roles/voyager-api-ingress/templates/voyager-ingress.yml
+++ b/playbook/roles/voyager-api-ingress/templates/voyager-ingress.yml
@@ -23,6 +23,9 @@ metadata:
 {% if voyager_api_ingress_config.node_selector %}
     ingress.appscode.com/node-selector: '{{ voyager_api_ingress_config.node_selector }}'
 {% endif %}
+{% if voyager_api_ingress_config.annotations_service %}
+    ingress.appscode.com/annotations-service: '{{ voyager_api_ingress_config.annotations_service | to_json | replace('_','-') }}'
+{% endif %}
 {% if astarte_api_enable_cors %}
     # CORS
     ingress.kubernetes.io/enable-cors: 'true'

--- a/playbook/roles/voyager-broker-ingress/defaults/main.yml
+++ b/playbook/roles/voyager-broker-ingress/defaults/main.yml
@@ -7,4 +7,5 @@ voyager_broker_ingress_config:
   load_balancer_ip: "{{ vars | json_query('broker.load_balancer_ip') | default(None, true) }}"
   replicas: "{{ vars | json_query('broker.replicas') | default(1, true) }}"
   node_selector: "{{ vars | json_query('broker.node_selector') | default(None, true) }}"
+  annotations_service: "{{ vars | json_query('broker.annotations_service') | default(None, true) }}"
   max_connections: "{{ vars | json_query('broker.max_connections') | default(10000, true) }}"

--- a/playbook/roles/voyager-broker-ingress/templates/voyager-ingress.yml
+++ b/playbook/roles/voyager-broker-ingress/templates/voyager-ingress.yml
@@ -13,6 +13,9 @@ metadata:
 {% if voyager_broker_ingress_config.node_selector %}
     ingress.appscode.com/node-selector: '{{ voyager_broker_ingress_config.node_selector }}'
 {% endif %}
+{% if voyager_broker_ingress_config.annotations_service %}
+    ingress.appscode.com/annotations-service: '{{ voyager_broker_ingress_config.annotations_service | to_json | replace('_','-') }}'
+{% endif %}
     # Keep source IP - we need this for a number of reasons
     ingress.appscode.com/keep-source-ip: "true"
     # These options are here to please VerneMQ/Astarte


### PR DESCRIPTION
This is necessary on some providers, such as AKS and EKS, where some annotations are needed to let the Kubernetes LoadBalancer play nicely with some of the native Cloud resources.