### PR TITLE
Update default Apache Cassandra version to 3.11.4

### DIFF
--- a/playbook/roles/cassandra/defaults/main.yml
+++ b/playbook/roles/cassandra/defaults/main.yml
@@ -1,6 +1,6 @@
 cassandra_k8s_enable_antiaffinity: "{{ false if (vars | json_query('cassandra.anti_affinity')) is sameas false else true }}"
 
-cassandra_image_tag: "{{ vars | json_query('cassandra.version') | default('3.11.3', true) }}"
+cassandra_image_tag: "{{ vars | json_query('cassandra.version') | default('3.11.4', true) }}"
 cassandra_cluster_size: "{{ vars | json_query('cassandra.replicas') | default('1', true) }}"
 cassandra_max_heap_size: "{{ vars | json_query('cassandra.max_heap_size') | default('1024M', true) }}"
 cassandra_heap_new_size: "{{ vars | json_query('cassandra.heap_new_size') | default('256M', true) }}"


### PR DESCRIPTION
Astarte is tested against Cassandra 3.11.4, update it.

Signed-off-by: Davide Bettio <davide.bettio@ispirata.com>