### PR TITLE
Fix cluster health computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Deploy Flow only if explicitly requested. If you have an existing deployment, set `deploy: true`
   in the flow component before upgrading if you want to keep it deployed.
+- When computing the cluster health, neglect all the Astarte components which are not to be deployed
+  (i.e. replicas is set to 0 or deploy is false).
 
 ## [1.0.0-beta.2] - 2021-03-26
 ### Changed

--- a/lib/controllerutils/astarte_controller.go
+++ b/lib/controllerutils/astarte_controller.go
@@ -106,7 +106,7 @@ func (r *ReconcileHelper) ComputeClusterHealth(reqLogger logr.Logger, instance *
 	if err := r.Client.List(context.TODO(), astarteDeployments, client.InNamespace(instance.Namespace),
 		client.MatchingLabels{"component": "astarte"}); err == nil {
 		for _, deployment := range astarteDeployments.Items {
-			if deployment.Status.ReadyReplicas == 0 {
+			if deployment.Status.ReadyReplicas == 0 && pointy.Int32Value(deployment.Spec.Replicas, 0) > 0 {
 				nonReadyDeployments++
 			}
 		}


### PR DESCRIPTION
While computing the cluster health, do not account for components which
are not to be deployed (e.g. replicas is 0 or deploy is false)

Signed-off-by: Mattia Mazzucato <matt.mazzucato@gmail.com>