### PR TITLE
broker-ingress: Ensure we don't reference non existent variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - AVI: Fixed typo which caused the Playbook operator to crash when Dashboard host was not defined
 - Use mqtts URI scheme in PAIRING_BROKER_URL
 - Fixed an issue which resulted in an invalid resource when using a Cassandra custom volume definition
+- Fixed an issue which prevented using a custom TLS secret
 
 ## [0.10.0] - 2019-04-17
 ### Changed

--- a/playbook/roles/voyager-broker-ingress/templates/voyager-ingress.yml
+++ b/playbook/roles/voyager-broker-ingress/templates/voyager-ingress.yml
@@ -42,6 +42,7 @@ spec:
 {% endif %}
 {% endif %} # if not voyager_bootstrapping_http_01
   rules:
+{% if voyager_use_letsencrypt %}
 {% if voyager_letsencrypt_challenge == 'http' %}
 # If we're using the http-01 challenge, we need to let the LoadBalancer know that port 80 has to be open and routed.
   - http:
@@ -51,6 +52,7 @@ spec:
         backend:
           serviceName: voyager-operator.kube-system
           servicePort: '56791'
+{% endif %}
 {% endif %}
   - host: {{ mqtt_broker_host }}
     tcp:


### PR DESCRIPTION
When not using Let's Encrypt, don't reference it anywhere