### PR TITLE
cfssl: use cfssl.certificate_expiry to determine certificate lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ is empty, replace Data Updater Plant with the new version and bring VerneMQ back
 ### Fixed
 - Reconciliation policy now prevents the Operator from reconciling forever for no reason
 - Fix deprecations in Playbook
+- Allow correctly passing the certificate expiry to CFSSL
 
 ### Changed
 - Updated Operator SDK to 0.12

--- a/playbook/roles/cfssl/defaults/main.yml
+++ b/playbook/roles/cfssl/defaults/main.yml
@@ -17,7 +17,7 @@ cfssl_db_driver: sqlite3
 cfssl_db_data_source: "/data/certs.db"
 
 cfssl_ca_expiry: "{{ vars | json_query('cfssl.ca_expiry') | default('262800h', true) }}"
-cfssl_ca_certificate_expiry: "{{ vars | json_query('cfssl.ca_expiry') | default('2190h', true) }}"
+cfssl_ca_certificate_expiry: "{{ vars | json_query('cfssl.certificate_expiry') | default('2190h', true) }}"
 cfssl_ca_cn: Astarte Root CA
 cfssl_ca_key_algo: ecdsa
 cfssl_ca_key_size: 256


### PR DESCRIPTION
Don't use cfssl.ca_expiry, its meaning is different

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>