### PR TITLE
housekeeping: Ensure the probe is long enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - Unreleased
+### Fixed
+- Fixed a situation where Housekeeping might never enter in ready state with low CPU allocations
+
 ## [0.11.0] - 2020-04-14
 ### Added
 - AstarteVoyagerIngress now has two more options in `api`: `serveMetrics` and `serveMetricsToSubnet`, to


### PR DESCRIPTION
This makes sure that, when deploying housekeeping, the timeout is long enough, as it goes through three init phases. With low CPU allocations, the previous timeout might simply be too short, resulting in a chain of CrashLoopBackoffs for no reason.