### PR TITLE
astarte_dashboard: add Astarte 1.0+ config format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - It is now possible to explictly set a CA for Devices through a Kubernetes TLS Secret
+- Add support for the Dashboard configuration used in Astarte 1.0 and later.
 
 ### Changed
 - Update RabbitMQ version to 3.8.x for 1.0.x releases

--- a/deploy/crds/api.astarte-platform.org_astartes_crd.yaml
+++ b/deploy/crds/api.astarte-platform.org_astartes_crd.yaml
@@ -94,8 +94,6 @@ spec:
                             type: boolean
                           sni:
                             type: boolean
-                        required:
-                        - enabled
                         type: object
                       username:
                         type: string
@@ -4996,6 +4994,8 @@ spec:
                       flowApiUrl:
                         type: string
                       image:
+                        type: string
+                      pairingApiUrl:
                         type: string
                       realmManagementApiUrl:
                         type: string

--- a/pkg/apis/api/v1alpha1/astarte_types.go
+++ b/pkg/apis/api/v1alpha1/astarte_types.go
@@ -362,6 +362,8 @@ type AstarteDashboardConfigSpec struct {
 	// +optional
 	AppEngineAPIURL string `json:"appEngineApiUrl,omitempty"`
 	// +optional
+	PairingAPIURL string `json:"pairingApiUrl,omitempty"`
+	// +optional
 	FlowAPIURL string `json:"flowApiUrl,omitempty"`
 	// +optional
 	DefaultRealm string `json:"defaultRealm,omitempty"`


### PR DESCRIPTION
If Astarte 1.0+ is used, pass the API urls only if they are explicit.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>