### PR TITLE
Prepare 0.11.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.11.0] - Unreleased
+## [0.11.0] - 2020-04-14
 ### Added
 - AstarteVoyagerIngress now has two more options in `api`: `serveMetrics` and `serveMetricsToSubnet`, to
   give fine-grained control on who has access to `/metrics`

--- a/pkg/controller/astarte/reconcile/astarte_dashboard.go
+++ b/pkg/controller/astarte/reconcile/astarte_dashboard.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 
+	semver "github.com/Masterminds/semver/v3"
 	apiv1alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/pkg/apis/api/v1alpha1"
 	"github.com/astarte-platform/astarte-kubernetes-operator/pkg/misc"
 	"github.com/openlyinc/pointy"
@@ -33,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	semver "github.com/Masterminds/semver/v3"
 )
 
 // EnsureAstarteDashboard reconciles Astarte Dashboard
@@ -161,9 +161,7 @@ func getAstarteDashboardConfigMapData(cr *apiv1alpha1.Astarte, dashboard apiv1al
 	dashboardConfig := make(map[string]interface{})
 
 	v := getSemanticVersionForAstarteComponent(cr, dashboard.Version)
-	// TODO: Right before 0.11.0, change this constraint to < 0.11.0. We shouldn't expose such details after
-	// we've gone stable.
-	constraint, _ := semver.NewConstraint("< 0.11.0-beta.3")
+	constraint, _ := semver.NewConstraint("< 0.11.0")
 
 	if dashboard.Config.RealmManagementAPIURL == "" {
 		if constraint.Check(v) {
@@ -194,7 +192,7 @@ func getAstarteDashboardConfigMapData(cr *apiv1alpha1.Astarte, dashboard apiv1al
 	if len(dashboard.Config.Auth) > 0 {
 		dashboardConfig["auth"] = dashboard.Config.Auth
 	} else {
-		dashboardConfig["auth"] = []apiv1alpha1.AstarteDashboardConfigAuthSpec{apiv1alpha1.AstarteDashboardConfigAuthSpec{Type: "token"}}
+		dashboardConfig["auth"] = []apiv1alpha1.AstarteDashboardConfigAuthSpec{{Type: "token"}}
 	}
 	dashboardConfig["secure_connection"] = pointy.BoolValue(cr.Spec.API.SSL, true)
 

--- a/pkg/controller/astarte/reconcile/astarte_generic_api.go
+++ b/pkg/controller/astarte/reconcile/astarte_generic_api.go
@@ -286,15 +286,6 @@ func getAstarteAPIProbe(cr *apiv1alpha1.Astarte, api apiv1alpha1.AstarteGenericA
 		return getAstarteAPIGenericProbe("/v1/health")
 	}
 
-	// TODO: Right before 0.11.0, change this constraint to < 0.11.0. We shouldn't expose such details after
-	// we've gone stable.
-	constraint, _ = semver.NewConstraint("<= 0.11.0-beta.2")
-	if constraint.Check(v) {
-		if component == apiv1alpha1.RealmManagementAPI || component == apiv1alpha1.PairingAPI {
-			return nil
-		}
-	}
-
 	// The rest are generic probes on /health
 	return getAstarteAPIGenericProbe("/health")
 }

--- a/pkg/controller/astarte/reconcile/astarte_generic_backend.go
+++ b/pkg/controller/astarte/reconcile/astarte_generic_backend.go
@@ -120,11 +120,11 @@ func getAstarteGenericBackendPodSpec(deploymentName string, cr *apiv1alpha1.Asta
 		ImagePullSecrets:              cr.Spec.ImagePullSecrets,
 		Affinity:                      getAffinityForClusteredResource(deploymentName, backend),
 		Containers: []v1.Container{
-			v1.Container{
+			{
 				Name: component.DashedString(),
 				Ports: []v1.ContainerPort{
 					// This port is not exposed through any service - it is just used for health checks and the likes.
-					v1.ContainerPort{Name: "http", ContainerPort: 4000},
+					{Name: "http", ContainerPort: 4000},
 				},
 				VolumeMounts:    getAstarteGenericBackendVolumeMounts(deploymentName, cr, backend, component),
 				Image:           getAstarteImageForClusteredResource(component.DockerImageName(), backend, cr),
@@ -296,13 +296,6 @@ func getAstarteBackendProbe(cr *apiv1alpha1.Astarte, backend apiv1alpha1.Astarte
 
 	if constraint.Check(&checkVersion) {
 		// 0.10.x has no such thing.
-		return nil
-	}
-
-	// TODO: Remove this check right before 0.11.0. We shouldn't expose such details after we've gone stable.
-	constraint, _ = semver.NewConstraint("<= 0.11.0-beta.2")
-	if constraint.Check(v) {
-		// This was implemented after beta2
 		return nil
 	}
 

--- a/test/e2e010/test_upgrade_0.11.go
+++ b/test/e2e010/test_upgrade_0.11.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var target011Version string = "0.11.0-rc.1"
+var target011Version string = "0.11.0"
 
 func astarteUpgradeTo011Test(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
 	namespace, err := ctx.GetNamespace()

--- a/test/e2e011/test_deploy_0.11.go
+++ b/test/e2e011/test_deploy_0.11.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var target011Version string = "0.11.0-rc.1"
+var target011Version string = "0.11.0"
 
 func astarteDeploy011Test(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
 	namespace, err := ctx.GetNamespace()

--- a/test/utils/astarte_resource.go
+++ b/test/utils/astarte_resource.go
@@ -33,7 +33,7 @@ var AstarteTestResource *operator.Astarte = &operator.Astarte{
 		Name: "example-astarte",
 	},
 	Spec: operator.AstarteSpec{
-		Version: "0.11.0-rc.1",
+		Version: "0.11.0",
 		// Use the "Recreate" strategy. Some test environments are really constrained, and might not have enough
 		// resources to support RollingUpdate.
 		DeploymentStrategy: appsv1.DeploymentStrategy{

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ package version
 
 const (
 	// Version is the Operator's version
-	Version = "0.11.0-rc.1"
+	Version = "0.11.0"
 
 	// AstarteVersionConstraintString represents the range of supported Astarte versions for this Operator.
 	// If the Astarte version falls out of this range, reconciliation will be immediately aborted.


### PR DESCRIPTION
This also removes all TODOs and partial constraints, making the operator de-facto incompatible with 0.11.x pre-releases.