### PR TITLE
Remove deprecated /realm path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ is empty, replace Data Updater Plant with the new version and bring VerneMQ back
 - Updated Kubernetes minimum requirement to 1.14
 - Updated RBAC APIs
 
+### Removed
+- Remove deprecated `/realm` path, use `/realmmanagement` to access Realm Management
+
 ## [0.10.1] - 2019-10-02
 ### Added
 - Added static IP support to load balancer in AVI

--- a/playbook/roles/voyager-api-ingress/templates/voyager-ingress.yml
+++ b/playbook/roles/voyager-api-ingress/templates/voyager-ingress.yml
@@ -64,12 +64,6 @@ spec:
           backendRules:
           - 'reqrep ^([^\ :]*)\ /housekeeping/(.*$) \1\ /\2'
 {% endif %}
-      - path: /realm
-        backend:
-          serviceName: {{ parent_resources_computed_prefix }}realm-management
-          servicePort: '4000'
-          backendRules:
-          - 'reqrep ^([^\ :]*)\ /realm/(.*$) \1\ /\2'
       - path: /realmmanagement
         backend:
           serviceName: {{ parent_resources_computed_prefix }}realm-management


### PR DESCRIPTION
Realm management has to be accessed from `/realmmanagement`

Fix #8 