### PR TITLE
vernemq: fix data queue count environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Force deployment strategy to Recreate for DUP and TE, overriding user preferences
 
+### Fixed
+- Fix data queue count environment variable mapping in VerneMQ
+
 ## [0.11.3] - 2020-09-24
 ### Changed
 - Default Trigger Engine's deployment strategy to Recreate

--- a/pkg/controller/astarte/reconcile/vernemq.go
+++ b/pkg/controller/astarte/reconcile/vernemq.go
@@ -224,7 +224,7 @@ func getVerneMQEnvVars(statefulSetName string, cr *apiv1alpha1.Astarte) []v1.Env
 	if c.Check(&checkVersion) {
 		// When installing Astarte >= 0.11, add the data queue count
 		envVars = append(envVars, v1.EnvVar{
-			Name:  "DOCKER_VERNEMQ_ASTARTE_VMQ_PLUGIN__AMQP__DATA_QUEUE_COUNT",
+			Name:  "DOCKER_VERNEMQ_ASTARTE_VMQ_PLUGIN__DATA_QUEUE_COUNT",
 			Value: strconv.Itoa(dataQueueCount),
 		})
 	}


### PR DESCRIPTION
The application env is named astarte_vmq_plugin.data_queue_count, not
astarte_vmq_plugin.amqp.data_queue_count (see
https://github.com/astarte-platform/astarte_vmq_plugin/blob/master/priv/astarte_vmq_plugin.schema#L66)

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>