### PR TITLE
Add a new version/check file with common constraint check functions

### DIFF
--- a/lib/deps/dependencies_versions.go
+++ b/lib/deps/dependencies_versions.go
@@ -18,56 +18,37 @@
 
 package deps
 
-import semver "github.com/Masterminds/semver/v3"
+import "github.com/astarte-platform/astarte-kubernetes-operator/version"
 
 // GetDefaultVersionForCFSSL returns the default CFSSL version based on the Astarte version requested
-func GetDefaultVersionForCFSSL(astarteVersion *semver.Version) string {
-	latestVersion := "1.4.1-astarte.1"
-	if astarteVersion == nil {
-		// We're on snapshot, return latest
-		return latestVersion
-	}
-
-	checkVersion, _ := astarteVersion.SetPrerelease("")
-
-	c, _ := semver.NewConstraint("< 0.11.0")
-	if c.Check(&checkVersion) {
+func GetDefaultVersionForCFSSL(astarteVersion string) string {
+	if version.CheckConstraintAgainstAstarteVersion("< 0.11.0", astarteVersion) == nil {
 		return "1.0.0-astarte.0"
 	}
 
 	// Before 1.0.0, we always defaulted to a must-have DB configuration. So keep it.
-	c, _ = semver.NewConstraint("< 1.0.0")
-	if c.Check(&checkVersion) {
+	if version.CheckConstraintAgainstAstarteVersion("< 1.0.0", astarteVersion) == nil {
 		return "1.4.1-astarte.0"
 	}
 
-	return latestVersion
+	return "1.4.1-astarte.1"
 }
 
 // GetDefaultVersionForCassandra returns the default Cassandra version based on the Astarte version requested
-func GetDefaultVersionForCassandra(astarteVersion *semver.Version) string {
+func GetDefaultVersionForCassandra(astarteVersion string) string {
 	// TODO: We should change this to the official images
 	return "v13"
 }
 
 // GetDefaultVersionForRabbitMQ returns the default RabbitMQ version based on the Astarte version requested
-func GetDefaultVersionForRabbitMQ(astarteVersion *semver.Version) string {
-	latestVersion := "3.8"
-	if astarteVersion == nil {
-		// We're on snapshot, return latest
-		return latestVersion
-	}
-
-	checkVersion, _ := astarteVersion.SetPrerelease("")
-	beforeZeroEleven, _ := semver.NewConstraint("< 0.11.0")
-	if beforeZeroEleven.Check(&checkVersion) {
+func GetDefaultVersionForRabbitMQ(astarteVersion string) string {
+	if version.CheckConstraintAgainstAstarteVersion("< 0.11.0", astarteVersion) == nil {
 		return "3.7.15"
 	}
 
-	beforeOne, _ := semver.NewConstraint("< 1.0.0")
-	if beforeOne.Check(&checkVersion) {
+	if version.CheckConstraintAgainstAstarteVersion("< 1.0.0", astarteVersion) == nil {
 		return "3.7.21"
 	}
 
-	return latestVersion
+	return "3.8"
 }

--- a/lib/reconcile/astarte_generic_backend.go
+++ b/lib/reconcile/astarte_generic_backend.go
@@ -22,9 +22,9 @@ import (
 	"context"
 	"strconv"
 
-	semver "github.com/Masterminds/semver/v3"
 	apiv1alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/pkg/apis/api/v1alpha1"
 	"github.com/astarte-platform/astarte-kubernetes-operator/pkg/misc"
+	"github.com/astarte-platform/astarte-kubernetes-operator/version"
 	"github.com/openlyinc/pointy"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -163,11 +163,11 @@ func getAstarteGenericBackendEnvVars(deploymentName string, cr *apiv1alpha1.Asta
 	ret := getAstarteCommonEnvVars(deploymentName, cr, backend, component)
 
 	cassandraPrefix := ""
-	v := getSemanticVersionForAstarteComponent(cr, backend.Version)
-	checkVersion, _ := v.SetPrerelease("")
-	constraint, _ := semver.NewConstraint("< 1.0.0")
-	if constraint.Check(&checkVersion) {
+	if version.CheckConstraintAgainstAstarteComponentVersion("< 1.0.0", backend.Version, cr) == nil {
 		cassandraPrefix = oldAstartePrefix
+	} else {
+		// Append Cassandra connection env vars only if version >= 1.0.0
+		ret = appendCassandraConnectionEnvVars(ret, cr)
 	}
 
 	// Add Cassandra Nodes
@@ -175,11 +175,6 @@ func getAstarteGenericBackendEnvVars(deploymentName string, cr *apiv1alpha1.Asta
 		Name:  cassandraPrefix + "CASSANDRA_NODES",
 		Value: getCassandraNodes(cr),
 	})
-
-	// Append Cassandra connection env vars only if version >= 1.0.0
-	if !constraint.Check(&checkVersion) {
-		ret = appendCassandraConnectionEnvVars(ret, cr)
-	}
 
 	eventsExchangeName := cr.Spec.RabbitMQ.EventsExchangeName
 
@@ -260,11 +255,8 @@ func getAstarteDataUpdaterPlantBackendEnvVars(eventsExchangeName string, cr *api
 			})
 	}
 
-	checkVersion := getSemanticVersionForAstarteComponent(cr, backend.Version)
 	// 0.11+ variables
-	c, _ := semver.NewConstraint(">= 0.11.0")
-
-	if c.Check(checkVersion) {
+	if version.CheckConstraintAgainstAstarteComponentVersion(">= 0.11.0", backend.Version, cr) == nil {
 		dataQueueCount := getDataQueueCount(cr)
 
 		// When installing Astarte >= 0.11, add the data queue count
@@ -281,8 +273,7 @@ func getAstarteDataUpdaterPlantBackendEnvVars(eventsExchangeName string, cr *api
 			})
 
 		// 0.11.1+ variables
-		c2, _ := semver.NewConstraint(">= 0.11.1")
-		if c2.Check(checkVersion) {
+		if version.CheckConstraintAgainstAstarteComponentVersion(">= 0.11.1", backend.Version, cr) == nil {
 			ret = append(ret,
 				v1.EnvVar{
 					Name: "DATA_UPDATER_PLANT_AMQP_DATA_QUEUE_TOTAL_COUNT",
@@ -301,8 +292,7 @@ func getAstarteDataUpdaterPlantBackendEnvVars(eventsExchangeName string, cr *api
 	}
 
 	// 1.0+ variables
-	c, _ = semver.NewConstraint(">= 1.0.0")
-	if c.Check(checkVersion) {
+	if version.CheckConstraintAgainstAstarteComponentVersion(">= 1.0.0", backend.Version, cr) == nil {
 		if cr.Spec.VerneMQ.DeviceHeartbeatSeconds > 0 {
 			ret = append(ret,
 				v1.EnvVar{
@@ -321,12 +311,7 @@ func getAstarteBackendProbe(cr *apiv1alpha1.Astarte, backend apiv1alpha1.Astarte
 		return customProbe
 	}
 
-	// Parse the version first
-	v := getSemanticVersionForAstarteComponent(cr, backend.Version)
-	checkVersion, _ := v.SetPrerelease("")
-	constraint, _ := semver.NewConstraint("< 0.11.0")
-
-	if constraint.Check(&checkVersion) {
+	if version.CheckConstraintAgainstAstarteComponentVersion("< 0.11.0", backend.Version, cr) == nil {
 		// 0.10.x has no such thing.
 		return nil
 	}

--- a/lib/reconcile/cassandra.go
+++ b/lib/reconcile/cassandra.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	semver "github.com/Masterminds/semver/v3"
 	"github.com/astarte-platform/astarte-kubernetes-operator/lib/deps"
 	apiv1alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/pkg/apis/api/v1alpha1"
 	"github.com/astarte-platform/astarte-kubernetes-operator/pkg/misc"
@@ -242,8 +241,6 @@ func getCassandraEnvVars(statefulSetName string, cr *apiv1alpha1.Astarte) []v1.E
 }
 
 func getCassandraPodSpec(statefulSetName, dataVolumeName string, cr *apiv1alpha1.Astarte) v1.PodSpec {
-	astarteVersion, _ := semver.NewVersion(cr.Spec.Version)
-
 	resources := v1.ResourceRequirements{}
 	if cr.Spec.Cassandra.Resources != nil {
 		resources = *cr.Spec.Cassandra.Resources
@@ -263,7 +260,7 @@ func getCassandraPodSpec(statefulSetName, dataVolumeName string, cr *apiv1alpha1
 						MountPath: "/cassandra_data",
 					},
 				},
-				Image: getImageForClusteredResource("gcr.io/google-samples/cassandra", deps.GetDefaultVersionForCassandra(astarteVersion),
+				Image: getImageForClusteredResource("gcr.io/google-samples/cassandra", deps.GetDefaultVersionForCassandra(cr.Spec.Version),
 					cr.Spec.Cassandra.AstarteGenericClusteredResource),
 				ImagePullPolicy: getImagePullPolicy(cr),
 				Ports: []v1.ContainerPort{

--- a/lib/reconcile/rabbitmq.go
+++ b/lib/reconcile/rabbitmq.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	semver "github.com/Masterminds/semver/v3"
 	"github.com/astarte-platform/astarte-kubernetes-operator/lib/deps"
 	apiv1alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/pkg/apis/api/v1alpha1"
 	"github.com/astarte-platform/astarte-kubernetes-operator/pkg/misc"
@@ -318,7 +317,6 @@ func getRabbitMQPodSpec(statefulSetName, dataVolumeName string, cr *apiv1alpha1.
 	if pointy.BoolValue(cr.Spec.RBAC, false) {
 		serviceAccountName = ""
 	}
-	astarteVersion, _ := semver.NewVersion(cr.Spec.Version)
 
 	resources := v1.ResourceRequirements{}
 	if cr.Spec.RabbitMQ.Resources != nil {
@@ -344,7 +342,7 @@ func getRabbitMQPodSpec(statefulSetName, dataVolumeName string, cr *apiv1alpha1.
 						MountPath: "/var/lib/rabbitmq",
 					},
 				},
-				Image: getImageForClusteredResource("rabbitmq", deps.GetDefaultVersionForRabbitMQ(astarteVersion),
+				Image: getImageForClusteredResource("rabbitmq", deps.GetDefaultVersionForRabbitMQ(cr.Spec.Version),
 					cr.Spec.RabbitMQ.AstarteGenericClusteredResource),
 				ImagePullPolicy: getImagePullPolicy(cr),
 				Ports: []v1.ContainerPort{

--- a/lib/reconcile/vernemq.go
+++ b/lib/reconcile/vernemq.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	semver "github.com/Masterminds/semver/v3"
 	apiv1alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/pkg/apis/api/v1alpha1"
 	"github.com/astarte-platform/astarte-kubernetes-operator/pkg/misc"
+	"github.com/astarte-platform/astarte-kubernetes-operator/version"
 	"github.com/openlyinc/pointy"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -208,11 +208,8 @@ func getVerneMQEnvVars(statefulSetName string, cr *apiv1alpha1.Astarte) []v1.Env
 	// Also append env vars for RPC
 	envVars = appendRabbitMQConnectionEnvVars(envVars, "RPC_AMQP_CONNECTION", cr)
 
-	checkVersion := getSemanticVersionForAstarteComponent(cr, cr.Spec.VerneMQ.Version)
 	// 0.11+ variables
-	c, _ := semver.NewConstraint(">= 0.11.0")
-
-	if c.Check(checkVersion) {
+	if version.CheckConstraintAgainstAstarteComponentVersion(">= 0.11.0", cr.Spec.VerneMQ.Version, cr) == nil {
 		// When installing Astarte >= 0.11, add the data queue count
 		envVars = append(envVars, v1.EnvVar{
 			Name:  "DOCKER_VERNEMQ_ASTARTE_VMQ_PLUGIN__AMQP__DATA_QUEUE_COUNT",
@@ -221,9 +218,7 @@ func getVerneMQEnvVars(statefulSetName string, cr *apiv1alpha1.Astarte) []v1.Env
 	}
 
 	// 1.0+ variables
-	c, _ = semver.NewConstraint(">= 1.0.0")
-
-	if c.Check(checkVersion) {
+	if version.CheckConstraintAgainstAstarteComponentVersion(">= 1.0.0", cr.Spec.VerneMQ.Version, cr) == nil {
 		if cr.Spec.VerneMQ.DeviceHeartbeatSeconds > 0 {
 			envVars = append(envVars,
 				v1.EnvVar{

--- a/lib/upgrade/upgrade.go
+++ b/lib/upgrade/upgrade.go
@@ -81,9 +81,7 @@ func validateConstraintAndPrepareUpgrade(oldVersion, newVersion *semver.Version,
 		*newVersion, _ = newVersion.SetPrerelease("")
 	}
 
-	oldConstraintValidated, _ := oldConstraint.Validate(oldVersion)
-	newConstraintValidated, _ := newConstraint.Validate(newVersion)
-	if oldConstraintValidated && newConstraintValidated {
+	if oldConstraint.Check(oldVersion) && newConstraint.Check(newVersion) {
 		// Set the Reconciliation Phase to Upgrading
 		reqLogger := log.WithValues("Request.Namespace", cr.Namespace, "Request.Name", cr.Name)
 		reqLogger.Info("Upgrade found, will start Upgrade routine")
@@ -93,7 +91,9 @@ func validateConstraintAndPrepareUpgrade(oldVersion, newVersion *semver.Version,
 			reqLogger.Error(err, "Failed to update Astarte Reconciliation Phase status. Not dying for this, though")
 			// That's it - no point in failing here.
 		}
+
+		return true, nil
 	}
 
-	return oldConstraintValidated && newConstraintValidated, nil
+	return false, nil
 }

--- a/version/checks.go
+++ b/version/checks.go
@@ -1,0 +1,68 @@
+/*
+  This file is part of Astarte.
+
+  Copyright 2020 Ispirata Srl
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package version
+
+import (
+	"errors"
+
+	semver "github.com/Masterminds/semver/v3"
+	apiv1alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/pkg/apis/api/v1alpha1"
+)
+
+var (
+	// ErrConstraintNotSatisfied means the check happened correctly, but the constraint wasn't satisfied
+	ErrConstraintNotSatisfied = errors.New("constraint not satisfied")
+)
+
+// CheckConstraintAgainstAstarteVersion validates a given Astarte version against a given constraint. Returns nil if
+// the constraint is satisfied, an error otherwise
+func CheckConstraintAgainstAstarteVersion(constraint, v string) error {
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return err
+	}
+	semVer, err := GetAstarteSemanticVersionFrom(v)
+	if err != nil {
+		return err
+	}
+	*semVer, err = semVer.SetPrerelease("")
+	if err != nil {
+		return err
+	}
+
+	if !c.Check(semVer) {
+		return ErrConstraintNotSatisfied
+	}
+
+	return nil
+}
+
+// CheckConstraintAgainstAstarteComponentVersion checks a constraint against a specialized Astarte component version
+func CheckConstraintAgainstAstarteComponentVersion(constraint, v string, cr *apiv1alpha1.Astarte) error {
+	versionString := GetVersionForAstarteComponent(cr, v)
+	return CheckConstraintAgainstAstarteVersion(constraint, versionString)
+}
+
+// GetVersionForAstarteComponent returns the version for a given Astarte Component
+func GetVersionForAstarteComponent(cr *apiv1alpha1.Astarte, componentVersion string) string {
+	if componentVersion != "" {
+		return componentVersion
+	}
+	return cr.Spec.Version
+}


### PR DESCRIPTION
This cleans up the code significantly and, most of all, prevents a number of potential inconsistencies/panic situation, centralizing the semver logic in a single place and demanding the rest to a simpler and safer string API.