### PR TITLE
block: allow container blocks to run as root

### DIFF
--- a/lib/flow/block.go
+++ b/lib/flow/block.go
@@ -197,9 +197,10 @@ func ensureWorkerContainer(block commontypes.ContainerBlockSpec, worker commonty
 		// Flow Containers are a good way to snitch malicious code into the Cluster, and potentially allowing
 		// Container breakout to the node. For this reason, do not trust this container and downscale its privileges
 		// to the bottom.
+		// TODO: handle RunAsNonRoot as a feature flag
 		SecurityContext: &v1.SecurityContext{
 			Privileged:               pointy.Bool(false),
-			RunAsNonRoot:             pointy.Bool(true),
+			RunAsNonRoot:             pointy.Bool(false),
 			AllowPrivilegeEscalation: pointy.Bool(false),
 			ReadOnlyRootFilesystem:   pointy.Bool(true),
 		},


### PR DESCRIPTION
Some users might need root access to perform operations in their containers. We
should allow to change this with a feature flag in the future.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>