### PR TITLE
Bump version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2020-09-01
+
 ## [0.11.1] - 2020-05-18
 ### Added
 - Add the `DATA_UPDATER_PLANT_AMQP_DATA_QUEUE_TOTAL_COUNT` variable to support Astarte >= 0.11.1

--- a/test/e2e010/test_upgrade_0.11.go
+++ b/test/e2e010/test_upgrade_0.11.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var target011Version string = "0.11.1"
+var target011Version string = "0.11.2"
 
 func astarteUpgradeTo011Test(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
 	namespace, err := ctx.GetNamespace()

--- a/test/e2e011/test_deploy_0.11.go
+++ b/test/e2e011/test_deploy_0.11.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var target011Version string = "0.11.1"
+var target011Version string = "0.11.2"
 
 func astarteDeploy011Test(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
 	namespace, err := ctx.GetNamespace()

--- a/test/utils/astarte_resource.go
+++ b/test/utils/astarte_resource.go
@@ -33,7 +33,7 @@ var AstarteTestResource *operator.Astarte = &operator.Astarte{
 		Name: "example-astarte",
 	},
 	Spec: operator.AstarteSpec{
-		Version: "0.11.1",
+		Version: "0.11.2",
 		// Use the "Recreate" strategy. Some test environments are really constrained, and might not have enough
 		// resources to support RollingUpdate.
 		DeploymentStrategy: appsv1.DeploymentStrategy{

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ package version
 
 const (
 	// Version is the Operator's version
-	Version = "0.11.1"
+	Version = "0.11.2"
 
 	// AstarteVersionConstraintString represents the range of supported Astarte versions for this Operator.
 	// If the Astarte version falls out of this range, reconciliation will be immediately aborted.


### PR DESCRIPTION
Prepare v0.11.2 release.

Signed-off-by: Davide Bettio <davide.bettio@ispirata.com>