### PR TITLE
Allow individual components to specify a custom DeploymentStrategy, and fix Upgrade routine

### DIFF
--- a/deploy/crds/api.astarte-platform.org_astartes_crd.yaml
+++ b/deploy/crds/api.astarte-platform.org_astartes_crd.yaml
@@ -647,6 +647,56 @@ spec:
                 deploy:
                   description: / +kubebuilder:default=true
                   type: boolean
+                deploymentStrategy:
+                  description: DeploymentStrategy describes how to replace existing
+                    pods with new ones.
+                  properties:
+                    rollingUpdate:
+                      description: 'Rolling update config params. Present only if
+                        DeploymentStrategyType = RollingUpdate. --- TODO: Update this
+                        to follow our convention for oneOf, whatever we decide it
+                        to be.'
+                      properties:
+                        maxSurge:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'The maximum number of pods that can be scheduled
+                            above the desired number of pods. Value can be an absolute
+                            number (ex: 5) or a percentage of desired pods (ex: 10%).
+                            This can not be 0 if MaxUnavailable is 0. Absolute number
+                            is calculated from percentage by rounding up. Defaults
+                            to 25%. Example: when this is set to 30%, the new ReplicaSet
+                            can be scaled up immediately when the rolling update starts,
+                            such that the total number of old and new pods do not
+                            exceed 130% of desired pods. Once old pods have been killed,
+                            new ReplicaSet can be scaled up further, ensuring that
+                            total number of pods running at any time during the update
+                            is at most 130% of desired pods.'
+                          x-kubernetes-int-or-string: true
+                        maxUnavailable:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'The maximum number of pods that can be unavailable
+                            during the update. Value can be an absolute number (ex:
+                            5) or a percentage of desired pods (ex: 10%). Absolute
+                            number is calculated from percentage by rounding down.
+                            This can not be 0 if MaxSurge is 0. Defaults to 25%. Example:
+                            when this is set to 30%, the old ReplicaSet can be scaled
+                            down to 70% of desired pods immediately when the rolling
+                            update starts. Once new pods are ready, old ReplicaSet
+                            can be scaled down further, followed by scaling up the
+                            new ReplicaSet, ensuring that the total number of pods
+                            available at all times during the update is at least 70%
+                            of desired pods.'
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type:
+                      description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                        Default is RollingUpdate.
+                      type: string
+                  type: object
                 heapNewSize:
                   type: string
                 image:
@@ -3925,6 +3975,58 @@ spec:
                     deploy:
                       description: / +kubebuilder:default=true
                       type: boolean
+                    deploymentStrategy:
+                      description: DeploymentStrategy describes how to replace existing
+                        pods with new ones.
+                      properties:
+                        rollingUpdate:
+                          description: 'Rolling update config params. Present only
+                            if DeploymentStrategyType = RollingUpdate. --- TODO: Update
+                            this to follow our convention for oneOf, whatever we decide
+                            it to be.'
+                          properties:
+                            maxSurge:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'The maximum number of pods that can be
+                                scheduled above the desired number of pods. Value
+                                can be an absolute number (ex: 5) or a percentage
+                                of desired pods (ex: 10%). This can not be 0 if MaxUnavailable
+                                is 0. Absolute number is calculated from percentage
+                                by rounding up. Defaults to 25%. Example: when this
+                                is set to 30%, the new ReplicaSet can be scaled up
+                                immediately when the rolling update starts, such that
+                                the total number of old and new pods do not exceed
+                                130% of desired pods. Once old pods have been killed,
+                                new ReplicaSet can be scaled up further, ensuring
+                                that total number of pods running at any time during
+                                the update is at most 130% of desired pods.'
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'The maximum number of pods that can be
+                                unavailable during the update. Value can be an absolute
+                                number (ex: 5) or a percentage of desired pods (ex:
+                                10%). Absolute number is calculated from percentage
+                                by rounding down. This can not be 0 if MaxSurge is
+                                0. Defaults to 25%. Example: when this is set to 30%,
+                                the old ReplicaSet can be scaled down to 70% of desired
+                                pods immediately when the rolling update starts. Once
+                                new pods are ready, old ReplicaSet can be scaled down
+                                further, followed by scaling up the new ReplicaSet,
+                                ensuring that the total number of pods available at
+                                all times during the update is at least 70% of desired
+                                pods.'
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        type:
+                          description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                            Default is RollingUpdate.
+                          type: string
+                      type: object
                     disableAuthentication:
                       type: boolean
                     image:
