### PR TITLE
voyager-ingress: fix rewrite rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use mqtts URI scheme in PAIRING_BROKER_URL
 - Fixed an issue which resulted in an invalid resource when using a Cassandra custom volume definition
 - Fixed an issue which prevented using a custom TLS secret
+- Remove extra leading / in URL rewrites
 
 ## [0.10.0] - 2019-04-17
 ### Changed

--- a/playbook/roles/voyager-api-ingress/templates/voyager-ingress.yml
+++ b/playbook/roles/voyager-api-ingress/templates/voyager-ingress.yml
@@ -62,39 +62,39 @@ spec:
           serviceName: {{ parent_resources_computed_prefix }}housekeeping
           servicePort: '4000'
           backendRules:
-          - 'reqrep ^([^\ :]*)\ /housekeeping(.*$) \1\ /\2'
+          - 'reqrep ^([^\ :]*)\ /housekeeping/(.*$) \1\ /\2'
 {% endif %}
       - path: /realm
         backend:
           serviceName: {{ parent_resources_computed_prefix }}realm-management
           servicePort: '4000'
           backendRules:
-          - 'reqrep ^([^\ :]*)\ /realm(.*$) \1\ /\2'
+          - 'reqrep ^([^\ :]*)\ /realm/(.*$) \1\ /\2'
       - path: /realmmanagement
         backend:
           serviceName: {{ parent_resources_computed_prefix }}realm-management
           servicePort: '4000'
           backendRules:
-          - 'reqrep ^([^\ :]*)\ /realmmanagement(.*$) \1\ /\2'
+          - 'reqrep ^([^\ :]*)\ /realmmanagement/(.*$) \1\ /\2'
       - path: /pairing
         backend:
           serviceName: {{ parent_resources_computed_prefix }}pairing
           servicePort: '4000'
           backendRules:
-          - 'reqrep ^([^\ :]*)\ /pairing(.*$) \1\ /\2'
+          - 'reqrep ^([^\ :]*)\ /pairing/(.*$) \1\ /\2'
       - path: /appengine
         backend:
           serviceName: {{ parent_resources_computed_prefix }}appengine
           servicePort: '4000'
           backendRules:
-          - 'reqrep ^([^\ :]*)\ /appengine(.*$) \1\ /\2'
+          - 'reqrep ^([^\ :]*)\ /appengine/(.*$) \1\ /\2'
 {% if deploy_astarte_dashboard and not astarte_dashboard_use_dedicated_host %}
       - path: /dashboard
         backend:
           serviceName: {{ parent_resources_computed_prefix }}dashboard
           servicePort: '80'
           backendRules:
-          - 'reqrep ^([^\ :]*)\ /dashboard(.*$) \1\ /\2'
+          - 'reqrep ^([^\ :]*)\ /dashboard/(.*$) \1\ /\2'
 {% endif %}
 {% if deploy_astarte_dashboard and astarte_dashboard_use_dedicated_host %}
   - host: {{ astarte_dashboard_host }}


### PR DESCRIPTION
Match the trailing slash in service prefix to avoid leaving an extra / in the
request rewrite