### PR TITLE
CI: install the chart with `helm install` instead of `ct install`

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -71,12 +71,6 @@ jobs:
       uses: jakejarvis/wait-action@master
       with:
         time: '20s'
-    - name: Run chart-testing (install)
-      run: ct install
-    - name: Sleep for 20 seconds (wait for Helm to clean up releases)
-      uses: jakejarvis/wait-action@master
-      with:
-        time: '20s'
     - name: Install Helm Chart
       run: |
         helm install astarte-operator ./charts/astarte-operator --set image.repository=kind-registry:5000/astarte-operator-ci --set image.tag=test


### PR DESCRIPTION
The testing of the chart requires that the operator's container can be
retrieved from a local KinD registry. Thus, use the `helm install`
command along with the `--set` flag to pull the right image.
Therefore `ct install` command is discarded.

Signed-off-by: Mattia Mazzucato <matt.mazzucato@gmail.com>