### PR TITLE
Modernize Astarte Operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+services: docker
+language: python
+install:
+  - pip3 install docker molecule openshift jmespath
+script:
+  - molecule test -s test-local

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 sudo: required
 services: docker
 language: python
+env:
+  global:
+    - TEST_NAMESPACE="astarte"
+  jobs:
+    - TEST_SUITE="test-local"
+
 install:
   - pip3 install docker molecule openshift jmespath
 script:
-  - molecule test -s test-local
+  - molecule test -s $TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 services: docker
 language: python
+python: 3.7
 env:
   global:
     - TEST_NAMESPACE="astarte"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added support for multi-queue Data Updater Plant and VerneMQ plugin. When migrating from single-queue deployments,
 the recommended procedure is this: scale VerneMQ to 0 replicas to allow the existing queue to be emptied. When it
 is empty, replace Data Updater Plant with the new version and bring VerneMQ back up to start publishing on the new queues.
+- Molecule-based CI
+- Added Finalizers upon Astarte deletion
+
+### Fixed
+- Reconciliation policy now prevents the Operator from reconciling forever for no reason
+- Fix deprecations in Playbook
+
+### Changed
+- Updated Operator SDK to 0.12
+- Updated Kubernetes minimum requirement to 1.14
+- Updated RBAC APIs
 
 ## [0.10.1] - 2019-10-02
 ### Added

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,7 @@
-FROM quay.io/operator-framework/ansible-operator:v0.6.0
+FROM quay.io/operator-framework/ansible-operator:v0.12.0
 
 # Add needed modules
-USER 0
-RUN pip install pyopenssl
-USER 1001
+RUN pip3 install --user pyopenssl jmespath
 
 COPY playbook/ ${HOME}/playbook/
 COPY watches.yaml ${HOME}/watches.yaml

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,4 +4,5 @@ FROM quay.io/operator-framework/ansible-operator:v0.12.0
 RUN pip3 install --user pyopenssl jmespath
 
 COPY playbook/ ${HOME}/playbook/
+COPY roles/ ${HOME}/roles/
 COPY watches.yaml ${HOME}/watches.yaml

--- a/deploy/test/api_v1alpha1_astarte_cr_minimal.yaml
+++ b/deploy/test/api_v1alpha1_astarte_cr_minimal.yaml
@@ -1,0 +1,61 @@
+apiVersion: api.astarte-platform.org/v1alpha1
+kind: Astarte
+metadata:
+  name: test-deployment
+  namespace: astarte
+spec:
+  # This is the most minimal set of reasonable configuration to spin up an Astarte
+  # instance with reasonable defaults and enough control over the deployment.
+  version: snapshot
+  imagePullPolicy: Always
+  api:
+    host: "api.autotest.astarte-platform.org" # MANDATORY
+  rabbitmq:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256M
+      limits:
+        cpu: 1
+        memory: 256M
+  cassandra:
+    maxHeapSize: 512M
+    heapNewSize: 256M
+    storage:
+      size: 10Gi
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1024M
+      limits:
+        cpu: 1
+        memory: 2048M
+  vernemq:
+    host: "broker.autotest.astarte-platform.org"
+    resources:
+      requests:
+        cpu: 0m
+        memory: 256M
+      limits:
+        cpu: 0m
+        memory: 512M
+  cfssl:
+    resources:
+      requests:
+        cpu: 0m
+        memory: 128M
+      limits:
+        cpu: 0m
+        memory: 128M
+    storage:
+      size: 2Gi
+  components:
+    # Global resource allocation. Automatically allocates resources to components weighted in a
+    # reasonable way.
+    resources:
+      requests:
+        cpu: 0m
+        memory: 2048M
+      limits:
+        cpu: 0m
+        memory: 3072M

--- a/deploy/test/operator-test.yaml
+++ b/deploy/test/operator-test.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: astarte-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: astarte-operator
+  template:
+    metadata:
+      labels:
+        name: astarte-operator
+    spec:
+      serviceAccountName: astarte-operator
+      containers:
+        - name: astarte-operator
+          # Replace this with the built image name
+          image: astarte-kubernetes-operator-molecule:testing
+          imagePullPolicy: Never
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "astarte-operator"

--- a/molecule/default/asserts.yml
+++ b/molecule/default/asserts.yml
@@ -7,7 +7,7 @@
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
   tasks:
     - name: Get all pods in {{ namespace }}