@@ -4604,6 +4706,58 @@ spec:
                     deploy:
                       description: / +kubebuilder:default=true
                       type: boolean
+                    deploymentStrategy:
+                      description: DeploymentStrategy describes how to replace existing
+                        pods with new ones.
+                      properties:
+                        rollingUpdate:
+                          description: 'Rolling update config params. Present only
+                            if DeploymentStrategyType = RollingUpdate. --- TODO: Update
+                            this to follow our convention for oneOf, whatever we decide
+                            it to be.'
+                          properties:
+                            maxSurge:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'The maximum number of pods that can be
+                                scheduled above the desired number of pods. Value
+                                can be an absolute number (ex: 5) or a percentage
+                                of desired pods (ex: 10%). This can not be 0 if MaxUnavailable
+                                is 0. Absolute number is calculated from percentage
+                                by rounding up. Defaults to 25%. Example: when this
+                                is set to 30%, the new ReplicaSet can be scaled up
+                                immediately when the rolling update starts, such that
+                                the total number of old and new pods do not exceed
+                                130% of desired pods. Once old pods have been killed,
+                                new ReplicaSet can be scaled up further, ensuring
+                                that total number of pods running at any time during
+                                the update is at most 130% of desired pods.'
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'The maximum number of pods that can be
+                                unavailable during the update. Value can be an absolute
+                                number (ex: 5) or a percentage of desired pods (ex:
+                                10%). Absolute number is calculated from percentage
+                                by rounding down. This can not be 0 if MaxSurge is
+                                0. Defaults to 25%. Example: when this is set to 30%,
+                                the old ReplicaSet can be scaled down to 70% of desired
+                                pods immediately when the rolling update starts. Once
+                                new pods are ready, old ReplicaSet can be scaled down
+                                further, followed by scaling up the new ReplicaSet,
+                                ensuring that the total number of pods available at
+                                all times during the update is at least 70% of desired
+                                pods.'
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        type:
+                          description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                            Default is RollingUpdate.
+                          type: string
+                      type: object
                     host:
                       type: string
                     image:
@@ -5273,6 +5427,58 @@ spec:
                     deploy:
                       description: / +kubebuilder:default=true
                       type: boolean
+                    deploymentStrategy:
+                      description: DeploymentStrategy describes how to replace existing
+                        pods with new ones.
+                      properties:
+                        rollingUpdate:
+                          description: 'Rolling update config params. Present only
+                            if DeploymentStrategyType = RollingUpdate. --- TODO: Update
+                            this to follow our convention for oneOf, whatever we decide
+                            it to be.'
+                          properties:
+                            maxSurge:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'The maximum number of pods that can be
+                                scheduled above the desired number of pods. Value
+                                can be an absolute number (ex: 5) or a percentage
+                                of desired pods (ex: 10%). This can not be 0 if MaxUnavailable
+                                is 0. Absolute number is calculated from percentage
+                                by rounding up. Defaults to 25%. Example: when this
+                                is set to 30%, the new ReplicaSet can be scaled up
+                                immediately when the rolling update starts, such that
+                                the total number of old and new pods do not exceed
+                                130% of desired pods. Once old pods have been killed,
+                                new ReplicaSet can be scaled up further, ensuring
+                                that total number of pods running at any time during
+                                the update is at most 130% of desired pods.'
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'The maximum number of pods that can be
+                                unavailable during the update. Value can be an absolute
+                                number (ex: 5) or a percentage of desired pods (ex:
+                                10%). Absolute number is calculated from percentage
+                                by rounding down. This can not be 0 if MaxSurge is
+                                0. Defaults to 25%. Example: when this is set to 30%,
+                                the old ReplicaSet can be scaled down to 70% of desired
+                                pods immediately when the rolling update starts. Once
+                                new pods are ready, old ReplicaSet can be scaled down
+                                further, followed by scaling up the new ReplicaSet,
+                                ensuring that the total number of pods available at
+                                all times during the update is at least 70% of desired
+                                pods.'
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        type:
+                          description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                            Default is RollingUpdate.
+                          type: string
+                      type: object
                     image:
                       type: string
                     replicas:
