### PR TITLE
Let the ADI controller watch Astarte resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgrade OperatorSDK to v1.17.0.
 - Upgrade go to v1.17.
 - Remove common types. Automate CRD conversion functions generation.
+- Reconcile AstarteDefaultIngress when the Astarte CR changes.
 
 ### Added
 - Add API reference docs generation.


### PR DESCRIPTION
Changes in the astarte CR might trigger changes to the ADI CR (e.g. when
the vernemq port is changed). Thus, let the ADI controller watch
Astarte. In this way the ADI reconciliation is triggered as soon as
Astarte is updated.