### PR TITLE
controller: Do not deadlock when upgrading an unhealthy cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - AstarteVoyagerIngress now has two more options in `api`: `serveMetrics` and `serveMetricsToSubnet`, to
   give fine-grained control on who has access to `/metrics`
 
+### Fixed
+- When checking whether an upgrade can be performed, do not deadlock in case the cluster wasn't green
+  when performing the request
+
 ### Changed
 - All `/metrics` endpoints are no longer exposed by default
 


### PR DESCRIPTION
As much as we want to prevent the scenario where an upgrade starts if the cluster is unhealthy, the current operator logic forbid any kind of health computation if the health status reported by the cluster was not green. As such, even if the cluster got healthy in the meanwhile, the Operator would have deadlocked forever on the previous Cluster status.

On the other hand, computed status does not tell the whole story. In case an upgrade was started, failed in between operations, and reconciliation retriggers restarting the upgrade workflow, the upgrade might not trigger because at that state, the cluster would be unhealthy.

The right solution is taking into account both states (from resource Status and from computation) and proceeding if at least one of them is reported being healthy.