@@ -5970,6 +6176,60 @@ spec:
                         deploy:
                           description: / +kubebuilder:default=true
                           type: boolean
+                        deploymentStrategy:
+                          description: DeploymentStrategy describes how to replace
+                            existing pods with new ones.
+                          properties:
+                            rollingUpdate:
+                              description: 'Rolling update config params. Present
+                                only if DeploymentStrategyType = RollingUpdate. ---
+                                TODO: Update this to follow our convention for oneOf,
+                                whatever we decide it to be.'
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of pods that can
+                                    be scheduled above the desired number of pods.
+                                    Value can be an absolute number (ex: 5) or a percentage
+                                    of desired pods (ex: 10%). This can not be 0 if
+                                    MaxUnavailable is 0. Absolute number is calculated
+                                    from percentage by rounding up. Defaults to 25%.
+                                    Example: when this is set to 30%, the new ReplicaSet
+                                    can be scaled up immediately when the rolling
+                                    update starts, such that the total number of old
+                                    and new pods do not exceed 130% of desired pods.
+                                    Once old pods have been killed, new ReplicaSet
+                                    can be scaled up further, ensuring that total
+                                    number of pods running at any time during the
+                                    update is at most 130% of desired pods.'
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of pods that can
+                                    be unavailable during the update. Value can be
+                                    an absolute number (ex: 5) or a percentage of
+                                    desired pods (ex: 10%). Absolute number is calculated
+                                    from percentage by rounding down. This can not
+                                    be 0 if MaxSurge is 0. Defaults to 25%. Example:
+                                    when this is set to 30%, the old ReplicaSet can
+                                    be scaled down to 70% of desired pods immediately
+                                    when the rolling update starts. Once new pods
+                                    are ready, old ReplicaSet can be scaled down further,
+                                    followed by scaling up the new ReplicaSet, ensuring
+                                    that the total number of pods available at all
+                                    times during the update is at least 70% of desired
+                                    pods.'
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of deployment. Can be "Recreate" or
+                                "RollingUpdate". Default is RollingUpdate.
+                              type: string
+                          type: object
                         disableAuthentication:
                           type: boolean
                         image:
@@ -6665,6 +6925,60 @@ spec:
                         deploy:
                           description: / +kubebuilder:default=true
                           type: boolean
+                        deploymentStrategy:
+                          description: DeploymentStrategy describes how to replace
+                            existing pods with new ones.
+                          properties:
+                            rollingUpdate:
+                              description: 'Rolling update config params. Present
+                                only if DeploymentStrategyType = RollingUpdate. ---
+                                TODO: Update this to follow our convention for oneOf,
+                                whatever we decide it to be.'
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of pods that can
+                                    be scheduled above the desired number of pods.
+                                    Value can be an absolute number (ex: 5) or a percentage
+                                    of desired pods (ex: 10%). This can not be 0 if
+                                    MaxUnavailable is 0. Absolute number is calculated
+                                    from percentage by rounding up. Defaults to 25%.
+                                    Example: when this is set to 30%, the new ReplicaSet
+                                    can be scaled up immediately when the rolling
+                                    update starts, such that the total number of old
+                                    and new pods do not exceed 130% of desired pods.
+                                    Once old pods have been killed, new ReplicaSet
+                                    can be scaled up further, ensuring that total
+                                    number of pods running at any time during the
+                                    update is at most 130% of desired pods.'
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of pods that can
+                                    be unavailable during the update. Value can be
+                                    an absolute number (ex: 5) or a percentage of
+                                    desired pods (ex: 10%). Absolute number is calculated
+                                    from percentage by rounding down. This can not
+                                    be 0 if MaxSurge is 0. Defaults to 25%. Example:
+                                    when this is set to 30%, the old ReplicaSet can
+                                    be scaled down to 70% of desired pods immediately
+                                    when the rolling update starts. Once new pods
+                                    are ready, old ReplicaSet can be scaled down further,
+                                    followed by scaling up the new ReplicaSet, ensuring
+                                    that the total number of pods available at all
+                                    times during the update is at least 70% of desired
+                                    pods.'
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of deployment. Can be "Recreate" or
+                                "RollingUpdate". Default is RollingUpdate.
+                              type: string
+                          type: object
                         image:
                           type: string
                         replicas:
