### PR TITLE
Add support for multiple data queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for multi-queue Data Updater Plant and VerneMQ plugin. When migrating from single-queue deployments,
+the recommended procedure is this: scale VerneMQ to 0 replicas to allow the existing queue to be emptied. When it
+is empty, replace Data Updater Plant with the new version and bring VerneMQ back up to start publishing on the new queues.
 
 ## [0.10.1] - Unreleased
 ### Added

--- a/deploy/examples/api_v1alpha1_astarte_cr.yaml
+++ b/deploy/examples/api_v1alpha1_astarte_cr.yaml
@@ -210,6 +210,7 @@ spec:
       # You can specify a component-specific version or tag
       # version: 0.10.999
       replicas: 1
+      dataQueueCount: 1
       resources:
         requests:
           cpu: 400m

--- a/playbook/deploy.yml
+++ b/playbook/deploy.yml
@@ -170,6 +170,12 @@
           value: "/"
         - name: DATA_UPDATER_PLANT_AMQP_PRODUCER_PORT
           value: "{{ vars | json_query('rabbitmq.connection.port') | default(rabbitmq_connection_port, true) }}"
+        - name: DATA_UPDATER_PLANT_AMQP_DATA_QUEUE_RANGE_START
+          # TODO: this is fixed to 0 for now, it will change when multiple Data Updater Plants are supported
+          value: "0"
+        - name: DATA_UPDATER_PLANT_AMQP_DATA_QUEUE_RANGE_END
+          # TODO: same as above, but fixed at queue count. Subtract 1 since the range ends at count - 1
+          value: "{{ astarte_k8s_data_queue_count | int - 1 }}"
       k8s_deployment_additional_secret_variables:
         - name: DATA_UPDATER_PLANT_AMQP_CONSUMER_USERNAME
           secret_name: "{{ rabbitmq_connection_k8s_credentials_secret_name }}"

--- a/playbook/group_vars/all
+++ b/playbook/group_vars/all
@@ -58,6 +58,9 @@ deploy_cfssl_k8s: "{{ false if (vars | json_query('cfssl.deploy')) is sameas fal
 deploy_astarte_trigger_engine: "{{ false if (vars | json_query('components.trigger_engine.deploy')) is sameas false else true }}"
 deploy_astarte_dashboard: "{{ false if (vars | json_query('components.dashboard.deploy')) is sameas false else true }}"
 
+### Data queue count, used by Data Updater Plant and VerneMQ
+astarte_k8s_data_queue_count: "{{ vars | json_query('components.data_updater_plant.data_queue_count') | default(1, true) }}"
+
 ### Data Updater Plant AMQP policies
 
 ### AppEngine API AMQP policies

--- a/playbook/roles/vernemq/defaults/main.yml
+++ b/playbook/roles/vernemq/defaults/main.yml
@@ -13,3 +13,5 @@ vernemq_k8s_resources_limits_memory: "{{ vars | json_query('vernemq.resources.li
 vernemq_k8s_volume_definition: "{{ vars | json_query('vernemq.storage.volume_definition') | default('', true) }}"
 vernemq_k8s_storage_class_name: "{{ vars | json_query('vernemq.storage.class_name') | default(k8s_storage_class_name, true) }}"
 vernemq_k8s_volume_size: "{{ vars | json_query('vernemq.storage.size') | default('4Gi', true) }}"
+
+vernemq_k8s_amqp_data_queue_count: "{{ astarte_k8s_data_queue_count }}"

--- a/playbook/roles/vernemq/templates/vernemq-statefulset.yml
+++ b/playbook/roles/vernemq/templates/vernemq-statefulset.yml
@@ -94,6 +94,8 @@ spec:
                 key: {{ rabbitmq_connection_k8s_credentials_secret_password_key }}
           - name: DOCKER_VERNEMQ_ASTARTE_VMQ_PLUGIN__AMQP__HOST
             value: "{{ vars | json_query('rabbitmq.connection.host') | default(rabbitmq_connection_host, true) }}"
+          - name: DOCKER_VERNEMQ_ASTARTE_VMQ_PLUGIN__AMQP__DATA_QUEUE_COUNT
+            value: "{{ vernemq_k8s_amqp_data_queue_count }}"
           - name: DOCKER_VERNEMQ_DISCOVERY_KUBERNETES
             value: "1"
           - name: DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR


### PR DESCRIPTION
Allow the user to specify the number of queues that will be used by VerneMQ
plugin to publish and Data Updater Plant to consume