### PR TITLE
Fix deployment strategy

### DIFF
--- a/pkg/apis/api/v1alpha1/astarte_types.go
+++ b/pkg/apis/api/v1alpha1/astarte_types.go
@@ -390,7 +390,7 @@ type AstarteSpec struct {
 	// +optional
 	DistributionChannel string `json:"distributionChannel,omitempty"`
 	// +optional
-	DeploymentStrategy appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
+	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
 	// +optional
 	/// +kubebuilder:default=true
 	RBAC *bool `json:"rbac,omitempty"`

--- a/pkg/apis/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/api/v1alpha1/zz_generated.deepcopy.go
@@ -704,7 +704,11 @@ func (in *AstarteSpec) DeepCopyInto(out *AstarteSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
-	in.DeploymentStrategy.DeepCopyInto(&out.DeploymentStrategy)
+	if in.DeploymentStrategy != nil {
+		in, out := &in.DeploymentStrategy, &out.DeploymentStrategy
+		*out = new(appsv1.DeploymentStrategy)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.RBAC != nil {
 		in, out := &in.RBAC, &out.RBAC
 		*out = new(bool)

--- a/pkg/controller/astarte/reconcile/astarte_dashboard.go
+++ b/pkg/controller/astarte/reconcile/astarte_dashboard.go
@@ -102,7 +102,7 @@ func EnsureAstarteDashboard(cr *apiv1alpha1.Astarte, dashboard apiv1alpha1.Astar
 		Selector: &metav1.LabelSelector{
 			MatchLabels: matchLabels,
 		},
-		Strategy: getDeploymentStrategyForClusteredResource(cr, dashboard.AstarteGenericClusteredResource),
+		Strategy: getDeploymentStrategyForClusteredResource(cr, dashboard.AstarteGenericClusteredResource, apiv1alpha1.Dashboard),
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,

--- a/pkg/controller/astarte/reconcile/astarte_generic_api.go
+++ b/pkg/controller/astarte/reconcile/astarte_generic_api.go
@@ -111,7 +111,7 @@ func EnsureAstarteGenericAPIWithCustomProbe(cr *apiv1alpha1.Astarte, api apiv1al
 		Selector: &metav1.LabelSelector{
 			MatchLabels: matchLabels,
 		},
-		Strategy: getDeploymentStrategyForClusteredResource(cr, api.AstarteGenericClusteredResource),
+		Strategy: getDeploymentStrategyForClusteredResource(cr, api.AstarteGenericClusteredResource, component),
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,

--- a/pkg/controller/astarte/reconcile/astarte_generic_backend.go
+++ b/pkg/controller/astarte/reconcile/astarte_generic_backend.go
@@ -82,7 +82,7 @@ func EnsureAstarteGenericBackendWithCustomProbe(cr *apiv1alpha1.Astarte, backend
 		Selector: &metav1.LabelSelector{
 			MatchLabels: matchLabels,
 		},
-		Strategy: getDeploymentStrategyForClusteredResource(cr, backend),
+		Strategy: getDeploymentStrategyForClusteredResource(cr, backend, component),
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,

--- a/pkg/controller/astarte/reconcile/utils.go
+++ b/pkg/controller/astarte/reconcile/utils.go
@@ -390,11 +390,21 @@ func getImageForClusteredResource(defaultImageName, defaultImageTag string, reso
 	return image
 }
 
-func getDeploymentStrategyForClusteredResource(cr *apiv1alpha1.Astarte, resource apiv1alpha1.AstarteGenericClusteredResource) appsv1.DeploymentStrategy {
-	if resource.DeploymentStrategy != nil {
+func getDeploymentStrategyForClusteredResource(cr *apiv1alpha1.Astarte, resource apiv1alpha1.AstarteGenericClusteredResource, component apiv1alpha1.AstarteComponent) appsv1.DeploymentStrategy {
+	switch {
+	case resource.DeploymentStrategy != nil:
 		return *resource.DeploymentStrategy
+	case cr.Spec.DeploymentStrategy != nil:
+		return *cr.Spec.DeploymentStrategy
+	case component == apiv1alpha1.DataUpdaterPlant:
+		return appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		}
+	default:
+		return appsv1.DeploymentStrategy{
+			Type: appsv1.RollingUpdateDeploymentStrategyType,
+		}
 	}
-	return cr.Spec.DeploymentStrategy
 }
 
 func getDataQueueCount(cr *apiv1alpha1.Astarte) int {

--- a/test/utils/astarte_resource.go
+++ b/test/utils/astarte_resource.go
@@ -36,7 +36,7 @@ var AstarteTestResource *operator.Astarte = &operator.Astarte{
 		Version: "0.11.2",
 		// Use the "Recreate" strategy. Some test environments are really constrained, and might not have enough
 		// resources to support RollingUpdate.
-		DeploymentStrategy: appsv1.DeploymentStrategy{
+		DeploymentStrategy: &appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
 		},
 		API: operator.AstarteAPISpec{


### PR DESCRIPTION
The default deployment strategy for DUP is "Recreate": it prevents
the consumption of messages from the same queue, thus avoiding
out of order message processing and properties inconsistencies.
Fix #152 