-      k8s_facts:
+      k8s_info:
         api_version: v1
         kind: Pod
         namespace: '{{ namespace }}'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,8 +10,9 @@ platforms:
 - name: kind-default
   groups:
   - k8s
-  image: bsycorp/kind:latest-1.12
+  image: bsycorp/kind:latest-1.15
   privileged: True
+  override_command: no
   exposed_ports:
     - 8443/tcp
     - 10080/tcp

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -19,14 +19,14 @@
 
     - name: Change the kubeconfig port to the proper value
       replace:
-        regexp: 8443
+        regexp: '8443'
         replace: "{{ lookup('env', 'KIND_PORT') }}"
         path: '{{ kubeconfig }}'
       delegate_to: localhost
 
     - name: Wait for the Kubernetes API to become available (this could take a minute)
       uri:
-        url: "https://localhost:8443/apis"
+        url: "http://localhost:10080/kubernetes-ready"
         status_code: 200
         validate_certs: no
       register: result

--- a/molecule/test-cluster/playbook.yml
+++ b/molecule/test-cluster/playbook.yml
@@ -19,7 +19,7 @@
       msg: "{{ lookup('k8s', group='api.astarte-platform.org', api_version='v1alpha1', kind='Astarte', namespace=namespace, resource_name=custom_resource.metadata.name) }}"
 
   - name: Wait 2m for reconciliation to run
-    k8s_facts:
+    k8s_info:
       api_version: 'v1alpha1'
       kind: 'Astarte'
       namespace: '{{ namespace }}'

--- a/molecule/test-cluster/playbook.yml
+++ b/molecule/test-cluster/playbook.yml
@@ -6,19 +6,19 @@
   vars:
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
     deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
-    image_name: api.astarte-platform.org/astarte-operator:0.10.1
-    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/api_v1alpha1_astarte_cr.yaml'])) | from_yaml }}"
+    image_name: astarte-kubernetes-operator-molecule:testing
+    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'examples/api_v1alpha1_astarte_cr_minimal.yaml'])) | from_yaml }}"
   tasks:
   - name: Create the api.astarte-platform.org/v1alpha1.Astarte
     k8s:
       namespace: '{{ namespace }}'
-      definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/api_v1alpha1_astarte_cr.yaml'])) }}"
+      definition: "{{ lookup('file', '/'.join([deploy_dir, 'examples/api_v1alpha1_astarte_cr_minimal.yaml'])) }}"
 
   - name: Get the newly created Custom Resource
     debug:
       msg: "{{ lookup('k8s', group='api.astarte-platform.org', api_version='v1alpha1', kind='Astarte', namespace=namespace, resource_name=custom_resource.metadata.name) }}"
 
-  - name: Wait 40s for reconcilation to run
+  - name: Wait 2m for reconciliation to run
     k8s_facts:
       api_version: 'v1alpha1'
       kind: 'Astarte'
@@ -27,7 +27,7 @@
     register: reconcile_cr
     until:
     - "'Successful' in (reconcile_cr | json_query('resources[].status.conditions[].reason'))"
-    delay: 4
+    delay: 12
     retries: 10
 
-- import_playbook: "{{ playbook_dir }}/../default/asserts.yml"
+- import_playbook: '{{ playbook_dir }}/../default/asserts.yml'

--- a/molecule/test-cluster/playbook.yml
+++ b/molecule/test-cluster/playbook.yml
@@ -7,12 +7,12 @@
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
     deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
     image_name: astarte-kubernetes-operator-molecule:testing
-    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'examples/api_v1alpha1_astarte_cr_minimal.yaml'])) | from_yaml }}"
+    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'test/api_v1alpha1_astarte_cr_minimal.yaml'])) | from_yaml }}"
   tasks:
   - name: Create the api.astarte-platform.org/v1alpha1.Astarte
     k8s:
       namespace: '{{ namespace }}'
-      definition: "{{ lookup('file', '/'.join([deploy_dir, 'examples/api_v1alpha1_astarte_cr_minimal.yaml'])) }}"
+      definition: "{{ lookup('file', '/'.join([deploy_dir, 'test/api_v1alpha1_astarte_cr_minimal.yaml'])) }}"
 
   - name: Get the newly created Custom Resource
     debug:

--- a/molecule/test-local/molecule.yml
+++ b/molecule/test-local/molecule.yml
@@ -10,8 +10,9 @@ platforms:
 - name: kind-test-local
   groups:
   - k8s
-  image: bsycorp/kind:latest-1.12
+  image: bsycorp/kind:latest-1.15
   privileged: True
