### PR TITLE
Allow setting a custom image for vernemq

### DIFF
--- a/playbook/roles/vernemq/defaults/main.yml
+++ b/playbook/roles/vernemq/defaults/main.yml
@@ -2,6 +2,7 @@ vernemq_version: "{{ vars | json_query('vernemq.version') | default(astarte_tag,
 vernemq_k8s_enable_antiaffinity: "{{ false if (vars | json_query('vernemq.anti_affinity')) is sameas false else true }}"
 
 vernemq_k8s_replicas: "{{ vars | json_query('vernemq.replicas') | default('1', true) }}"
+vernemq_k8s_custom_image: "{{ vars | json_query('vernemq.image') | default('', true) }}"
 k8s_image_pull_secrets:
 
 vernemq_k8s_resources_requests_cpu: "{{ vars | json_query('vernemq.resources.requests.cpu') | default('200m', true) }}"

--- a/playbook/roles/vernemq/templates/vernemq-statefulset.yml
+++ b/playbook/roles/vernemq/templates/vernemq-statefulset.yml
@@ -43,7 +43,11 @@ spec:
 {% endif %}
       containers:
       - name: vernemq
+{% if vernemq_k8s_custom_image %}
+        image: {{ vernemq_k8s_custom_image }}
+{% else %}
         image: {{ astarte_distribution_channel }}/vernemq:{{ vernemq_version }}
+{% endif %}
         imagePullPolicy: {{ astarte_image_pull_policy }}
         resources:
           requests:


### PR DESCRIPTION
This completes 30a5e67e70e3b872257cce932293cbce7890be09 because vernemq
is effectively an Astarte component since it includes Astarte VMQ plugin