### PR TITLE
All Astarte services have a corresponding k8s service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - It is now possible to explictly set a CA for Devices through a Kubernetes TLS Secret
 - Add support for the Dashboard configuration used in Astarte 1.0 and later.
+- Add a k8s service for each Astarte service.
 
 ### Changed
 - Update RabbitMQ version to 3.8.x for 1.0.x releases
 - Starting with Astarte 1.0.0, CFSSL by default doesn't use a Database instead of using SQLite.
 - CFSSL is now deployed as a Deployment, and no longer requires a Persistent Volume. This also
   means SQLite is no longer supported as a Database.
+- Append `-api` to existing API service names.
 
 ## [0.11.1] - 2020-05-18
 ### Added

--- a/lib/reconcile/astarte_generic_api.go
+++ b/lib/reconcile/astarte_generic_api.go
@@ -70,28 +70,7 @@ func EnsureAstarteGenericAPIWithCustomProbe(cr *apiv1alpha1.Astarte, api apiv1al
 	}
 
 	// Good. Now, reconcile the service first of all.
-	service := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: cr.Namespace}}
-	if result, err := controllerutil.CreateOrUpdate(context.TODO(), c, service, func() error {
-		if err := controllerutil.SetControllerReference(cr, service, scheme); err != nil {
-			return err
-		}
-		// Always set everything to what we require.
-		service.ObjectMeta.Labels = labels
-		service.Spec.Type = v1.ServiceTypeClusterIP
-		service.Spec.ClusterIP = noneClusterIP
-		service.Spec.Ports = []v1.ServicePort{
-			{
-				Name:       "http",
-				Port:       astarteServicesPort,
-				TargetPort: intstr.FromString("http"),
-				Protocol:   v1.ProtocolTCP,
-			},
-		}
-		service.Spec.Selector = matchLabels
-		return nil
-	}); err == nil {
-		misc.LogCreateOrUpdateOperationResult(log, result, cr, service)
-	} else {
+	if err := createOrUpdateService(cr, c, serviceName, scheme, matchLabels, labels); err != nil {
 		return err
 	}
 

--- a/lib/reconcile/astarte_generic_backend.go
+++ b/lib/reconcile/astarte_generic_backend.go
@@ -47,6 +47,7 @@ func EnsureAstarteGenericBackendWithCustomProbe(cr *apiv1alpha1.Astarte, backend
 	component apiv1alpha1.AstarteComponent, c client.Client, scheme *runtime.Scheme, customProbe *v1.Probe) error {
 	reqLogger := log.WithValues("Request.Namespace", cr.Namespace, "Request.Name", cr.Name, "Astarte.Component", component)
 	deploymentName := cr.Name + "-" + component.DashedString()
+	serviceName := cr.Name + "-" + component.ServiceName()
 	labels := map[string]string{
 		"app":               deploymentName,
 		"component":         "astarte",
@@ -75,6 +76,11 @@ func EnsureAstarteGenericBackendWithCustomProbe(cr *apiv1alpha1.Astarte, backend
 
 	// First of all, check if we need to regenerate the cookie.
 	if err := ensureErlangCookieSecret(deploymentName+"-cookie", cr, c, scheme); err != nil {
+		return err
+	}
+
+	// Good. Now, reconcile the service first of all.
+	if err := createOrUpdateService(cr, c, serviceName, scheme, matchLabels, labels); err != nil {
 		return err
 	}
 

--- a/pkg/apis/api/v1alpha1/astarte_types.go
+++ b/pkg/apis/api/v1alpha1/astarte_types.go
@@ -138,14 +138,19 @@ func (a *AstarteComponent) DockerImageName() string {
 	return "astarte_" + a.String()
 }
 
-// ServiceName returns the Kubernetes Service Name associated to this Astarte component,
-// if any, otherwise returns an empty string.
-// This will return a meaningful value only for API components or the Dashboard.
+// ServiceName returns the Kubernetes Service Name associated to this Astarte component.
 func (a *AstarteComponent) ServiceName() string {
+	return a.DashedString()
+}
+
+// ServiceRelativePath returns the relative path where the service will be served by the Astarte Voyager Ingress.
+// This will return a meaningful value only for API components or the Dashboard.
+func (a *AstarteComponent) ServiceRelativePath() string {
 	if !strings.Contains(a.String(), "api") && a.String() != "dashboard" && a.String() != "flow" {
 		return ""
 	}
-	return strings.Replace(a.DashedString(), "-api", "", -1)
+	ret := strings.Replace(a.DashedString(), "-", "", -1)
+	return strings.Replace(ret, "api", "", -1)
 }
 
 type AstarteGenericClusteredResource struct {

--- a/pkg/controller/astartevoyageringress/api_ingress.go
+++ b/pkg/controller/astartevoyageringress/api_ingress.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 
 	voyager "github.com/astarte-platform/astarte-kubernetes-operator/external/voyager/v1beta1"
 	apiv1alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/pkg/apis/api/v1alpha1"
@@ -241,7 +240,7 @@ func getLEFixupForAPIIngress(cr *apiv1alpha1.AstarteVoyagerIngress, parent *apiv
 
 func getHTTPIngressPathForAstarteComponent(parent *apiv1alpha1.Astarte, component apiv1alpha1.AstarteComponent,
 	serveMetrics bool, serveMetricsToSubnet string) voyager.HTTPIngressPath {
-	return getHTTPIngressWithPath(parent, strings.Replace(component.ServiceName(), "-", "", -1), component.ServiceName(), serveMetrics, serveMetricsToSubnet)
+	return getHTTPIngressWithPath(parent, component.ServiceRelativePath(), component.ServiceName(), serveMetrics, serveMetricsToSubnet)
 }
 
 func getHTTPIngressWithPath(parent *apiv1alpha1.Astarte, relativePath, serviceName string, serveMetrics bool, serveMetricsToSubnet string) voyager.HTTPIngressPath {


### PR DESCRIPTION
+ all Astarte services have a corresponding k8s service
+ append `-api` to API services name
+ endpoints exposed by the ingress keep the same names

Fix #126, #127, #128