+  override_command: no
   exposed_ports:
     - 8443/tcp
     - 10080/tcp

--- a/molecule/test-local/playbook.yml
+++ b/molecule/test-local/playbook.yml
@@ -69,8 +69,8 @@
       register: cr
       until:
       - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
-      delay: 12
-      retries: 50
+      delay: 10
+      retries: 60
     rescue:
     - name: debug cr
       ignore_errors: yes

--- a/molecule/test-local/playbook.yml
+++ b/molecule/test-local/playbook.yml
@@ -36,7 +36,7 @@
       when: hostvars[groups.k8s.0].build_cmd.changed
 
     - name: Wait 30s for Operator Deployment to terminate
-      k8s_facts:
+      k8s_info:
         api_version: '{{ definition.apiVersion }}'
         kind: '{{ definition.kind }}'
         namespace: 'kube-system'
@@ -61,7 +61,7 @@
         definition: '{{ custom_resource }}'
 
     - name: Wait 10m for reconciliation to run
-      k8s_facts:
+      k8s_info:
         api_version: '{{ custom_resource.apiVersion }}'
         kind: '{{ custom_resource.kind }}'
         namespace: '{{ namespace }}'

--- a/molecule/test-local/playbook.yml
+++ b/molecule/test-local/playbook.yml
@@ -3,11 +3,11 @@
 - name: Build Operator in Kubernetes docker container
   hosts: k8s
   vars:
-    image_name: api.astarte-platform.org/astarte-operator:0.10.1
+    image_name: astarte-kubernetes-operator-molecule:testing
   tasks:
   # using command so we don't need to install any dependencies
   - name: Get existing image hash
-    command: docker images -q {{image_name}}
+    command: docker images -q {{ image_name }}
     register: prev_hash
     changed_when: false
 
@@ -23,15 +23,15 @@
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
     deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
     pull_policy: Never
-    REPLACE_IMAGE: api.astarte-platform.org/astarte-operator:0.10.1
-    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/api_v1alpha1_astarte_cr.yaml'])) | from_yaml }}"
+    REPLACE_IMAGE: astarte-kubernetes-operator-molecule:testing
+    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'examples/api_v1alpha1_astarte_cr_minimal.yaml'])) | from_yaml }}"
   tasks:
   - block:
     - name: Delete the Operator Deployment
       k8s:
         state: absent
-        namespace: '{{ namespace }}'
-        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) }}"
+        namespace: 'kube-system'
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'test/operator-test.yaml'])) }}"
       register: delete_deployment
       when: hostvars[groups.k8s.0].build_cmd.changed
 
@@ -39,10 +39,10 @@
       k8s_facts:
         api_version: '{{ definition.apiVersion }}'
         kind: '{{ definition.kind }}'
-        namespace: '{{ namespace }}'
+        namespace: 'kube-system'
         name: '{{ definition.metadata.name }}'
       vars:
-        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'test/operator-test.yaml'])) | from_yaml }}"
       register: deployment
       until: not deployment.resources
       delay: 3
@@ -51,16 +51,16 @@
 
     - name: Create the Operator Deployment
       k8s:
-        namespace: '{{ namespace }}'
-        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) }}"
+        namespace: 'kube-system'
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'test/operator-test.yaml'])) }}"
 
     - name: Create the api.astarte-platform.org/v1alpha1.Astarte
       k8s:
         state: present
         namespace: '{{ namespace }}'
-        definition: "{{ custom_resource }}"
+        definition: '{{ custom_resource }}'
 
-    - name: Wait 40s for reconcilation to run
+    - name: Wait 10m for reconciliation to run
       k8s_facts:
         api_version: '{{ custom_resource.apiVersion }}'
         kind: '{{ custom_resource.kind }}'
@@ -69,8 +69,8 @@
       register: cr
       until:
       - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
-      delay: 4
-      retries: 10
+      delay: 12
+      retries: 50
     rescue:
     - name: debug cr
       ignore_errors: yes
@@ -85,7 +85,7 @@
           resource_name=custom_resource.metadata.name
         )}}'
 
-    - name: debug memcached lookup
+    - name: debug astarte service deployments lookup
       ignore_errors: yes
       failed_when: false
       debug:
@@ -95,18 +95,30 @@
           kind="Deployment",
           api_version="apps/v1",
           namespace=namespace,
-          label_selector="app=memcached"
+          label_selector="component=astarte"
         )}}'