@@ -7363,6 +7677,60 @@ spec:
                         deploy:
                           description: / +kubebuilder:default=true
                           type: boolean
+                        deploymentStrategy:
+                          description: DeploymentStrategy describes how to replace
+                            existing pods with new ones.
+                          properties:
+                            rollingUpdate:
+                              description: 'Rolling update config params. Present
+                                only if DeploymentStrategyType = RollingUpdate. ---
+                                TODO: Update this to follow our convention for oneOf,
+                                whatever we decide it to be.'
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of pods that can
+                                    be scheduled above the desired number of pods.
+                                    Value can be an absolute number (ex: 5) or a percentage
+                                    of desired pods (ex: 10%). This can not be 0 if
+                                    MaxUnavailable is 0. Absolute number is calculated
+                                    from percentage by rounding up. Defaults to 25%.
+                                    Example: when this is set to 30%, the new ReplicaSet
+                                    can be scaled up immediately when the rolling
+                                    update starts, such that the total number of old
+                                    and new pods do not exceed 130% of desired pods.
+                                    Once old pods have been killed, new ReplicaSet
+                                    can be scaled up further, ensuring that total
+                                    number of pods running at any time during the
+                                    update is at most 130% of desired pods.'
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of pods that can
+                                    be unavailable during the update. Value can be
+                                    an absolute number (ex: 5) or a percentage of
+                                    desired pods (ex: 10%). Absolute number is calculated
+                                    from percentage by rounding down. This can not
+                                    be 0 if MaxSurge is 0. Defaults to 25%. Example:
+                                    when this is set to 30%, the old ReplicaSet can
+                                    be scaled down to 70% of desired pods immediately
+                                    when the rolling update starts. Once new pods
+                                    are ready, old ReplicaSet can be scaled down further,
+                                    followed by scaling up the new ReplicaSet, ensuring
+                                    that the total number of pods available at all
+                                    times during the update is at least 70% of desired
+                                    pods.'
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of deployment. Can be "Recreate" or
+                                "RollingUpdate". Default is RollingUpdate.
+                              type: string
+                          type: object
                         disableAuthentication:
                           type: boolean
                         image:
@@ -8058,6 +8426,60 @@ spec:
                         deploy:
                           description: / +kubebuilder:default=true
                           type: boolean
+                        deploymentStrategy:
+                          description: DeploymentStrategy describes how to replace
+                            existing pods with new ones.
+                          properties:
+                            rollingUpdate:
+                              description: 'Rolling update config params. Present
+                                only if DeploymentStrategyType = RollingUpdate. ---
+                                TODO: Update this to follow our convention for oneOf,
+                                whatever we decide it to be.'
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of pods that can
+                                    be scheduled above the desired number of pods.
+                                    Value can be an absolute number (ex: 5) or a percentage
+                                    of desired pods (ex: 10%). This can not be 0 if
+                                    MaxUnavailable is 0. Absolute number is calculated
+                                    from percentage by rounding up. Defaults to 25%.
+                                    Example: when this is set to 30%, the new ReplicaSet
+                                    can be scaled up immediately when the rolling
+                                    update starts, such that the total number of old
+                                    and new pods do not exceed 130% of desired pods.
+                                    Once old pods have been killed, new ReplicaSet
+                                    can be scaled up further, ensuring that total
+                                    number of pods running at any time during the
+                                    update is at most 130% of desired pods.'
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of pods that can
+                                    be unavailable during the update. Value can be
+                                    an absolute number (ex: 5) or a percentage of
+                                    desired pods (ex: 10%). Absolute number is calculated
+                                    from percentage by rounding down. This can not
+                                    be 0 if MaxSurge is 0. Defaults to 25%. Example:
+                                    when this is set to 30%, the old ReplicaSet can
+                                    be scaled down to 70% of desired pods immediately
+                                    when the rolling update starts. Once new pods
+                                    are ready, old ReplicaSet can be scaled down further,
+                                    followed by scaling up the new ReplicaSet, ensuring
+                                    that the total number of pods available at all
+                                    times during the update is at least 70% of desired
+                                    pods.'
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of deployment. Can be "Recreate" or
+                                "RollingUpdate". Default is RollingUpdate.
+                              type: string
+                          type: object
                         image:
                           type: string
                         replicas:
