### PR TITLE
Flow: fix deployment strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added a Helm chart for deploying the Operator
 
 ### Changed
+- Default Flow's deployment strategy to Recreate
 - Astarte Operator SDK now uses Kubebuilder as the base project structure
 - Update RabbitMQ version to 3.8.x for 1.0.x releases
 - Starting with Astarte 1.0.0, CFSSL by default doesn't use a Database instead of using SQLite.

--- a/lib/reconcile/utils.go
+++ b/lib/reconcile/utils.go
@@ -624,7 +624,8 @@ func getDeploymentStrategyForClusteredResource(cr *apiv1alpha1.Astarte, resource
 		return *resource.DeploymentStrategy
 	case cr.Spec.DeploymentStrategy != nil:
 		return *cr.Spec.DeploymentStrategy
-	case component == apiv1alpha1.DataUpdaterPlant, component == apiv1alpha1.TriggerEngine:
+	case component == apiv1alpha1.DataUpdaterPlant, component == apiv1alpha1.TriggerEngine,
+		component == apiv1alpha1.FlowComponent:
 		return appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
 		}


### PR DESCRIPTION
The default deployment strategy for Flow is Recreate. This PR addresses an issue similar to the one described in #152.