### PR TITLE
Fix dashboard configmap when Flow isn't deployed

### DIFF
--- a/lib/misc/utils.go
+++ b/lib/misc/utils.go
@@ -338,7 +338,7 @@ func IsAstarteComponentDeployed(cr *apiv1alpha1.Astarte, component commontypes.A
 	case commontypes.DataUpdaterPlant:
 		return pointy.BoolValue(cr.Spec.Components.DataUpdaterPlant.Deploy, true)
 	case commontypes.FlowComponent:
-		return pointy.BoolValue(cr.Spec.Components.Flow.Deploy, true)
+		return pointy.BoolValue(cr.Spec.Components.Flow.Deploy, false)
 	case commontypes.Housekeeping:
 		return pointy.BoolValue(cr.Spec.Components.Housekeeping.Backend.Deploy, true)
 	case commontypes.HousekeepingAPI:


### PR DESCRIPTION
If Flow is not explicitly deployed the Dashboard configmap should not
check for Flow's health. Fix this by changing the default in
`IsAstarteComponentDeployed` for Flow.

Fix #218 