@@ -8756,6 +9178,60 @@ spec:
                         deploy:
                           description: / +kubebuilder:default=true
                           type: boolean
+                        deploymentStrategy:
+                          description: DeploymentStrategy describes how to replace
+                            existing pods with new ones.
+                          properties:
+                            rollingUpdate:
+                              description: 'Rolling update config params. Present
+                                only if DeploymentStrategyType = RollingUpdate. ---
+                                TODO: Update this to follow our convention for oneOf,
+                                whatever we decide it to be.'
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of pods that can
+                                    be scheduled above the desired number of pods.
+                                    Value can be an absolute number (ex: 5) or a percentage
+                                    of desired pods (ex: 10%). This can not be 0 if
+                                    MaxUnavailable is 0. Absolute number is calculated
+                                    from percentage by rounding up. Defaults to 25%.
+                                    Example: when this is set to 30%, the new ReplicaSet
+                                    can be scaled up immediately when the rolling
+                                    update starts, such that the total number of old
+                                    and new pods do not exceed 130% of desired pods.
+                                    Once old pods have been killed, new ReplicaSet
+                                    can be scaled up further, ensuring that total
+                                    number of pods running at any time during the
+                                    update is at most 130% of desired pods.'
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of pods that can
+                                    be unavailable during the update. Value can be
+                                    an absolute number (ex: 5) or a percentage of
+                                    desired pods (ex: 10%). Absolute number is calculated
+                                    from percentage by rounding down. This can not
+                                    be 0 if MaxSurge is 0. Defaults to 25%. Example:
+                                    when this is set to 30%, the old ReplicaSet can
+                                    be scaled down to 70% of desired pods immediately
+                                    when the rolling update starts. Once new pods
+                                    are ready, old ReplicaSet can be scaled down further,
+                                    followed by scaling up the new ReplicaSet, ensuring
+                                    that the total number of pods available at all
+                                    times during the update is at least 70% of desired
+                                    pods.'
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of deployment. Can be "Recreate" or
+                                "RollingUpdate". Default is RollingUpdate.
+                              type: string
+                          type: object
                         disableAuthentication:
                           type: boolean
                         image:
@@ -9451,6 +9927,60 @@ spec:
                         deploy:
                           description: / +kubebuilder:default=true
                           type: boolean
+                        deploymentStrategy:
+                          description: DeploymentStrategy describes how to replace
+                            existing pods with new ones.
+                          properties:
+                            rollingUpdate:
+                              description: 'Rolling update config params. Present
+                                only if DeploymentStrategyType = RollingUpdate. ---
+                                TODO: Update this to follow our convention for oneOf,
+                                whatever we decide it to be.'
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of pods that can
+                                    be scheduled above the desired number of pods.
+                                    Value can be an absolute number (ex: 5) or a percentage
+                                    of desired pods (ex: 10%). This can not be 0 if
+                                    MaxUnavailable is 0. Absolute number is calculated
+                                    from percentage by rounding up. Defaults to 25%.
+                                    Example: when this is set to 30%, the new ReplicaSet
+                                    can be scaled up immediately when the rolling
+                                    update starts, such that the total number of old
+                                    and new pods do not exceed 130% of desired pods.
+                                    Once old pods have been killed, new ReplicaSet
+                                    can be scaled up further, ensuring that total
+                                    number of pods running at any time during the
+                                    update is at most 130% of desired pods.'
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of pods that can
+                                    be unavailable during the update. Value can be
+                                    an absolute number (ex: 5) or a percentage of
+                                    desired pods (ex: 10%). Absolute number is calculated
+                                    from percentage by rounding down. This can not
+                                    be 0 if MaxSurge is 0. Defaults to 25%. Example:
+                                    when this is set to 30%, the old ReplicaSet can
+                                    be scaled down to 70% of desired pods immediately
+                                    when the rolling update starts. Once new pods
+                                    are ready, old ReplicaSet can be scaled down further,
+                                    followed by scaling up the new ReplicaSet, ensuring
+                                    that the total number of pods available at all
+                                    times during the update is at least 70% of desired
+                                    pods.'
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of deployment. Can be "Recreate" or
+                                "RollingUpdate". Default is RollingUpdate.
+                              type: string
+                          type: object
                         image:
                           type: string
                         replicas:
@@ -10131,6 +10661,58 @@ spec:
                     deploy:
                       description: / +kubebuilder:default=true
                       type: boolean
