### PR TITLE
Implement Upgrade to Astarte 1.0.x

### DIFF
--- a/lib/upgrade/0.10_to_0.11.go
+++ b/lib/upgrade/0.10_to_0.11.go
@@ -21,17 +21,9 @@ package upgrade
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/astarte-platform/astarte-kubernetes-operator/lib/reconcile"
 	apiv1alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/pkg/apis/api/v1alpha1"
-	"github.com/astarte-platform/astarte-kubernetes-operator/pkg/misc"
-	"github.com/openlyinc/pointy"
-	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -65,7 +57,7 @@ func upgradeTo011(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Sche
 	recorder.Event(cr, "Normal", apiv1alpha1.AstarteResourceEventUpgrade.String(),
 		"Starting Database Migration")
 	reqLogger.Info("Upgrading Housekeeping and migrating the Database...")
-	housekeepingBackend, err := upgradeHousekeeping(cr, c, scheme, recorder)
+	housekeepingBackend, err := upgradeHousekeeping(landing011Version, true, cr, c, scheme, recorder)
 	if err != nil {
 		return err
 	}
@@ -89,7 +81,7 @@ func upgradeTo011(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Sche
 	reqLogger.Info("Ensuring new RabbitMQ Queue Layout through Data Updater Plant...")
 	recorder.Event(cr, "Normal", apiv1alpha1.AstarteResourceEventUpgrade.String(),
 		"Starting Queue layout migration")
-	if err := waitForQueueLayoutMigration(cr, c, scheme); err != nil {
+	if err := waitForQueueLayoutMigration(landing011Version, cr, c, scheme); err != nil {
 		recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
 			"Could not migrate data queues. Upgrade will be retried, but manual intervention is likely required")
 		return fmt.Errorf("Failed in waiting for Data Updater Plant to come up: %v", err)
@@ -112,23 +104,7 @@ func upgradeTo011(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Sche
 	// Just to be sure, scale down Housekeeping to 0 replicas. If we're *really* tight on resources, it might be that
 	// the additional pool prevents other pods from coming up.
 	reqLogger.Info("Restoring original environment and waiting for cluster to settle...")
-	housekeepingBackend.Replicas = pointy.Int32(0)
-	if err := reconcile.EnsureAstarteGenericBackend(cr, *housekeepingBackend, apiv1alpha1.Housekeeping, c, scheme); err != nil {
-		return err
-	}
-	// Wait for it to go down, then we should be good to go.
-	if err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
-		deployment := &appsv1.Deployment{}
-		if err = c.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-housekeeping", Namespace: cr.Namespace}, deployment); err != nil {
-			return false, err
-		}
-
-		if deployment.Status.ReadyReplicas > 0 {
-			return false, nil
-		}
-
-		return true, nil
-	}); err != nil {
+	if err := scaleDownHousekeeping(housekeepingBackend, cr, c, scheme); err != nil {
 		reqLogger.Error(err, "Failed in waiting for Housekeeping to go down. Continuing anyway.")
 	}
 
@@ -136,148 +112,4 @@ func upgradeTo011(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Sche
 	recorder.Event(cr, "Normal", apiv1alpha1.AstarteResourceEventUpgrade.String(),
 		"Astarte upgraded successfully to the 0.11.x series")
 	return nil
-}
-
-func waitForQueueLayoutMigration(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Scheme) error {
-	dataUpdaterPlant := cr.Spec.Components.DataUpdaterPlant.DeepCopy()
-	dataUpdaterPlant.Version = landing011Version
-	// Ensure the policy is Replace. We don't want to have old pods hanging around.
-	dataUpdaterPlant.DeploymentStrategy = &appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}
-	if err := reconcile.EnsureAstarteGenericBackend(cr, dataUpdaterPlant.AstarteGenericClusteredResource, apiv1alpha1.DataUpdaterPlant, c, scheme); err != nil {
-		return err
-	}
-	// The operation should be pretty normal and quick enough. Wait with standard timeouts here
-	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
-		deployment := &appsv1.Deployment{}
-		if err = c.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-data-updater-plant", Namespace: cr.Namespace}, deployment); err != nil {
-			return false, err
-		}
-
-		if deployment.Status.ReadyReplicas > 0 {
-			return true, nil
-		}
-
-		return false, nil
-	})
-}
-
-func waitForHousekeepingUpgrade(cr *apiv1alpha1.Astarte, c client.Client, recorder record.EventRecorder) error {
-	weirdFailuresCount := 0
-	weirdFailuresThreshold := 10
-
-	return wait.Poll(retryInterval, time.Hour, func() (done bool, err error) {
-		deployment := &appsv1.Deployment{}
-		if err = c.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-housekeeping-api", Namespace: cr.Namespace}, deployment); err != nil {
-			weirdFailuresCount++
-			if weirdFailuresCount > weirdFailuresThreshold {
-				// Something is off.
-				recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
-					"Repeated errors in monitoring Database Migration. Manual intervention is likely required")
-				return false, fmt.Errorf("Failed in looking up Housekeeping API Deployment. Most likely, manual intervention is required. %v", err)
-			}
-			// Something is off.
-			log.Error(err, "Failed in looking up Housekeeping API Deployment. This might be a temporary problem - will retry")
-			return false, nil
-		}
-
-		if deployment.Status.ReadyReplicas >= 1 {
-			// That's it bros.
-			return true, nil
-		}
-
-		// Ensure we aren't in the position where Housekeeping itself is crashing.
-		housekeepingComponent := apiv1alpha1.Housekeeping
-		podList := &v1.PodList{}
-		if err = c.List(context.TODO(), podList, client.InNamespace(cr.Namespace),
-			client.MatchingLabels{"astarte-component": housekeepingComponent.DashedString()}); err != nil {
-			weirdFailuresCount++
-			if weirdFailuresCount > weirdFailuresThreshold {
-				// Something is off.
-				recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
-					"Repeated errors in monitoring Database Migration. Manual intervention is likely required")
-				return false, fmt.Errorf("Failed in looking up Housekeeping pods. Most likely, manual intervention is required. %v", err)
-			}
-			// Something is off.
-			log.Error(err, "Failed in looking up Housekeeping pods. This might be a temporary problem - will retry")
-			return false, nil
-		}
-
-		// Inspect the list!
-		if len(podList.Items) != 1 {
-			weirdFailuresCount++
-			if weirdFailuresCount > weirdFailuresThreshold {
-				// Something is off.
-				recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
-					"Repeated errors in monitoring Database Migration. Manual intervention is likely required")
-				return false, fmt.Errorf("%v Housekeeping pods found. Most likely, manual intervention is required. %v", len(podList.Items), err)
-			}
-			// Something is off.
-			log.Error(err, fmt.Sprintf("%v Housekeeping pods found. This might be a temporary problem - will retry", len(podList.Items)))
-			return false, nil
-		}
-
-		if len(podList.Items[0].Status.ContainerStatuses) != 1 {
-			weirdFailuresCount++
-			if weirdFailuresCount > weirdFailuresThreshold {
-				// Something is off.
-				recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
-					"Repeated errors in monitoring Database Migration. Manual intervention is likely required")
-				return false, fmt.Errorf("%v Container Statuses retrieved. Most likely, manual intervention is required. %v", len(podList.Items[0].Status.ContainerStatuses), err)
-			}
-			// Something is off.
-			log.Error(err, fmt.Sprintf("%v Container Statuses retrieved. This might be a temporary problem - will retry", len(podList.Items[0].Status.ContainerStatuses)))
-			return false, nil
-		}
-
-		if podList.Items[0].Status.ContainerStatuses[0].State.Waiting != nil {
-			if podList.Items[0].Status.ContainerStatuses[0].State.Waiting.Reason == "CrashLoopBackoff" {
-				recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
-					"Database Migration failed. Manual intervention is likely required")
-				return true, fmt.Errorf("Housekeeping is crashing repeatedly. There has to be a problem in handling Database migrations. Please take manual action as soon as possible")
-			}
-		}
-
-		return false, nil
-	})
-}
-
-func upgradeHousekeeping(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Scheme,
-	recorder record.EventRecorder) (*apiv1alpha1.AstarteGenericClusteredResource, error) {
-	housekeepingBackend := cr.Spec.Components.Housekeeping.Backend.DeepCopy()
-	housekeepingBackend.Version = landing011Version
-	housekeepingBackend.Replicas = pointy.Int32(1)
-	// Ensure the policy is Replace. We don't want to have old pods hanging around.
-	housekeepingBackend.DeploymentStrategy = &appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}
-	if cr.Spec.VerneMQ.Resources != nil {
-		resourceRequirements := misc.GetResourcesForAstarteComponent(cr, housekeepingBackend.Resources, apiv1alpha1.Housekeeping)
-		resourceRequirements.Requests.Cpu().Add(*cr.Spec.VerneMQ.Resources.Requests.Cpu())
-		resourceRequirements.Requests.Memory().Add(*cr.Spec.VerneMQ.Resources.Requests.Memory())
-		resourceRequirements.Limits.Cpu().Add(*cr.Spec.VerneMQ.Resources.Limits.Cpu())
-		resourceRequirements.Limits.Memory().Add(*cr.Spec.VerneMQ.Resources.Limits.Memory())
-
-		// This way, on the next call to GetResourcesForAstarteComponent, these resources will be returned as explicitly stated
-		// in the original spec.
-		housekeepingBackend.Resources = &resourceRequirements
-	}
-
-	// Add a custom, more permissive probe to the Backend
-	if err := reconcile.EnsureAstarteGenericBackendWithCustomProbe(cr, *housekeepingBackend, apiv1alpha1.Housekeeping,
-		c, scheme, getSpecialHousekeepingMigrationProbe("/health")); err != nil {
-		recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventUpgradeError.String(),
-			"Could not initiate Database Migration. Upgrade will be retried")
-		return nil, err
-	}
-	housekeepingAPI := cr.Spec.Components.Housekeeping.API.DeepCopy()
-	housekeepingAPI.Replicas = pointy.Int32(1)
-	housekeepingAPI.Version = landing011Version
-	// Ensure the policy is Replace. We don't want to have old pods hanging around.
-	housekeepingAPI.DeploymentStrategy = &appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}
-	if err := reconcile.EnsureAstarteGenericAPIWithCustomProbe(cr, *housekeepingAPI, apiv1alpha1.HousekeepingAPI, c,
-		scheme, getSpecialHousekeepingMigrationProbe("/health")); err != nil {
-		recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventUpgradeError.String(),
-			"Could not initiate Database Migration. Upgrade will be retried")
-		return nil, err
-	}
-
-	return housekeepingBackend, nil
 }

