### PR TITLE
Fix HTTP-01 challenge failure

### DIFF
--- a/pkg/controller/astartevoyageringress/api_ingress.go
+++ b/pkg/controller/astartevoyageringress/api_ingress.go
@@ -186,6 +186,31 @@ func ensureAPIIngress(cr *apiv1alpha1.AstarteVoyagerIngress, parent *apiv1alpha1
 		})
 	}
 
+	if pointy.BoolValue(cr.Spec.Letsencrypt.Use, true) &&
+		(cr.Spec.Letsencrypt.ChallengeProvider.HTTP != nil || pointy.BoolValue(cr.Spec.Letsencrypt.AutoHTTPChallenge, false)) {
+		// The Voyager operator will try to add this rule if the HTTP challenge is enabled, so we
+		// must add it too on our side, otherwise the two operators will fight over the state of the
+		// ingress, resulting in the failure of the HTTP-01 challenge.
+		rules = append(rules, voyager.IngressRule{
+			IngressRuleValue: voyager.IngressRuleValue{
+				HTTP: &voyager.HTTPIngressRuleValue{
+					NoTLS: true,
+					Paths: []voyager.HTTPIngressPath{
+						voyager.HTTPIngressPath{
+							Path: "/.well-known/acme-challenge/",
+							Backend: voyager.HTTPIngressBackend{
+								IngressBackend: voyager.IngressBackend{
+									ServiceName: "voyager-operator.kube-system",
+									ServicePort: intstr.FromInt(56791),
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+	}
+
 	ingressSpec.Rules = rules
 
 	// Reconcile the Ingress

--- a/pkg/controller/astartevoyageringress/broker_ingress.go
+++ b/pkg/controller/astartevoyageringress/broker_ingress.go
@@ -131,8 +131,9 @@ func ensureBrokerIngress(cr *apiv1alpha1.AstarteVoyagerIngress, parent *apiv1alp
 
 	if pointy.BoolValue(cr.Spec.Letsencrypt.Use, true) &&
 		(cr.Spec.Letsencrypt.ChallengeProvider.HTTP != nil || pointy.BoolValue(cr.Spec.Letsencrypt.AutoHTTPChallenge, false)) {
-		// In this case, we need to add another special rule to instruct the Load Balancer to keep port 80
-		// open and routed. Doing this, we can ensure the HTTP-01 challenge will succeed.
+		// The Voyager operator will try to add this rule if the HTTP challenge is enabled, so we
+		// must add it too on our side, otherwise the two operators will fight over the state of the
+		// ingress, resulting in the failure of the HTTP-01 challenge.
 		rules = append(rules, voyager.IngressRule{
 			IngressRuleValue: voyager.IngressRuleValue{
 				HTTP: &voyager.HTTPIngressRuleValue{


### PR DESCRIPTION
The Astarte Operator and the Voyager Operator had conflicting target states,
resulting often in failures during certificate emission and/or renewal when
using HTTP-01 challenge. This should fix the issue on the Astarte Operator side,
even if it seems there's still some issues for HTTP-01 certificate renewal in
Voyager 12.0 (see https://github.com/voyagermesh/voyager/pull/1531 and
https://github.com/voyagermesh/voyager/pull/1535).

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>