### PR TITLE
CI: Update KinD action and push operator's container to local KinD registry

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -44,10 +44,19 @@ jobs:
         if [[ -n "$changed" ]]; then
           echo "::set-output name=changed::true"
         fi
-    - uses: engineerd/setup-kind@v0.5.0
+    - uses: container-tools/kind-action@v1
       with:
         version: "v0.8.1"
-        image: "kindest/node:v1.18.2@sha256:7b27a6d0f2517ff88ba444025beae41491b016bc6af573ba467b70c5e8e0d85f"
+        node_image: "kindest/node:v1.18.2@sha256:7b27a6d0f2517ff88ba444025beae41491b016bc6af573ba467b70c5e8e0d85f"
+    - name: Build test image
+      run: |
+        docker build -t astarte-operator-ci:test -f Dockerfile .
+    - name: Tag test image
+      run: |
+        docker tag astarte-operator-ci:test kind-registry:5000/astarte-operator-ci:test
+    - name: Push test image to local registry
+      run: |
+        docker push kind-registry:5000/astarte-operator-ci:test
     - name: Ensure KinD is up
       run: |
         kubectl cluster-info
@@ -70,7 +79,7 @@ jobs:
         time: '20s'
     - name: Install Helm Chart
       run: |
-        helm install astarte-operator ./charts/astarte-operator
+        helm install astarte-operator ./charts/astarte-operator --set image.repository=kind-registry:5000/astarte-operator-ci --set image.tag=test
     - name: Sleep for 20 seconds (wait for Astarte Operator to come up)
       uses: jakejarvis/wait-action@master
       with:

--- a/.github/workflows/old-operator.yaml
+++ b/.github/workflows/old-operator.yaml
@@ -36,10 +36,10 @@ jobs:
         kustomize: 3.5.5
         helm: 2.16.7
         helmv3: 3.2.1
-    - uses: engineerd/setup-kind@v0.5.0
+    - uses: container-tools/kind-action@v1
       with:
         version: "v0.8.1"
-        image: "kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765"
+        node_image: "kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765"
     # Download Operator SDK binary
     - name: Download Operator SDK
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,10 +47,10 @@ jobs:
         kustomize: 3.5.5
         helm: 2.16.7
         helmv3: 3.2.1
-    - uses: engineerd/setup-kind@v0.5.0
+    - uses: container-tools/kind-action@v1
       with:
         version: "v0.8.1"
-        image: "${{ matrix.kubernetesNodeImage }}"
+        node_image: "${{ matrix.kubernetesNodeImage }}"
     - name: Ensure KinD is up
       run: |
         kubectl cluster-info


### PR DESCRIPTION
+ Use `container-tools/kind-action@v1` instead of `engineerd/setup-kind@v0.5.0`: the new action allows to exploit a local registry within the KinD cluster
+ When testing the helm chart installation, build and push the operator's container to the KinD local registry. This solution allows to test the latest docker image without the need of pushing to a remote registry.