### PR TITLE
Update RabbitMQ default version to 3.8.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   in the flow component before upgrading if you want to keep it deployed.
 - When computing the cluster health, neglect all the Astarte components which are not to be deployed
   (i.e. replicas is set to 0 or deploy is false).
+- Update rabbitmq to 3.8.16.
 
 ## [1.0.0-beta.2] - 2021-03-26
 ### Changed

--- a/lib/deps/dependencies_versions.go
+++ b/lib/deps/dependencies_versions.go
@@ -50,5 +50,5 @@ func GetDefaultVersionForRabbitMQ(astarteVersion string) string {
 		return "3.7.21"
 	}
 
-	return "3.8.14"
+	return "3.8.16"
 }


### PR DESCRIPTION
The default version of RabbitMQ is 3.8.16 for Astarte >= v1.0.0.