### PR TITLE
Deployment strategy for DUP and TE is forced to Recreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.4] - Unreleased
+### Changed
+- Force deployment strategy to Recreate for DUP and TE, overriding user preferences
+
 ## [0.11.3] - 2020-09-24
 ### Changed
 - Default Trigger Engine's deployment strategy to Recreate

--- a/pkg/controller/astarte/reconcile/utils.go
+++ b/pkg/controller/astarte/reconcile/utils.go
@@ -392,14 +392,14 @@ func getImageForClusteredResource(defaultImageName, defaultImageTag string, reso
 
 func getDeploymentStrategyForClusteredResource(cr *apiv1alpha1.Astarte, resource apiv1alpha1.AstarteGenericClusteredResource, component apiv1alpha1.AstarteComponent) appsv1.DeploymentStrategy {
 	switch {
-	case resource.DeploymentStrategy != nil:
-		return *resource.DeploymentStrategy
-	case cr.Spec.DeploymentStrategy != nil:
-		return *cr.Spec.DeploymentStrategy
 	case component == apiv1alpha1.DataUpdaterPlant, component == apiv1alpha1.TriggerEngine:
 		return appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
 		}
+	case resource.DeploymentStrategy != nil:
+		return *resource.DeploymentStrategy
+	case cr.Spec.DeploymentStrategy != nil:
+		return *cr.Spec.DeploymentStrategy
 	default:
 		return appsv1.DeploymentStrategy{
 			Type: appsv1.RollingUpdateDeploymentStrategyType,


### PR DESCRIPTION
Both DUP and TE must be deployed with deployment strategy set to Recreate: therefore, override user preferences and force the desired strategy.