### PR TITLE
Update operator-sdk to 0.13.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.12.0
+FROM quay.io/operator-framework/ansible-operator:v0.13.0
 
 # Add needed modules
 RUN pip3 install --user pyopenssl jmespath

--- a/playbook/deploy-ingresses.yml
+++ b/playbook/deploy-ingresses.yml
@@ -14,7 +14,7 @@
   roles:
     - name: astarte-k8s-facts
       when:
-        - vars | json_query('meta.name')
+        - running_in_operator
 
 - name: Deploy Voyager Broker Ingress
   hosts: localhost

--- a/playbook/group_vars/all
+++ b/playbook/group_vars/all
@@ -24,7 +24,7 @@ cfssl_url: "http://{{ resources_computed_prefix }}cfssl.{{ astarte_k8s_namespace
 
 # This weird conditional means: default to empty when running from the Operator, and to 'housekeeping.pub'
 # when running as a standard playbook.
-astarte_housekeeping_public_key_file: "{{ '' if vars | json_query('meta.name') else 'housekeeping.pub' }}"
+astarte_housekeeping_public_key_file: "{{ '' if running_in_operator else 'housekeeping.pub' }}"
 astarte_housekeeping_public_key_secret: "{{ resources_computed_prefix }}housekeeping-public-key"
 astarte_housekeeping_private_key_secret: "{{ resources_computed_prefix }}housekeeping-private-key"
 

--- a/playbook/roles/astarte-common/tasks/main.yml
+++ b/playbook/roles/astarte-common/tasks/main.yml
@@ -1,6 +1,6 @@
 - debug:
-    msg: "This playbook is running in Operator mode. If this is not what you want, ensure the 'meta.name' variable is not defined"
-  when: vars | json_query('meta.name')
+    msg: "This playbook is running in Operator mode."
+  when: running_in_operator
 
 - debug:
     msg: "Will install Astarte version '{{ astarte_tag }}' in namespace '{{ astarte_k8s_namespace }}' with prefix '{{ resources_computed_prefix }}'"
@@ -13,7 +13,7 @@
     state: present
   # Avoid patching the namespace from the operator
   when:
-    - not (vars | json_query('meta.name'))
+    - not running_in_operator
 
 - name: Ensure Astarte Generic Erlang Configuration
   k8s:

--- a/watches.yaml
+++ b/watches.yaml
@@ -4,6 +4,8 @@
   kind: Astarte
   playbook: /opt/ansible/playbook/deploy.yml
   reconcilePeriod: 2m
+  vars:
+    running_in_operator: yes
   finalizer:
     name: finalizer.astarte.astarte-platform.org
     role: /opt/ansible/roles/astarte-finalizer
@@ -12,3 +14,5 @@
   kind: AstarteVoyagerIngress
   playbook: /opt/ansible/playbook/deploy-ingresses.yml
   reconcilePeriod: 2m
+  vars:
+    running_in_operator: yes


### PR DESCRIPTION
This allows us, in particular, to rely on newer Ansible and use custom vars in watchers.