### PR TITLE
 Make Helm sync GH workflow add Helm Chart docs, too

### DIFF
--- a/.github/workflows/helm-sync.yaml
+++ b/.github/workflows/helm-sync.yaml
@@ -62,6 +62,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: operator
+    # Setup Go for helm-docs (ubuntu-20.04 defaults to go 1.15)
+    # see https://github.com/actions/virtual-environments/issues/2447
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17.x'
     # Checkout the Helm repository
     - uses: actions/checkout@v2
       with:
@@ -69,6 +75,9 @@ jobs:
         path: helm
         ref: "${{ github.ref }}"
         token: "${{ secrets.CR_TOKEN }}"
+    - name: Generate Chart README.md
+      run: make chart-docs
+      working-directory: ./operator
     - name: Copy all charts
       run: |
         cp -r operator/charts/* helm/charts

--- a/charts/astarte-operator/Chart.yaml
+++ b/charts/astarte-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: astarte-operator
-description: A Helm chart for Kubernetes
+description: The Astarte Kubernetes Operator Helm Chart.
 type: application
 
 version: 1.1.0-dev.0

--- a/charts/astarte-operator/values.yaml
+++ b/charts/astarte-operator/values.yaml
@@ -2,16 +2,19 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- The number of Astarte Operator replicas in your cluster.
 replicaCount: 1
 
+# -- Whether or not to install Astarte CRDs.
 installCRDs: true
 
 image:
   repository: astarte/astarte-kubernetes-operator
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # -- Overrides the image tag whose default is the chart appVersion.
   tag: "1.1.0-dev"
 
+# -- Resources to assign to each Astarte Operator instance.
 resources:
   limits:
     cpu: 100m

--- a/docs/autogen/templates/helm-chart/README.md.gotmpl
+++ b/docs/autogen/templates/helm-chart/README.md.gotmpl
@@ -1,0 +1,21 @@
+{{ template "chart.header" . }}
+[astarte-operator](https://github.com/astarte-platform/astarte-kubernetes-operator) Astarte Kubernetes Operator.
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+This chart bootstraps an Astarte Operator deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+See the [Astarte Documentation](https://docs.astarte-platform.org/) for more information about the Astarte platform.
+
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}
+
+This document was generated from sources using [helm-docs](https://github.com/norwoodj/helm-docs).


### PR DESCRIPTION
The Helm Chart did not include a README.md file. Add Helm Chart docs generation from sources using [helm-docs](https://github.com/norwoodj/helm-docs) in the Helm sync workflow.