### PR TITLE
Deploy flow if explicitly requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fixed a regression in 1.0 causing CPU requests for components to go to 0
 
+### Changed
+- Deploy Flow only if explicitly requested. If you have an existing deployment, set `deploy: true`
+  in the flow component before upgrading if you want to keep it deployed.
+
 ## [1.0.0-beta.2] - 2021-03-26
 ### Changed
 - Updated Operator SDK to 1.4.2

--- a/lib/reconcile/astarte_generic_api.go
+++ b/lib/reconcile/astarte_generic_api.go
@@ -120,7 +120,13 @@ func EnsureAstarteGenericAPIWithCustomProbe(cr *apiv1alpha1.Astarte, api commont
 
 func checkShouldDeployAPI(reqLogger logr.Logger, deploymentName string, cr *apiv1alpha1.Astarte, api commontypes.AstarteGenericAPISpec,
 	component commontypes.AstarteComponent, c client.Client) bool {
-	if !pointy.BoolValue(api.Deploy, true) {
+	defaultDeployValue := true
+	// Flow should be deployed only if explicitly requested
+	if component == commontypes.FlowComponent {
+		defaultDeployValue = false
+	}
+
+	if !pointy.BoolValue(api.Deploy, defaultDeployValue) {
 		reqLogger.V(1).Info("Skipping Astarte Component Deployment")
 		// Before returning - check if we shall clean up the Deployment.
 		// It is the only thing actually requiring resources, the rest will be cleaned up eventually when the

--- a/test/utils/astarte_resource.go
+++ b/test/utils/astarte_resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/astarte-platform/astarte-kubernetes-operator/apis/api/commontypes"
 	operator "github.com/astarte-platform/astarte-kubernetes-operator/apis/api/v1alpha1"
 
+	"github.com/openlyinc/pointy"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -123,7 +124,8 @@ var AstarteTestResource *operator.Astarte = &operator.Astarte{
 			// on a regular basis
 			Flow: commontypes.AstarteGenericAPISpec{
 				AstarteGenericClusteredResource: commontypes.AstarteGenericClusteredResource{
-					Image: "astarte/astarte_flow:snapshot",
+					Deploy: pointy.Bool(true),
+					Image:  "astarte/astarte_flow:snapshot",
 					Resources: &v1.ResourceRequirements{
 						Limits: v1.ResourceList{
 							v1.ResourceCPU:    *resource.NewScaledQuantity(0, resource.Milli),


### PR DESCRIPTION
Fix the default behavior when deploying a new Astarte instance: Flow must be deployed only if explicitly requested.