+                    deploymentStrategy:
+                      description: DeploymentStrategy describes how to replace existing
+                        pods with new ones.
+                      properties:
+                        rollingUpdate:
+                          description: 'Rolling update config params. Present only
+                            if DeploymentStrategyType = RollingUpdate. --- TODO: Update
+                            this to follow our convention for oneOf, whatever we decide
+                            it to be.'
+                          properties:
+                            maxSurge:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'The maximum number of pods that can be
+                                scheduled above the desired number of pods. Value
+                                can be an absolute number (ex: 5) or a percentage
+                                of desired pods (ex: 10%). This can not be 0 if MaxUnavailable
+                                is 0. Absolute number is calculated from percentage
+                                by rounding up. Defaults to 25%. Example: when this
+                                is set to 30%, the new ReplicaSet can be scaled up
+                                immediately when the rolling update starts, such that
+                                the total number of old and new pods do not exceed
+                                130% of desired pods. Once old pods have been killed,
+                                new ReplicaSet can be scaled up further, ensuring
+                                that total number of pods running at any time during
+                                the update is at most 130% of desired pods.'
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'The maximum number of pods that can be
+                                unavailable during the update. Value can be an absolute
+                                number (ex: 5) or a percentage of desired pods (ex:
+                                10%). Absolute number is calculated from percentage
+                                by rounding down. This can not be 0 if MaxSurge is
+                                0. Defaults to 25%. Example: when this is set to 30%,
+                                the old ReplicaSet can be scaled down to 70% of desired
+                                pods immediately when the rolling update starts. Once
+                                new pods are ready, old ReplicaSet can be scaled down
+                                further, followed by scaling up the new ReplicaSet,
+                                ensuring that the total number of pods available at
+                                all times during the update is at least 70% of desired
+                                pods.'
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        type:
+                          description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                            Default is RollingUpdate.
+                          type: string
+                      type: object
                     image:
                       type: string
                     replicas:
@@ -10863,6 +11445,56 @@ spec:
                 deploy:
                   description: / +kubebuilder:default=true
                   type: boolean
+                deploymentStrategy:
+                  description: DeploymentStrategy describes how to replace existing
+                    pods with new ones.
+                  properties:
+                    rollingUpdate:
+                      description: 'Rolling update config params. Present only if
+                        DeploymentStrategyType = RollingUpdate. --- TODO: Update this
+                        to follow our convention for oneOf, whatever we decide it
+                        to be.'
+                      properties:
+                        maxSurge:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'The maximum number of pods that can be scheduled
+                            above the desired number of pods. Value can be an absolute
+                            number (ex: 5) or a percentage of desired pods (ex: 10%).
+                            This can not be 0 if MaxUnavailable is 0. Absolute number
+                            is calculated from percentage by rounding up. Defaults
+                            to 25%. Example: when this is set to 30%, the new ReplicaSet
+                            can be scaled up immediately when the rolling update starts,
+                            such that the total number of old and new pods do not
+                            exceed 130% of desired pods. Once old pods have been killed,
+                            new ReplicaSet can be scaled up further, ensuring that
+                            total number of pods running at any time during the update
+                            is at most 130% of desired pods.'
+                          x-kubernetes-int-or-string: true
+                        maxUnavailable:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'The maximum number of pods that can be unavailable
+                            during the update. Value can be an absolute number (ex:
+                            5) or a percentage of desired pods (ex: 10%). Absolute
+                            number is calculated from percentage by rounding down.
+                            This can not be 0 if MaxSurge is 0. Defaults to 25%. Example:
+                            when this is set to 30%, the old ReplicaSet can be scaled
+                            down to 70% of desired pods immediately when the rolling
+                            update starts. Once new pods are ready, old ReplicaSet
+                            can be scaled down further, followed by scaling up the
+                            new ReplicaSet, ensuring that the total number of pods
+                            available at all times during the update is at least 70%
+                            of desired pods.'
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type:
+                      description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                        Default is RollingUpdate.
+                      type: string
+                  type: object
                 image:
                   type: string
                 replicas:
@@ -12747,6 +13379,56 @@ spec:
                 deploy:
                   description: / +kubebuilder:default=true
                   type: boolean