+
+    - name: describe operator
+      ignore_errors: yes
+      failed_when: false
+      command: kubectl describe deployment/{{ definition.metadata.name }} -n kube-system
+      environment:
+        KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
+      vars:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'test/operator-test.yaml'])) | from_yaml }}"
+      register: operator_describe
 
     - name: get operator logs
       ignore_errors: yes
       failed_when: false
-      command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ namespace }}
+      command: kubectl logs deployment/{{ definition.metadata.name }} -n kube-system
       environment:
         KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
       vars:
-        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'test/operator-test.yaml'])) | from_yaml }}"
       register: log
+
+    - debug: var=operator_describe.stdout_lines
 
     - debug: var=log.stdout_lines
 

--- a/molecule/test-local/playbook.yml
+++ b/molecule/test-local/playbook.yml
@@ -24,7 +24,7 @@
     deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
     pull_policy: Never
     REPLACE_IMAGE: astarte-kubernetes-operator-molecule:testing
-    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'examples/api_v1alpha1_astarte_cr_minimal.yaml'])) | from_yaml }}"
+    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'test/api_v1alpha1_astarte_cr_minimal.yaml'])) | from_yaml }}"
   tasks:
   - block:
     - name: Delete the Operator Deployment
@@ -71,6 +71,21 @@
       - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
       delay: 10
       retries: 60
+
+    - name: Wait for 5m until all pods are running
+      k8s_info:
+        kind: Pod
+        namespace: '{{ namespace }}'
+        # Exclude Job Pods, which of course aren't deleted.
+        label_selectors:
+          - "!job-name"
+        field_selectors:
+          - "status.phase!=Running"
+      register: non_running_pods_list
+      until:
+      - "non_running_pods_list.resources|length == 0"
+      delay: 10
+      retries: 30
     rescue:
     - name: debug cr
       ignore_errors: yes
@@ -98,6 +113,124 @@
           label_selector="component=astarte"
         )}}'
 
+    - name: describe nodes
+      ignore_errors: yes
+      failed_when: false
+      command: kubectl describe nodes
+      environment:
+        KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
+      register: nodes_describe
+
+    - name: describe operator
+      ignore_errors: yes
+      failed_when: false
+      command: kubectl describe deployment/{{ definition.metadata.name }} -n kube-system
+      environment:
+        KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
+      vars:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'test/operator-test.yaml'])) | from_yaml }}"
+      register: operator_describe
+
+    - name: get operator logs
+      ignore_errors: yes
+      failed_when: false
+      command: kubectl logs deployment/{{ definition.metadata.name }} -n kube-system
+      environment:
+        KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
+      vars:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'test/operator-test.yaml'])) | from_yaml }}"
+      register: log
+
+    - debug: var=operator_describe.stdout_lines
+
+    - debug: var=nodes_describe.stdout_lines
+
+    - debug: var=log.stdout_lines
+
+    - fail:
+        msg: "Failed on action: converge"
+
+- import_playbook: '{{ playbook_dir }}/../default/asserts.yml'
+
+# Validate deletion
+- name: Delete
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+    pull_policy: Never
+    REPLACE_IMAGE: astarte-kubernetes-operator-molecule:testing
+    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'test/api_v1alpha1_astarte_cr_minimal.yaml'])) | from_yaml }}"
+  tasks:
+  - block:
+    - name: Delete the api.astarte-platform.org/v1alpha1.Astarte
+      k8s:
+        state: absent
+        namespace: '{{ namespace }}'
+        definition: '{{ custom_resource }}'
+
+    - name: Wait 5m until all pods are down
+      k8s_info:
+        kind: Pod
+        namespace: '{{ namespace }}'
+        # Exclude Job Pods, which of course aren't deleted.
+        label_selectors:
+          - "!job-name"
+      register: pod_list
+      until:
+      - "pod_list.resources|length == 0"
+      delay: 10
+      retries: 30
+
+    - name: Ensure no secrets are left
+      k8s_info:
+        kind: Secret
+        namespace: '{{ namespace }}'
+        # Exclude Job Pods, which of course aren't deleted.
+        field_selectors:
+          - "type=Opaque"
+      register: secret_list
+      until:
+      - "secret_list.resources|length == 0"
+      delay: 10
+      retries: 12
+    rescue:
+    - name: debug cr
+      ignore_errors: yes
+      failed_when: false
+      debug:
+        var: debug_cr
+      vars:
+        debug_cr: '{{ lookup("k8s",
+          kind=custom_resource.kind,
+          api_version=custom_resource.apiVersion,
+          namespace=namespace,
+          resource_name=custom_resource.metadata.name
+        )}}'
+
+    - name: debug pods lookup
+      ignore_errors: yes
+      failed_when: false
+      debug:
+        var: deploy
+      vars:
+        deploy: '{{ lookup("k8s",
+          kind="Pod",
+          namespace=namespace
+        )}}'
+
+    - name: debug secrets lookup
+      ignore_errors: yes
+      failed_when: false
+      debug:
+        var: deploy
+      vars:
+        deploy: '{{ lookup("k8s",
+          kind="Secret",
+          namespace=namespace
+        )}}'
+
     - name: describe operator
       ignore_errors: yes
       failed_when: false
