### PR TITLE
AVI: Do not expose /metrics by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - Unreleased
+### Added
+- AstarteVoyagerIngress now has two more options in `api`: `serveMetrics` and `serveMetricsToSubnet`, to
+  give fine-grained control on who has access to `/metrics`
+
+### Changed
+- All `/metrics` endpoints are no longer exposed by default
+
 ## [0.11.0-rc.1] - 2020-03-26
 ### Fixed
 - Allocate resources correctly in Components when non-explicit per-component requirements are given

--- a/deploy/crds/api.astarte-platform.org_astartevoyageringresses_crd.yaml
+++ b/deploy/crds/api.astarte-platform.org_astartevoyageringresses_crd.yaml
@@ -55,6 +55,17 @@ spec:
                 replicas:
                   format: int32
                   type: integer
+                serveMetrics:
+                  description: When true, all /metrics endpoints for Astarte services
+                    will be served by the Ingress. Beware this might be a security
+                    hole. You can control which IPs can access /metrics with serveMetricsToSubnet
+                  type: boolean
+                serveMetricsToSubnet:
+                  description: 'When specified and when serveMetrics is true, /metrics
+                    endpoints will be served only to IPs in the provided subnet range.
+                    The subnet has to be compatible with the HAProxy ACL src syntax
+                    (e.g.: 10.0.0.0/16)'
+                  type: string
                 tlsRef:
                   description: LocalTypedReference contains enough information to
                     let you inspect or modify the referred object.

--- a/deploy/examples/api_v1alpha1_astarte_voyager_ingress_cr.yaml
+++ b/deploy/examples/api_v1alpha1_astarte_voyager_ingress_cr.yaml
@@ -16,6 +16,8 @@ spec:
     nodeSelector: "mynodeselector"
     exposeHousekeeping: true
     tlsSecret: my-custom-broker-ssl-certificate
+    serveMetrics: true
+    serveMetricsToSubnet: '198.51.100.0/24'
     annotationsService:
       service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
   dashboard:

--- a/pkg/apis/api/v1alpha1/astartevoyageringress_types.go
+++ b/pkg/apis/api/v1alpha1/astartevoyageringress_types.go
@@ -54,6 +54,16 @@ type AstarteVoyagerIngressAPISpec struct {
 	Cors *bool `json:"cors,omitempty"`
 	// +optional
 	ExposeHousekeeping *bool `json:"exposeHousekeeping,omitempty"`
+	// When true, all /metrics endpoints for Astarte services will be served by the Ingress.
+	// Beware this might be a security hole. You can control which IPs can access /metrics
+	// with serveMetricsToSubnet
+	// +optional
+	ServeMetrics *bool `json:"serveMetrics,omitempty"`
+	// When specified and when serveMetrics is true, /metrics endpoints will be served only to IPs
+	// in the provided subnet range. The subnet has to be compatible with the HAProxy
+	// ACL src syntax (e.g.: 10.0.0.0/16)
+	// +optional
+	ServeMetricsToSubnet string `json:"serveMetricsToSubnet,omitempty"`
 }
 
 // AstarteVoyagerIngressDashboardSpec defines the specification of the Dashboard

--- a/pkg/apis/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/api/v1alpha1/zz_generated.deepcopy.go
@@ -814,6 +814,11 @@ func (in *AstarteVoyagerIngressAPISpec) DeepCopyInto(out *AstarteVoyagerIngressA
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ServeMetrics != nil {
+		in, out := &in.ServeMetrics, &out.ServeMetrics
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
The new monitoring feature in Astarte services exposes a Prometheus-compatible /metrics endpoint. Such an endpoint, however, is meant to be scraped by a trusted source, and can leak sensitive information.

Do not serve it by default, and allow fine grained configuration of allowed subnets in case it should be served to an external scraper.