### PR TITLE
Let Astarte controller delete collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add AstarteDefaultIngress type.
 - Add validating and mutating webhooks for AstarteDefaultIngress.
 
+### Fixed
+- Fix bug that prevented the Astarte controller from deleting collections of deployments.
+
 ## [1.0.0] - 2021-07-01
 ### Changed
 - Fix bug that prevent OSX users to upgrade from v0.11 to v1.0 (now the upgrade procedure requires

--- a/charts/astarte-operator/templates/rbac.yaml
+++ b/charts/astarte-operator/templates/rbac.yaml
@@ -122,6 +122,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -82,6 +82,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/controllers/api/astarte_controller.go
+++ b/controllers/api/astarte_controller.go
@@ -52,7 +52,7 @@ type AstarteReconciler struct {
 // +kubebuilder:rbac:groups=api.astarte-platform.org,resources=astartes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=api.astarte-platform.org,resources=astartes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=apps,resourceNames=astarte-operator,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
Now the operator can delete collections of deployments. This is particularly relevant when scaling down the number of replicas for DUP.