### PR TITLE
examples: wrap CPU quotas in single quotes

### DIFF
--- a/deploy/examples/api_v1alpha1_astarte_cr_minimal.yaml
+++ b/deploy/examples/api_v1alpha1_astarte_cr_minimal.yaml
@@ -15,7 +15,7 @@ spec:
         cpu: 300m
         memory: 512M
       limits:
-        cpu: 1
+        cpu: '1'
         memory: 1000M
   cassandra:
     maxHeapSize: 1024M
@@ -24,10 +24,10 @@ spec:
       size: 30Gi
     resources:
       requests:
-        cpu: 1
+        cpu: '1'
         memory: 1024M
       limits:
-        cpu: 2
+        cpu: '2'
         memory: 2048M
   vernemq:
     host: "broker.astarte-example.com"


### PR DESCRIPTION
Otherwise yaml interprets them as integers and CR installation fails

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>