@@ -123,6 +256,4 @@
     - debug: var=log.stdout_lines
 
     - fail:
-        msg: "Failed on action: converge"
-
-- import_playbook: '{{ playbook_dir }}/../default/asserts.yml'
+        msg: "Failed on action: delete"

--- a/molecule/test-local/prepare.yml
+++ b/molecule/test-local/prepare.yml
@@ -12,6 +12,10 @@
     k8s:
       definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/api_v1alpha1_astarte_crd.yaml'])) }}"
 
+  - name: Create Custom Resource Definition
+    k8s:
+      definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/api_v1alpha1_astarte_voyager_ingress_crd.yaml'])) }}"
+
   - name: Ensure specified namespace is present
     k8s:
       api_version: v1

--- a/playbook/deploy-ingresses.yml
+++ b/playbook/deploy-ingresses.yml
@@ -1,16 +1,14 @@
 ---
 - name: Setting play-specific variables
   hosts: localhost
-  remote_user: root
-  connection: local
+  gather_facts: no
   tasks:
     - set_fact:
         astarte_resource_type: "AstarteVoyagerIngress"
 
 - name: Gather facts from existing Astarte Operator object
   hosts: localhost
-  remote_user: root
-  connection: local
+  gather_facts: no
   tags:
     - operator
   roles:
@@ -20,8 +18,7 @@
 
 - name: Deploy Voyager Broker Ingress
   hosts: localhost
-  remote_user: root
-  connection: local
+  gather_facts: no
   tags:
     - voyager
   roles:
@@ -31,8 +28,7 @@
 
 - name: Deploy Voyager API Ingress
   hosts: localhost
-  remote_user: root
-  connection: local
+  gather_facts: no
   tags:
     - voyager
   roles:
@@ -42,8 +38,7 @@
 
 - name: Obtain Voyager Let's Encrypt Certificate
   hosts: localhost
-  remote_user: root
-  connection: local
+  gather_facts: no
   tags:
     - voyager
     - letsencrypt

--- a/playbook/deploy.yml
+++ b/playbook/deploy.yml
@@ -1,16 +1,14 @@
 ---
 - name: Setting play-specific variables
   hosts: localhost
-  remote_user: root
-  connection: local
+  gather_facts: no
   tasks:
     - set_fact:
         astarte_resource_type: "Astarte"
 
 - name: Deploy Common Astarte Resources
   hosts: localhost
-  remote_user: root
-  connection: local
+  gather_facts: no
   tags:
     - astarte
   roles:
@@ -19,8 +17,7 @@
 
 - name: Deploy Astarte Dependencies
   hosts: localhost
-  remote_user: root
-  connection: local
+  gather_facts: no
   tags:
     - rabbitmq
   roles:
@@ -43,8 +40,7 @@
 
 - name: Retrieve CFSSL CA Secret
   hosts: localhost
-  remote_user: root
-  connection: local
+  gather_facts: no
   tags:
     - cfssl
   roles:
@@ -52,8 +48,7 @@
 
 - name: Deploy Astarte
   hosts: localhost
-  remote_user: root
-  connection: local
+  gather_facts: no
   tags:
     - astarte
   roles:

--- a/playbook/roles/astarte-k8s-facts/tasks/avi.yml
+++ b/playbook/roles/astarte-k8s-facts/tasks/avi.yml
@@ -15,7 +15,7 @@
     - voyager_letsencrypt_challenge == 'http'
 
 - name: Retrieve API Ingress
-  k8s_facts:
+  k8s_info:
     api_version: voyager.appscode.com/v1beta1
     kind: Ingress
     name: "{{ resources_computed_prefix }}api-ingress"