--- a/lib/upgrade/0.11_to_1.0.go
+++ b/lib/upgrade/0.11_to_1.0.go
@@ -1,0 +1,85 @@
+/*
+  This file is part of Astarte.
+
+  Copyright 2020 Ispirata Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+
+	apiv1alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/pkg/apis/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const landing10Version string = "1.0-snapshot"
+
+// blindly upgrades to 1.0. Invokable only by the upgrade logic
+func upgradeTo10(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) error {
+	reqLogger := log.WithValues("Request.Namespace", cr.Namespace, "Request.Name", cr.Name)
+	// Follow the script!
+	reqLogger.Info("Upgrading Astarte to the 1.0.x series. The cluster might become partially unresponsive during the process")
+	reqLogger.Info("At some point, the broker will be brought down during reconciliation. Devices won't be able to connect for a short period of time.")
+
+	// Step 1: Migrate the Database
+	// 1.0 allows us to do this "live". So simply upgrade Housekeeping and wait for it to settle while the cluster remains up.
+	recorder.Event(cr, "Normal", apiv1alpha1.AstarteResourceEventUpgrade.String(),
+		"Starting Database Migration")
+	reqLogger.Info("Upgrading Housekeeping and migrating the Database...")
+	if _, err := upgradeHousekeeping(landing10Version, false, cr, c, scheme, recorder); err != nil {
+		return err
+	}
+
+	// Now we wait indefinitely until this is done. Upgrading the Database might take *a lot* of time, so unless we enter in
+	// weird states such as CrashLoopBackoff, we wait almost forever
+	if err := waitForHousekeepingUpgrade(cr, c, recorder); err != nil {
+		recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
+			"Timed out waiting for Database Migration. Upgrade will be retried, but manual intervention is likely required")
+		return fmt.Errorf("Failed in waiting for Housekeeping deployment and migrations to go up: %v", err)
+	}
+	recorder.Event(cr, "Normal", apiv1alpha1.AstarteResourceEventUpgrade.String(),
+		"Database migrated successfully")
+	reqLogger.Info("Database successfully migrated!")
+
+	// Step 2: Stop the Broker. We need to upgrade its RPC
+	if err := shutdownVerneMQ(cr, c, recorder); err != nil {
+		return err
+	}
+
+	// Step 3: Drain RabbitMQ Queues, to ensure nothing is left before we move forward.
+	if err := drainRabbitMQQueues(cr, c, recorder); err != nil {
+		return err
+	}
+
+	reqLogger.Info("Your Astarte cluster has been successfully upgraded to the 1.0.x series!")
+
+	// This is it. Do not bring up VerneMQ or anything: the reconciliation will now do the right thing with the right versions.
+	// On the other hand, as the update successfully completed, increase the Astarte version in the status to ensure we don't
+	// go through this twice.
+	cr.Status.AstarteVersion = landing10Version
+	if err := c.Status().Update(context.TODO(), cr); err != nil {
+		reqLogger.Error(err, "Failed to update Astarte status. The Operator might misbehave")
+		return err
+	}
+
+	// All done! Upgraded successfully. Now let the standard reconciliation workflow do the rest.
+	recorder.Event(cr, "Normal", apiv1alpha1.AstarteResourceEventUpgrade.String(),
+		"Astarte upgraded successfully to the 1.0.x series")
+	return nil
+}

--- a/lib/upgrade/operations.go
+++ b/lib/upgrade/operations.go
@@ -25,14 +25,18 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
+	"github.com/astarte-platform/astarte-kubernetes-operator/lib/reconcile"
 	apiv1alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/pkg/apis/api/v1alpha1"
 	"github.com/astarte-platform/astarte-kubernetes-operator/pkg/misc"
+	"github.com/go-logr/logr"
 	"github.com/openlyinc/pointy"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -104,9 +108,9 @@ func drainRabbitMQQueues(cr *apiv1alpha1.Astarte, c client.Client, recorder reco
 	recorder.Event(cr, "Normal", apiv1alpha1.AstarteResourceEventUpgrade.String(),
 		"Draining RabbitMQ Data Queues")
 
-	// Get the 0.10 queue state
+	// Get the queue state
 	httpClient := &http.Client{}
-	req, _ := http.NewRequest("GET", "http://"+rmqHost+":15672/api/queues/%2F/vmq_all", nil)
+	req, _ := http.NewRequest("GET", "http://"+rmqHost+":15672/api/queues", nil)
 	req.SetBasicAuth(rmqUser, rmqPass)
 
 	// Wait up to a minute, otherwise restart
@@ -119,18 +123,18 @@ func drainRabbitMQQueues(cr *apiv1alpha1.Astarte, c client.Client, recorder reco
 
 		defer resp.Body.Close()
 		respBody, _ := ioutil.ReadAll(resp.Body)
-		respJSON := map[string]interface{}{}
+		respJSON := []map[string]interface{}{}
 		if e2 := json.Unmarshal(respBody, &respJSON); e2 != nil {
 			recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
 				"Unrecoverable error in querying RabbitMQ Management. Upgrade will be retried, but manual intervention is likely required")
 			reqLogger.Error(e2, "Unrecoverable error in querying RabbitMQ Management")
 			return false, e2
 		}
-		// float64 is how this is decoded by Go
-		messagesReady := respJSON["messages_ready"].(float64)
-		if messagesReady > 0 {
-			reqLogger.Info("Waiting for RabbitMQ Data Queue to drain.", "MessagesLeft", messagesReady)
-			return false, nil
+		for _, queueState := range respJSON {
+			// Check if it matches one of the data queues from 0.10 onwards
+			if ok, e3 := checkRabbitMQQueue(queueState, reqLogger); !ok {
+				return false, e3
+			}
 		}
 		return true, nil
 	}); err != nil {
@@ -150,6 +154,36 @@ func drainRabbitMQQueues(cr *apiv1alpha1.Astarte, c client.Client, recorder reco
 	}
 
 	return nil
+}
+
+func checkRabbitMQQueue(queueState map[string]interface{}, reqLogger logr.Logger) (bool, error) {
+	// Check if it matches one of the data queues from 0.10 onwards
+	queueName, ok := queueState["name"].(string)
+	switch {
+	case !ok:
+		return false, fmt.Errorf("Malformed JSON reply from RabbitMQ management")
+	case queueName == "astarte_data_updater_plant_rpc":
+		// Break false positives
+		return true, nil
+	case queueName == "vmq_all", strings.HasPrefix(queueName, "astarte_data_"):
+		// Match, don't do anything
+	default:
+		// Don't take the queue into account
+		return true, nil
+	}
+
+	// float64 is how this is decoded by Go
+	messagesReady, ok := queueState["messages_ready"].(float64)
+	switch {
+	case !ok:
+		return false, fmt.Errorf("Malformed JSON reply from RabbitMQ management")
+	case messagesReady > 0:
+		reqLogger.Info("Waiting for RabbitMQ Data Queues to drain.",
+			"MessagesLeft", messagesReady, "QueueName", queueName)
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func openRabbitMQPortForward(cr *apiv1alpha1.Astarte) (string, chan struct{}, error) {
@@ -205,6 +239,171 @@ func openRabbitMQPortForward(cr *apiv1alpha1.Astarte) (string, chan struct{}, er
 	}
 
 	return "", nil, nil
+}
+
+func waitForQueueLayoutMigration(version string, cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Scheme) error {
+	dataUpdaterPlant := cr.Spec.Components.DataUpdaterPlant.DeepCopy()
+	dataUpdaterPlant.Version = version
+	// Ensure the policy is Replace. We don't want to have old pods hanging around.
+	dataUpdaterPlant.DeploymentStrategy = &appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}
+	if err := reconcile.EnsureAstarteGenericBackend(cr, dataUpdaterPlant.AstarteGenericClusteredResource, apiv1alpha1.DataUpdaterPlant, c, scheme); err != nil {
+		return err
+	}
+	// The operation should be pretty normal and quick enough. Wait with standard timeouts here
+	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		deployment := &appsv1.Deployment{}
+		if err = c.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-data-updater-plant", Namespace: cr.Namespace}, deployment); err != nil {
+			return false, err
+		}
+
+		if deployment.Status.ReadyReplicas > 0 {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}
+
+func waitForHousekeepingUpgrade(cr *apiv1alpha1.Astarte, c client.Client, recorder record.EventRecorder) error {
+	weirdFailuresCount := 0
+	weirdFailuresThreshold := 10
+
+	return wait.Poll(retryInterval, time.Hour, func() (done bool, err error) {
+		deployment := &appsv1.Deployment{}
+		if err = c.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-housekeeping-api", Namespace: cr.Namespace}, deployment); err != nil {
+			weirdFailuresCount++
+			if weirdFailuresCount > weirdFailuresThreshold {
+				// Something is off.
+				recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
+					"Repeated errors in monitoring Database Migration. Manual intervention is likely required")
+				return false, fmt.Errorf("Failed in looking up Housekeeping API Deployment. Most likely, manual intervention is required. %v", err)
+			}
+			// Something is off.
+			log.Error(err, "Failed in looking up Housekeeping API Deployment. This might be a temporary problem - will retry")
+			return false, nil
+		}
+
+		if deployment.Status.ReadyReplicas >= 1 {
+			// That's it bros.
+			return true, nil
+		}
+
+		// Ensure we aren't in the position where Housekeeping itself is crashing.
+		housekeepingComponent := apiv1alpha1.Housekeeping
+		podList := &v1.PodList{}
+		if err = c.List(context.TODO(), podList, client.InNamespace(cr.Namespace),
+			client.MatchingLabels{"astarte-component": housekeepingComponent.DashedString()}); err != nil {
+			weirdFailuresCount++
+			if weirdFailuresCount > weirdFailuresThreshold {
+				// Something is off.
+				recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
+					"Repeated errors in monitoring Database Migration. Manual intervention is likely required")
+				return false, fmt.Errorf("Failed in looking up Housekeeping pods. Most likely, manual intervention is required. %v", err)
+			}
+			// Something is off.
+			log.Error(err, "Failed in looking up Housekeeping pods. This might be a temporary problem - will retry")
+			return false, nil
+		}
+
+		// Inspect the list!
+		if len(podList.Items) != 1 {
+			weirdFailuresCount++
+			if weirdFailuresCount > weirdFailuresThreshold {
+				// Something is off.
+				recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
+					"Repeated errors in monitoring Database Migration. Manual intervention is likely required")
+				return false, fmt.Errorf("%v Housekeeping pods found. Most likely, manual intervention is required. %v", len(podList.Items), err)
+			}
+			// Something is off.
+			log.Error(err, fmt.Sprintf("%v Housekeeping pods found. This might be a temporary problem - will retry", len(podList.Items)))
+			return false, nil
+		}
+
+		if len(podList.Items[0].Status.ContainerStatuses) != 1 {
+			weirdFailuresCount++
+			if weirdFailuresCount > weirdFailuresThreshold {
+				// Something is off.
+				recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
+					"Repeated errors in monitoring Database Migration. Manual intervention is likely required")
+				return false, fmt.Errorf("%v Container Statuses retrieved. Most likely, manual intervention is required. %v", len(podList.Items[0].Status.ContainerStatuses), err)
+			}
+			// Something is off.
+			log.Error(err, fmt.Sprintf("%v Container Statuses retrieved. This might be a temporary problem - will retry", len(podList.Items[0].Status.ContainerStatuses)))
+			return false, nil
+		}
+
+		if podList.Items[0].Status.ContainerStatuses[0].State.Waiting != nil {
+			if podList.Items[0].Status.ContainerStatuses[0].State.Waiting.Reason == "CrashLoopBackoff" {
+				recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventCriticalError.String(),
+					"Database Migration failed. Manual intervention is likely required")
+				return true, fmt.Errorf("Housekeeping is crashing repeatedly. There has to be a problem in handling Database migrations. Please take manual action as soon as possible")
+			}
+		}
+
+		return false, nil
+	})
+}
+
+func upgradeHousekeeping(version string, drainVerneMQResources bool, cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Scheme,
+	recorder record.EventRecorder) (*apiv1alpha1.AstarteGenericClusteredResource, error) {
+	housekeepingBackend := cr.Spec.Components.Housekeeping.Backend.DeepCopy()
+	housekeepingBackend.Version = version
+	housekeepingBackend.Replicas = pointy.Int32(1)
+	// Ensure the policy is Replace. We don't want to have old pods hanging around.
+	housekeepingBackend.DeploymentStrategy = &appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}
+	if cr.Spec.VerneMQ.Resources != nil && drainVerneMQResources {
+		resourceRequirements := misc.GetResourcesForAstarteComponent(cr, housekeepingBackend.Resources, apiv1alpha1.Housekeeping)
+		resourceRequirements.Requests.Cpu().Add(*cr.Spec.VerneMQ.Resources.Requests.Cpu())
+		resourceRequirements.Requests.Memory().Add(*cr.Spec.VerneMQ.Resources.Requests.Memory())
+		resourceRequirements.Limits.Cpu().Add(*cr.Spec.VerneMQ.Resources.Limits.Cpu())
+		resourceRequirements.Limits.Memory().Add(*cr.Spec.VerneMQ.Resources.Limits.Memory())
+
+		// This way, on the next call to GetResourcesForAstarteComponent, these resources will be returned as explicitly stated
+		// in the original spec.
+		housekeepingBackend.Resources = &resourceRequirements
+	}
+
+	// Add a custom, more permissive probe to the Backend
+	if err := reconcile.EnsureAstarteGenericBackendWithCustomProbe(cr, *housekeepingBackend, apiv1alpha1.Housekeeping,
+		c, scheme, getSpecialHousekeepingMigrationProbe("/health")); err != nil {
+		recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventUpgradeError.String(),
+			"Could not initiate Database Migration. Upgrade will be retried")
+		return nil, err
+	}
+	housekeepingAPI := cr.Spec.Components.Housekeeping.API.DeepCopy()
+	housekeepingAPI.Replicas = pointy.Int32(1)
+	housekeepingAPI.Version = version
+	// Ensure the policy is Replace. We don't want to have old pods hanging around.
+	housekeepingAPI.DeploymentStrategy = &appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}
+	if err := reconcile.EnsureAstarteGenericAPIWithCustomProbe(cr, *housekeepingAPI, apiv1alpha1.HousekeepingAPI, c,
+		scheme, getSpecialHousekeepingMigrationProbe("/health")); err != nil {
+		recorder.Event(cr, "Warning", apiv1alpha1.AstarteResourceEventUpgradeError.String(),
+			"Could not initiate Database Migration. Upgrade will be retried")
+		return nil, err
+	}
+
+	return housekeepingBackend, nil
+}
+
+func scaleDownHousekeeping(housekeepingBackend *apiv1alpha1.AstarteGenericClusteredResource, cr *apiv1alpha1.Astarte,
+	c client.Client, scheme *runtime.Scheme) error {
+	housekeepingBackend.Replicas = pointy.Int32(0)
+	if err := reconcile.EnsureAstarteGenericBackend(cr, *housekeepingBackend, apiv1alpha1.Housekeeping, c, scheme); err != nil {
+		return err
+	}
+	// Wait for it to go down, then we should be good to go.
+	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		deployment := &appsv1.Deployment{}
+		if err = c.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-housekeeping", Namespace: cr.Namespace}, deployment); err != nil {
+			return false, err
+		}
+
+		if deployment.Status.ReadyReplicas > 0 {
+			return false, nil
+		}
+
+		return true, nil
+	})
 }
 
 func getSpecialHousekeepingMigrationProbe(path string) *v1.Probe {

--- a/test/e2e011/test_upgrade_1.0.go
+++ b/test/e2e011/test_upgrade_1.0.go
@@ -27,12 +27,11 @@ import (
 
 	operator "github.com/astarte-platform/astarte-kubernetes-operator/pkg/apis/api/v1alpha1"
 	"github.com/astarte-platform/astarte-kubernetes-operator/test/utils"
-	"github.com/astarte-platform/astarte-kubernetes-operator/version"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var target10Version string = version.SnapshotVersion
+var target10Version string = "1.0-snapshot"
 
 func astarteUpgradeTo10Test(f *framework.Framework, ctx *framework.Context) error {
 	namespace, err := ctx.GetWatchNamespace()

--- a/version/version.go
+++ b/version/version.go
@@ -59,6 +59,9 @@ func CanManageVersion(v string) bool {
 		return false
 	}
 
+	// Strip the prerelease
+	*targetVersion, _ = targetVersion.SetPrerelease("")
+
 	c, _ := semver.NewConstraint(AstarteVersionConstraintString)
 
 	return c.Check(targetVersion)


### PR DESCRIPTION
This PR introduces support in the Operator for upgrading Astarte to the 1.0.x series. It also ensures the tests are run against the correct branches and that x.y-snapshot versions are handled correctly.

Fixes #123 