### PR TITLE
Update RabbitMQ to 3.8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Update RabbitMQ version to 3.8.x for 1.0.x releases
+
 ## [0.11.0-rc.1] - 2020-03-26
 ### Fixed
 - Allocate resources correctly in Components when non-explicit per-component requirements are given

--- a/pkg/controller/astarte/deps/dependencies_versions.go
+++ b/pkg/controller/astarte/deps/dependencies_versions.go
@@ -40,10 +40,15 @@ func GetDefaultVersionForCassandra(astarteVersion *semver.Version) string {
 // GetDefaultVersionForRabbitMQ returns the default RabbitMQ version based on the Astarte version requested
 func GetDefaultVersionForRabbitMQ(astarteVersion *semver.Version) string {
 	checkVersion, _ := astarteVersion.SetPrerelease("")
-	c, _ := semver.NewConstraint("< 0.11.0")
-	if c.Check(&checkVersion) {
+	beforeZeroEleven, _ := semver.NewConstraint("< 0.11.0")
+	if beforeZeroEleven.Check(&checkVersion) {
 		return "3.7.15"
 	}
 
-	return "3.7.21"
+	beforeOne, _ := semver.NewConstraint("< 1.0.0")
+	if beforeOne.Check(&checkVersion) {
+		return "3.7.21"
+	}
+
+	return "3.8"
 }


### PR DESCRIPTION
Update to latest 3.8.x version.
RabbitMQ minor release will be frozen when branching out.