+                deploymentStrategy:
+                  description: DeploymentStrategy describes how to replace existing
+                    pods with new ones.
+                  properties:
+                    rollingUpdate:
+                      description: 'Rolling update config params. Present only if
+                        DeploymentStrategyType = RollingUpdate. --- TODO: Update this
+                        to follow our convention for oneOf, whatever we decide it
+                        to be.'
+                      properties:
+                        maxSurge:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'The maximum number of pods that can be scheduled
+                            above the desired number of pods. Value can be an absolute
+                            number (ex: 5) or a percentage of desired pods (ex: 10%).
+                            This can not be 0 if MaxUnavailable is 0. Absolute number
+                            is calculated from percentage by rounding up. Defaults
+                            to 25%. Example: when this is set to 30%, the new ReplicaSet
+                            can be scaled up immediately when the rolling update starts,
+                            such that the total number of old and new pods do not
+                            exceed 130% of desired pods. Once old pods have been killed,
+                            new ReplicaSet can be scaled up further, ensuring that
+                            total number of pods running at any time during the update
+                            is at most 130% of desired pods.'
+                          x-kubernetes-int-or-string: true
+                        maxUnavailable:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'The maximum number of pods that can be unavailable
+                            during the update. Value can be an absolute number (ex:
+                            5) or a percentage of desired pods (ex: 10%). Absolute
+                            number is calculated from percentage by rounding down.
+                            This can not be 0 if MaxSurge is 0. Defaults to 25%. Example:
+                            when this is set to 30%, the old ReplicaSet can be scaled
+                            down to 70% of desired pods immediately when the rolling
+                            update starts. Once new pods are ready, old ReplicaSet
+                            can be scaled down further, followed by scaling up the
+                            new ReplicaSet, ensuring that the total number of pods
+                            available at all times during the update is at least 70%
+                            of desired pods.'
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type:
+                      description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                        Default is RollingUpdate.
+                      type: string
+                  type: object
                 host:
                   type: string
                 image:

