### PR TITLE
Update setup-kind Github action

### DIFF
--- a/.github/workflows/old-operator.yaml
+++ b/.github/workflows/old-operator.yaml
@@ -30,7 +30,7 @@ jobs:
       with:
         # Ensure we're on Go 1.13
         go-version: '1.13.x'
-    - uses: engineerd/setup-kind@v0.3.0
+    - uses: engineerd/setup-kind@v0.5.0
       with:
         version: "v0.7.0"
         image: "kindest/node:v1.16.4@sha256:b91a2c2317a000f3a783489dfb755064177dbc3a0b2f4147d50f04825d016f55"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
       with:
         # Ensure we're on Go 1.13
         go-version: '1.13.x'
-    - uses: engineerd/setup-kind@v0.3.0
+    - uses: engineerd/setup-kind@v0.5.0
       with:
         version: "v0.7.0"
         image: "${{ matrix.kubernetesNodeImage }}"


### PR DESCRIPTION
Bump setup-kind version as it previously used commands that are now
deprecated. See:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/