### PR TITLE
Allow enabling additional RabbitMQ plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support setting maxResultsLimit in AppEngine API
 - Support fetching images from private registries
 - Allow setting a custom image for RabbitMQ
+- Support enabling additional plugins in RabbitMQ
 
 ### Changed
 - Update default RabbitMQ version to 3.7.15

--- a/playbook/roles/rabbitmq/defaults/main.yml
+++ b/playbook/roles/rabbitmq/defaults/main.yml
@@ -13,3 +13,9 @@ rabbitmq_k8s_resources_limits_memory: "{{ vars | json_query('rabbitmq.resources.
 rabbitmq_k8s_volume_definition: "{{ vars | json_query('rabbitmq.storage.volume_definition') | default('', true) }}"
 rabbitmq_k8s_storage_class_name: "{{ vars | json_query('rabbitmq.storage.class_name') | default(k8s_storage_class_name, true) }}"
 rabbitmq_k8s_volume_size: "{{ vars | json_query('rabbitmq.storage.size') | default('4Gi', true) }}"
+
+rabbitmq_k8s_base_enabled_plugins:
+  - rabbitmq_management
+  - rabbitmq_peer_discovery_k8s
+rabbitmq_k8s_additional_enabled_plugins: "{{ vars | json_query('rabbitmq.additional_plugins') | default([], true) }}"
+rabbitmq_k8s_enabled_plugins: "{{ rabbitmq_k8s_base_enabled_plugins + rabbitmq_k8s_additional_enabled_plugins }}"

--- a/playbook/roles/rabbitmq/templates/rabbitmq-statefulset.yml
+++ b/playbook/roles/rabbitmq/templates/rabbitmq-statefulset.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ astarte_k8s_namespace }}
 data:
   enabled_plugins: |
-      [rabbitmq_management,rabbitmq_peer_discovery_k8s].
+      [{{ rabbitmq_k8s_enabled_plugins | list | join(",") }}].
   rabbitmq.conf: |
       ## Clustering
       cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s


### PR DESCRIPTION
This allows to enable plugins that could be present in a custom RabbitMQ image