### PR TITLE
Bump Hugo version in CRD docs GH workflow

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v2
       with:
-        hugo-version: '0.92.2'
+        hugo-version: '0.94.1'
         extended: true
     # Checkout the hugo-book theme
     - name: Checkout hugo-book


### PR DESCRIPTION
Move Hugo from v0.92.2 to v0.94.1, in order to render output correctly.
