### PR TITLE
Fix CRD docs GH workflow event filter

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -8,7 +8,7 @@ on:
     # APIs
     - 'apis/**'
     # The workflow itself
-    - '.github/workflows/generate-api-reference-docs.yaml'
+    - '.github/workflows/generate-docs.yaml'
     branches:
     # Create the snapshot only when it matters
     - 'master'


### PR DESCRIPTION
An outdated path was preventing the workflow to run when its YAML file was updated.
