### PR TITLE
Fix StatefulSets health detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.0-beta.3] - Unreleased
+### Fixed
+- Ensure that the Astarte CR status takes into account VerneMQ and CFSSL StatefulSets as well.
+
 ## [0.11.0-beta.2] - 2020-01-25
 ### Added
 - Upgrade support


### PR DESCRIPTION
This PR ensures that the Status/Health of the Astarte Custom Resource also takes into account the state of all StatefulSets.

This also adds more labels to the StatefulSets, making de-facto the reconciliation fail when upgrading from previous 0.11 beta versions. If one wishes to upgrade, it would have to manually delete with --cascade false all statefulsets to ensure a safe reconciliation.

0.10 users are not affected by this