### PR TITLE
Fix v0.11 --> v1.0 upgrade script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - Unreleased
+### Changed
+- Fix bug that prevent OSX users to upgrade from v0.11 to v1.0 (now the upgrade procedure requires
+  `gawk`)
+
 ## [1.0.0-rc.0] - 2021-05-10
 ### Fixed
 - Fixed a regression in 1.0 causing CPU requests for components to go to 0

--- a/hack/upgrade-operator-011-10.sh
+++ b/hack/upgrade-operator-011-10.sh
@@ -17,13 +17,13 @@ function update_resources() {
     # crds.yaml contains all the CRDs defined by Astarte Operator in a single file.
     # Split each Custom Resource Definition and redirect it to a dedicated file whose name
     # is formatted as crd_n.yaml.
-    awk '/^# Source:/{n++}{print > "crd_" n ".yaml"}' crds.yaml
+    gawk '/^# Source:/{n++}{print > "crd_" n ".yaml"}' crds.yaml
 
     # Check which CRD is defined within each crd_n.yaml file and rename the file accordingly
     # e.g.: if crd_1.yaml implements the Astarte CRD, rename it as crd_astarte.yaml
-    mv $(grep 'singular: astarte$' ./crd_* | awk '{print $1;}' | cut -f 1 -d ":") crd_astarte.yaml
-    mv $(grep 'singular: astartevoyageringress$' ./crd_* | awk '{print $1;}' | cut -f 1 -d ":") crd_astartevoyageringress.yaml
-    mv $(grep 'singular: flow$' ./crd_* | awk '{print $1;}' | cut -f 1 -d ":") crd_flow.yaml
+    mv $(grep 'singular: astarte$' ./crd_* | gawk '{print $1;}' | cut -f 1 -d ":") crd_astarte.yaml
+    mv $(grep 'singular: astartevoyageringress$' ./crd_* | gawk '{print $1;}' | cut -f 1 -d ":") crd_astartevoyageringress.yaml
+    mv $(grep 'singular: flow$' ./crd_* | gawk '{print $1;}' | cut -f 1 -d ":") crd_flow.yaml
 
     kubectl replace -f crd_astarte.yaml
     kubectl replace -f crd_astartevoyageringress.yaml


### PR DESCRIPTION
Using `awk` breaks the upgrade procedure for OSX users. Replace it with `gawk`.