### PR TITLE
Append RPC_AMQP_CONNECTION_* env vars to VerneMQ statefulset

### DIFF
--- a/lib/reconcile/vernemq.go
+++ b/lib/reconcile/vernemq.go
@@ -199,6 +199,8 @@ func getVerneMQEnvVars(statefulSetName string, cr *apiv1alpha1.Astarte) []v1.Env
 
 	// Append RabbitMQ variables (trailing _, as we need two)
 	envVars = appendRabbitMQConnectionEnvVars(envVars, "DOCKER_VERNEMQ_ASTARTE_VMQ_PLUGIN__AMQP_", cr)
+	// Also append env vars for RPC
+	envVars = appendRabbitMQConnectionEnvVars(envVars, "RPC_AMQP_CONNECTION", cr)
 
 	checkVersion := getSemanticVersionForAstarteComponent(cr, cr.Spec.VerneMQ.Version)
 	// 0.11+ variables


### PR DESCRIPTION
RPC connection options are read at runtime by Skogsra, so an additional set of
environment variable has to be passed. This currently contains the same
information that is contained in DOCKER_VERNEMQ_ASTARTE_VMQ_PLUGIN__AMQP_*
variables, but they effectively represent two different AMQP connections (the
one where data flows and the one to handle RPC).

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>