@@ -23,7 +23,7 @@
   register: avi_api_ingress
 
 - name: Retrieve Broker Ingress
-  k8s_facts:
+  k8s_info:
     api_version: voyager.appscode.com/v1beta1
     kind: Ingress
     name: "{{ resources_computed_prefix }}vernemq-ingress"

--- a/playbook/roles/astarte-k8s-facts/tasks/main.yml
+++ b/playbook/roles/astarte-k8s-facts/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Retrieve Astarte object
-  k8s_facts:
+  k8s_info:
     api_version: api.astarte-platform.org/v1alpha1
     kind: Astarte
     name: "{{ astarte }}"

--- a/playbook/roles/cfssl-ca-secret-job/templates/cfssl-ca-secret-job-rbac.yml
+++ b/playbook/roles/cfssl-ca-secret-job/templates/cfssl-ca-secret-job-rbac.yml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
@@ -21,7 +21,7 @@ metadata:
   name: {{ resources_computed_prefix }}cfssl-ca-secret-job
   namespace: {{ astarte_k8s_namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/playbook/roles/rabbitmq/templates/rabbitmq-rbac.yml
+++ b/playbook/roles/rabbitmq/templates/rabbitmq-rbac.yml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
@@ -18,7 +18,7 @@ metadata:
   name: {{ resources_computed_prefix }}rabbitmq
   namespace: {{ astarte_k8s_namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/playbook/roles/vernemq/templates/vernemq-rbac.yml
+++ b/playbook/roles/vernemq/templates/vernemq-rbac.yml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
@@ -18,7 +18,7 @@ metadata:
   name: {{ resources_computed_prefix }}vernemq
   namespace: {{ astarte_k8s_namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/roles/astarte-finalizer/defaults/main.yml
+++ b/roles/astarte-finalizer/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+astarte_k8s_namespace: "{{ vars | json_query('meta.namespace') | default('astarte', true) }}"
+
+# Resource prefix. Most useful for Operator.
+astarte_resources_prefix: "{{ vars | json_query('meta.name') | default('astarte', true) }}"
+resources_computed_prefix: "{{ '' if not astarte_resources_prefix else astarte_resources_prefix + '-' }}"
+parent_resources_computed_prefix: "{{ '' if not astarte_resources_prefix else astarte_resources_prefix + '-' }}"
+
+mqtt_broker_ca_secret: "{{ vars | json_query('vernemq.ca_secret') | default(resources_computed_prefix + 'cfssl-ca', true) }}"

--- a/roles/astarte-finalizer/tasks/main.yml
+++ b/roles/astarte-finalizer/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Delete CFSSL generated CA
+  k8s:
+    api_version: v1
+    state: absent
+    kind: Secret
+    namespace: "{{ astarte_k8s_namespace }}"
+    name: "{{ mqtt_broker_ca_secret }}"
+  when: lookup('k8s', kind='Secret', resource_name=mqtt_broker_ca_secret, namespace=astarte_k8s_namespace)

--- a/watches.yaml
+++ b/watches.yaml
@@ -3,6 +3,7 @@
   group: api.astarte-platform.org
   kind: Astarte
   playbook: /opt/ansible/playbook/deploy.yml
+  reconcilePeriod: 2m
   finalizer:
     name: finalizer.astarte.astarte-platform.org
     role: /opt/ansible/roles/astarte-finalizer
@@ -10,3 +11,4 @@
   group: api.astarte-platform.org
   kind: AstarteVoyagerIngress
   playbook: /opt/ansible/playbook/deploy-ingresses.yml
+  reconcilePeriod: 2m

--- a/watches.yaml
+++ b/watches.yaml
@@ -3,6 +3,9 @@
   group: api.astarte-platform.org
   kind: Astarte
   playbook: /opt/ansible/playbook/deploy.yml
+  finalizer:
+    name: finalizer.astarte.astarte-platform.org
+    role: /opt/ansible/roles/astarte-finalizer
 - version: v1alpha1
   group: api.astarte-platform.org
   kind: AstarteVoyagerIngress


### PR DESCRIPTION
This PR hugely revamps the plumbing of Astarte Operator. Most notably:

 * Astarte Operator now runs on top of Operator SDK 0.12.0
 * Molecule autotests are now working (Also on Travis)
 * Operator Reconciliation is not running forever for no reason
 * Finalizers are now working, and dangling CA secrets are now deleted correctly when deleting Astarte
 * Misc fixes and modernization to playbook(s)

Fixes #41 