--- a/pkg/apis/api/v1alpha1/astarte_types.go
+++ b/pkg/apis/api/v1alpha1/astarte_types.go
@@ -120,6 +120,8 @@ type AstarteGenericClusteredResource struct {
 	// +optional
 	CustomAffinity *v1.Affinity `json:"customAffinity,omitempty"`
 	// +optional
+	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
+	// +optional
 	Version string `json:"version,omitempty"`
 	// +optional
 	Image string `json:"image,omitempty"`

--- a/pkg/apis/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/api/v1alpha1/zz_generated.deepcopy.go
@@ -6,6 +6,7 @@ package v1alpha1
 
 import (
 	v1beta1 "github.com/astarte-platform/astarte-kubernetes-operator/external/voyager/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -473,6 +474,11 @@ func (in *AstarteGenericClusteredResource) DeepCopyInto(out *AstarteGenericClust
 	if in.CustomAffinity != nil {
 		in, out := &in.CustomAffinity, &out.CustomAffinity
 		*out = new(v1.Affinity)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.DeploymentStrategy != nil {
+		in, out := &in.DeploymentStrategy, &out.DeploymentStrategy
+		*out = new(appsv1.DeploymentStrategy)
 		(*in).DeepCopyInto(*out)
 	}
 	in.Resources.DeepCopyInto(&out.Resources)

--- a/pkg/controller/astarte/reconcile/astarte_dashboard.go
+++ b/pkg/controller/astarte/reconcile/astarte_dashboard.go
@@ -101,7 +101,7 @@ func EnsureAstarteDashboard(cr *apiv1alpha1.Astarte, dashboard apiv1alpha1.Astar
 		Selector: &metav1.LabelSelector{
 			MatchLabels: matchLabels,
 		},
-		Strategy: cr.Spec.DeploymentStrategy,
+		Strategy: getDeploymentStrategyForClusteredResource(cr, dashboard.GenericClusteredResource),
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,

--- a/pkg/controller/astarte/reconcile/astarte_generic_api.go
+++ b/pkg/controller/astarte/reconcile/astarte_generic_api.go
@@ -104,7 +104,7 @@ func EnsureAstarteGenericAPI(cr *apiv1alpha1.Astarte, api apiv1alpha1.AstarteGen
 		Selector: &metav1.LabelSelector{
 			MatchLabels: matchLabels,
 		},
-		Strategy: cr.Spec.DeploymentStrategy,
+		Strategy: getDeploymentStrategyForClusteredResource(cr, api.GenericClusteredResource),
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,

--- a/pkg/controller/astarte/reconcile/astarte_generic_backend.go
+++ b/pkg/controller/astarte/reconcile/astarte_generic_backend.go
@@ -74,7 +74,7 @@ func EnsureAstarteGenericBackend(cr *apiv1alpha1.Astarte, backend apiv1alpha1.As
 		Selector: &metav1.LabelSelector{
 			MatchLabels: matchLabels,
 		},
-		Strategy: cr.Spec.DeploymentStrategy,
+		Strategy: getDeploymentStrategyForClusteredResource(cr, backend),
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,

--- a/pkg/controller/astarte/reconcile/utils.go
+++ b/pkg/controller/astarte/reconcile/utils.go
@@ -35,6 +35,7 @@ import (
 	apiv1alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/pkg/apis/api/v1alpha1"
 	"github.com/astarte-platform/astarte-kubernetes-operator/pkg/misc"
 	"github.com/openlyinc/pointy"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -407,6 +408,13 @@ func getImageForClusteredResource(defaultImageName, defaultImageTag string, reso
 	}
 
 	return image
+}
+
+func getDeploymentStrategyForClusteredResource(cr *apiv1alpha1.Astarte, resource apiv1alpha1.AstarteGenericClusteredResource) appsv1.DeploymentStrategy {
+	if resource.DeploymentStrategy != nil {
+		return *resource.DeploymentStrategy
+	}
+	return cr.Spec.DeploymentStrategy
 }
 
 func getDataQueueCount(cr *apiv1alpha1.Astarte) int {

--- a/pkg/controller/astarte/upgrade/0.10_to_0.11.go
+++ b/pkg/controller/astarte/upgrade/0.10_to_0.11.go
@@ -92,6 +92,8 @@ func upgradeTo011(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Sche
 	housekeepingBackend := cr.Spec.Components.Housekeeping.Backend.DeepCopy()
 	housekeepingBackend.Version = landing011Version
 	housekeepingBackend.Replicas = pointy.Int32(1)
+	// Ensure the policy is Replace. We don't want to have old pods hanging around.
+	housekeepingBackend.DeploymentStrategy = &appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}
 	if misc.IsResourceRequirementsExplicit(cr.Spec.VerneMQ.GenericClusteredResource.Resources) {
 		resourceRequirements := misc.GetResourcesForAstarteComponent(cr, housekeepingBackend.Resources, apiv1alpha1.Housekeeping)
 		resourceRequirements.Requests.Cpu().Add(*cr.Spec.VerneMQ.GenericClusteredResource.Resources.Requests.Cpu())
@@ -109,6 +111,8 @@ func upgradeTo011(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Sche
 	housekeepingAPI := cr.Spec.Components.Housekeeping.API.DeepCopy()
 	housekeepingAPI.GenericClusteredResource.Replicas = pointy.Int32(1)
 	housekeepingAPI.GenericClusteredResource.Version = landing011Version
+	// Ensure the policy is Replace. We don't want to have old pods hanging around.
+	housekeepingAPI.GenericClusteredResource.DeploymentStrategy = &appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}
 	if err := reconcile.EnsureAstarteGenericAPI(cr, *housekeepingAPI, apiv1alpha1.HousekeepingAPI, c, scheme); err != nil {
 		return err
 	}
@@ -282,6 +286,8 @@ func upgradeTo011(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Sche
 	reqLogger.Info("Ensuring new RabbitMQ Queue Layout through Data Updater Plant...")
 	dataUpdaterPlant := cr.Spec.Components.DataUpdaterPlant.DeepCopy()
 	dataUpdaterPlant.GenericClusteredResource.Version = landing011Version
+	// Ensure the policy is Replace. We don't want to have old pods hanging around.
+	dataUpdaterPlant.GenericClusteredResource.DeploymentStrategy = &appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}
 	if err := reconcile.EnsureAstarteGenericBackend(cr, dataUpdaterPlant.GenericClusteredResource, apiv1alpha1.DataUpdaterPlant, c, scheme); err != nil {
 		return err
 	}


### PR DESCRIPTION
This prevents flakes in Readiness status during Upgrade, and allows users to specify an individual strategy per-component.