### PR TITLE
Update RabbitMQ default version to 3.7.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support to Let's Encrypt Staging in AVI Certificates
 - Allow setting a different version for each Astarte component
 
+### Changed
+- Update default RabbitMQ version to 3.7.15
+
 ### Fixed
 - Ensure Let's Encrypt http-01 challenge works in AVI
 - Fixed typo which caused RabbitMQ pods to have memory limits identical to requests, even when explicitly set otherwise

--- a/playbook/roles/rabbitmq/defaults/main.yml
+++ b/playbook/roles/rabbitmq/defaults/main.yml
@@ -1,6 +1,6 @@
 rabbitmq_k8s_enable_antiaffinity: "{{ false if (vars | json_query('rabbitmq.anti_affinity')) is sameas false else true }}"
 
-rabbitmq_image_tag: "{{ vars | json_query('rabbitmq.version') | default('3.7.12', true) }}"
+rabbitmq_image_tag: "{{ vars | json_query('rabbitmq.version') | default('3.7.15', true) }}"
 rabbitmq_k8s_replicas: "{{ vars | json_query('rabbitmq.replicas') | default('1', true) }}"
 
 rabbitmq_k8s_resources_requests_cpu: "{{ vars | json_query('rabbitmq.resources.requests.cpu') | default('500m', true) }}"


### PR DESCRIPTION
Astarte 0.10.1 will be tested against RabbitMQ 3.7.15, so use that
version.