### PR TITLE
Fix RabbitMQ resource allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Ensure Let's Encrypt http-01 challenge works in AVI
+- Fixed typo which caused RabbitMQ pods to have memory limits identical to requests, even when explicitly set otherwise
 
 ## [0.10.0] - 2019-04-17
 ### Changed

--- a/playbook/roles/rabbitmq/templates/rabbitmq-statefulset.yml
+++ b/playbook/roles/rabbitmq/templates/rabbitmq-statefulset.yml
@@ -87,7 +87,7 @@ spec:
             memory: "{{ rabbitmq_k8s_resources_requests_memory }}"
           limits:
             cpu: "{{ rabbitmq_k8s_resources_limits_cpu }}"
-            memory: "{{ rabbitmq_k8s_resources_requests_memory }}"
+            memory: "{{ rabbitmq_k8s_resources_limits_memory }}"
         env:
         - name: RABBITMQ_USE_LONGNAME
           value: "true"


### PR DESCRIPTION
A typo caused memory requests and limits to always coincide.