### PR TITLE
Fix PAIRING_BROKER_URL URI scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ensure Let's Encrypt http-01 challenge works in AVI
 - Fixed typo which caused RabbitMQ pods to have memory limits identical to requests, even when explicitly set otherwise
 - AVI: Fixed typo which caused the Playbook operator to crash when Dashboard host was not defined
+- Use mqtts URI scheme in PAIRING_BROKER_URL
 
 ## [0.10.0] - 2019-04-17
 ### Changed

--- a/playbook/deploy.yml
+++ b/playbook/deploy.yml
@@ -134,7 +134,7 @@
         - name: PAIRING_CFSSL_URL
           value: "{{ vars | json_query('cfssl.url') | default(cfssl_url, true) }}"
         - name: PAIRING_BROKER_URL
-          value: "ssl://{{ mqtt_broker_host }}:{{ mqtt_broker_port }}/"
+          value: "mqtts://{{ mqtt_broker_host }}:{{ mqtt_broker_port }}/"
     - role: astarte-generic-api-service
       tags:
         - pairing


### PR DESCRIPTION
It must be mqtts since some SDKs (e.g. ESP32) pick up information about
encryption from this