### PR TITLE
Handle additionalEnv also in Cassandra, RabbitMQ and VerneMQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `additionalEnv` field to `AstarteGenericClusteredResource`, allowing to pass custom
   environment variables to all Astarte components.
 - Add Astarte and AVI (v1plha2) custom resource samples.
+- Add support to `additionalEnv` also to Cassandra, RabbitMQ and VerneMQ.
 
 ## [1.0.0-beta.1] - 2021-02-16
 ### Added

--- a/lib/reconcile/cassandra.go
+++ b/lib/reconcile/cassandra.go
@@ -239,6 +239,11 @@ func getCassandraEnvVars(statefulSetName string, cr *apiv1alpha1.Astarte) []v1.E
 		},
 	}
 
+	// Add any explicit additional env
+	if len(cr.Spec.Cassandra.AdditionalEnv) > 0 {
+		envVars = append(envVars, cr.Spec.Cassandra.AdditionalEnv...)
+	}
+
 	return envVars
 }
 

--- a/lib/reconcile/rabbitmq.go
+++ b/lib/reconcile/rabbitmq.go
@@ -273,7 +273,7 @@ func getRabbitMQReadinessProbe() *v1.Probe {
 func getRabbitMQEnvVars(statefulSetName string, cr *apiv1alpha1.Astarte) []v1.EnvVar {
 	userCredentialsSecretName, userCredentialsSecretUsernameKey, userCredentialsSecretPasswordKey := misc.GetRabbitMQUserCredentialsSecret(cr)
 
-	return []v1.EnvVar{
+	ret := []v1.EnvVar{
 		{
 			Name:  "RABBITMQ_USE_LONGNAME",
 			Value: strconv.FormatBool(true),
@@ -312,6 +312,13 @@ func getRabbitMQEnvVars(statefulSetName string, cr *apiv1alpha1.Astarte) []v1.En
 			}},
 		},
 	}
+
+	// Add any explicit additional env
+	if len(cr.Spec.RabbitMQ.AdditionalEnv) > 0 {
+		ret = append(ret, cr.Spec.RabbitMQ.AdditionalEnv...)
+	}
+
+	return ret
 }
 
 func getRabbitMQPodSpec(statefulSetName, dataVolumeName string, cr *apiv1alpha1.Astarte) v1.PodSpec {

--- a/lib/reconcile/vernemq.go
+++ b/lib/reconcile/vernemq.go
@@ -254,6 +254,11 @@ func getVerneMQEnvVars(statefulSetName string, cr *apiv1alpha1.Astarte) []v1.Env
 			})
 	}
 
+	// Add any explicit additional env
+	if len(cr.Spec.VerneMQ.AdditionalEnv) > 0 {
+		envVars = append(envVars, cr.Spec.VerneMQ.AdditionalEnv...)
+	}
+
 	return envVars
 }
 


### PR DESCRIPTION
Actually use the provided extra environment variables

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>