### PR TITLE
vernemq: allow using the mirror queue feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Force deployment strategy to Recreate for DUP and TE, overriding user preferences
 
+### Added
+- Allow using the mirror queue functionality in the VerneMQ plugin. Note that this is not a stable
+  API and it will be removed in future versions of Astarte, since it is superseeded by AMQP
+  Triggers.
+
 ## [0.11.3] - 2020-09-24
 ### Changed
 - Default Trigger Engine's deployment strategy to Recreate

--- a/deploy/crds/api.astarte-platform.org_astartes_crd.yaml
+++ b/deploy/crds/api.astarte-platform.org_astartes_crd.yaml
@@ -13442,6 +13442,8 @@ spec:
                   type: string
                 image:
                   type: string
+                mirrorQueue:
+                  type: string
                 port:
                   type: integer
                 replicas:

--- a/pkg/apis/api/v1alpha1/astarte_types.go
+++ b/pkg/apis/api/v1alpha1/astarte_types.go
@@ -229,6 +229,8 @@ type AstarteVerneMQSpec struct {
 	CaSecret string `json:"caSecret,omitempty"`
 	// +optional
 	Storage *AstartePersistentStorageSpec `json:"storage,omitempty"`
+	// +optional
+	MirrorQueue string `json:"mirrorQueue,omitempty"`
 }
 
 type AstarteGenericComponentSpec struct {

--- a/pkg/controller/astarte/reconcile/vernemq.go
+++ b/pkg/controller/astarte/reconcile/vernemq.go
@@ -179,6 +179,7 @@ func getVerneMQEnvVars(statefulSetName string, cr *apiv1alpha1.Astarte) []v1.Env
 	userCredentialsSecretName, userCredentialsSecretUsernameKey, userCredentialsSecretPasswordKey := misc.GetRabbitMQUserCredentialsSecret(cr)
 	rabbitMQHost, _ := misc.GetRabbitMQHostnameAndPort(cr)
 	dataQueueCount := getDataQueueCount(cr)
+	mirrorQueue := getMirrorQueue(cr)
 
 	envVars := []v1.EnvVar{
 		v1.EnvVar{
@@ -226,6 +227,14 @@ func getVerneMQEnvVars(statefulSetName string, cr *apiv1alpha1.Astarte) []v1.Env
 		envVars = append(envVars, v1.EnvVar{
 			Name:  "DOCKER_VERNEMQ_ASTARTE_VMQ_PLUGIN__AMQP__DATA_QUEUE_COUNT",
 			Value: strconv.Itoa(dataQueueCount),
+		})
+	}
+
+	if mirrorQueue != "" {
+		// If a mirror queue is defined, set the relevant environment variable
+		envVars = append(envVars, v1.EnvVar{
+			Name:  "DOCKER_VERNEMQ_ASTARTE_VMQ_PLUGIN__AMQP__MIRROR_QUEUE_NAME",
+			Value: mirrorQueue,
 		})
 	}
 
@@ -298,4 +307,8 @@ func getVerneMQPolicyRules() []rbacv1.PolicyRule {
 			Verbs:     []string{"list", "get"},
 		},
 	}
+}
+
+func getMirrorQueue(cr *apiv1alpha1.Astarte) string {
+	return cr.Spec.VerneMQ.MirrorQueue
 }


### PR DESCRIPTION
Shovel all data in a secondary queue, while also sending it to the usual data
queues. This is a temporary workaround until Astarte 1.0, which will handle this
with AMQP triggers.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>