### PR TITLE
Tear down CFSSL StatefulSet when upgrading Astarte 0.11 -> 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.0-beta.2] - Unreleased
 ### Changed
 - Updated Operator SDK to 1.4.2
+- Remove the dangling CFSSL statefulset while upgrading Astarte from v0.11 to v1.0.
 
 ### Added
 - Add `additionalEnv` field to `AstarteGenericClusteredResource`, allowing to pass custom

--- a/lib/upgrade/0.11_to_1.0.go
+++ b/lib/upgrade/0.11_to_1.0.go
@@ -69,6 +69,11 @@ func upgradeTo10(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Schem
 		return err
 	}
 
+	// Step 4: Remove CFSSL StatefulSet
+	if err := tearDownCFSSLStatefulSet(cr, c, recorder); err != nil {
+		return err
+	}
+
 	reqLogger.Info("Your Astarte cluster has been successfully upgraded to the 1.0.x series!")
 
 	// This is it. Do not bring up VerneMQ or anything: the reconciliation will now do the right thing with the right versions.


### PR DESCRIPTION
Starting from 1.0, CFSSL is a deployment. Therefore when upgrading Astarte 0.11 --> 1.0 remove the dangling statefulset.
Fix #149 