### PR TITLE
Expose port 8888 for VerneMQ metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add support for the Dashboard configuration used in Astarte 1.0 and later.
 - Add a k8s service for each Astarte service.
 - Make port 15692 available for RabbitMQ metrics.
+- Expose port 8888 for VerneMQ metrics.
 
 ### Changed
 - Update RabbitMQ version to 3.8.x for 1.0.x releases

--- a/lib/reconcile/vernemq.go
+++ b/lib/reconcile/vernemq.go
@@ -98,6 +98,12 @@ func EnsureVerneMQ(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Sch
 				TargetPort: intstr.FromString("mqtt-reverse"),
 				Protocol:   v1.ProtocolTCP,
 			},
+			{
+				Name:       "webadmin",
+				Port:       8888,
+				TargetPort: intstr.FromString("webadmin"),
+				Protocol:   v1.ProtocolTCP,
+			},
 		}
 		service.Spec.Selector = labels
 		// Add Annotations for Voyager (when deployed)


### PR DESCRIPTION
Fix #130 