### PR TITLE
Allow setting a custom image for RabbitMQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Allow setting custom images for individual Astarte components
 - Support setting maxResultsLimit in AppEngine API
 - Support fetching images from private registries
+- Allow setting a custom image for RabbitMQ
 
 ### Changed
 - Update default RabbitMQ version to 3.7.15

--- a/playbook/roles/rabbitmq/defaults/main.yml
+++ b/playbook/roles/rabbitmq/defaults/main.yml
@@ -1,6 +1,7 @@
 rabbitmq_k8s_enable_antiaffinity: "{{ false if (vars | json_query('rabbitmq.anti_affinity')) is sameas false else true }}"
 k8s_image_pull_secrets:
 
+rabbitmq_k8s_custom_image: "{{ vars | json_query('rabbitmq.image') | default('', true) }}"
 rabbitmq_image_tag: "{{ vars | json_query('rabbitmq.version') | default('3.7.15', true) }}"
 rabbitmq_k8s_replicas: "{{ vars | json_query('rabbitmq.replicas') | default('1', true) }}"
 

--- a/playbook/roles/rabbitmq/templates/rabbitmq-statefulset.yml
+++ b/playbook/roles/rabbitmq/templates/rabbitmq-statefulset.yml
@@ -75,7 +75,11 @@ spec:
 {% endif %}
       containers:
       - name: rabbitmq
+{% if rabbitmq_k8s_custom_image %}
+        image: {{ rabbitmq_k8s_custom_image }}
+{% else %}
         image: rabbitmq:{{ rabbitmq_image_tag }}
+{% endif %}
         livenessProbe:
           exec:
             command: ["rabbitmqctl", "status"]


### PR DESCRIPTION
This makes it possible to build custom RabbitMQ images containing custom plugins
and use them with Astarte