### PR TITLE
Remove Travis CI from 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-sudo: required
-services: docker
-language: python
-install:
-  - pip install docker molecule openshift
-script:
-  - molecule test -s test-local


### PR DESCRIPTION
CI started working only from master. Remove it to avoid annoying and useless errors.