### PR TITLE
Update ci and README

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,9 +31,10 @@ jobs:
         - "011"
         - "10"
         kubernetesNodeImage:
-        - "kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729"
-        - "kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
-        - "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
+        - "kindest/node:v1.20.15@sha256:393bb9096c6c4d723bb17bceb0896407d7db581532d11ea2839c80b28e5d8deb"
+        - "kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c"
+        - "kindest/node:v1.22.7@sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166"
+        - "kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
       fail-fast: false
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.3] - Unreleased
+### Changed
+- Add Kubernetes 1.22 and 1.23 to the supported list. Remove tests for Kubernetes 1.19.
 
 ## [1.0.2] - 2022-04-01
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Astarte Kubernetes Operator
 
-![CI](https://github.com/astarte-platform/astarte-kubernetes-operator/workflows/Operator%20e2e%20tests/badge.svg?branch=release-0.11)
+![CI](https://github.com/astarte-platform/astarte-kubernetes-operator/workflows/Operator%20e2e%20tests/badge.svg?branch=release-1.0)
 [![Go Report Card](https://goreportcard.com/badge/github.com/astarte-platform/astarte-kubernetes-operator)](https://goreportcard.com/report/github.com/astarte-platform/astarte-kubernetes-operator)
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 ![Docker Pulls](https://img.shields.io/docker/pulls/astarte/astarte-kubernetes-operator)

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ and how to use it once installed in the
 The preferred way to install and manage Astarte Operator leverages its [Helm
 chart](https://artifacthub.io/packages/helm/astarte/astarte-operator).
 
-Astarte Operator requires [`cert-manager`](https://cert-manager.io/) (`>= v1.1`) to be installed in the
-cluster in its default configuration. If you are using `cert-manager` in your cluster already you
-don't need to take any action - otherwise, you will need to install it. A complete overview on
+Astarte Operator requires [`cert-manager`](https://cert-manager.io/) (`v1.7+`) to be installed in
+the cluster in its default configuration. If you are using `cert-manager` in your cluster already
+you don't need to take any action - otherwise, you will need to install it. A complete overview on
 prerequisites can be found
 [here](https://docs.astarte-platform.org/1.0/020-prerequisites.html#content).
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ kubectl create namespace cert-manager
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.1.0 \
+  --version v1.7.0 \
   --set installCRDs=true
 ```
 
@@ -66,24 +66,28 @@ Astarte's Documentation.
 
 ## Kubernetes support
 
-| Kubernetes Version | Supported | Tested by CI |
-| --- | --- | --- |
-| v1.17.x  | :x: | :x: |
-| v1.18.x  | :x: | :x: |
-| v1.19.x  | :white_check_mark: | :white_check_mark: |
-| v1.20.x  | :white_check_mark: | :white_check_mark: |
-| v1.21.x  | :white_check_mark: | :white_check_mark: |
+| Kubernetes Version | Supported                        | Tested by CI                     |
+| ---                | ---                              | ---                              |
+| v1.18.x            | :x:                              | :x:                              |
+| v1.19.x            | :large_orange_diamond: :warning: | :large_orange_diamond: :warning: |
+| v1.20.x            | :white_check_mark: :warning:     | :white_check_mark: :warning:     |
+| v1.21.x            | :white_check_mark: :warning:     | :white_check_mark: :warning:     |
+| v1.22.x            | :white_check_mark:               | :white_check_mark:               |
+| v1.23.x            | :white_check_mark:               | :white_check_mark:               |
 
 Key:
 
-* :white_check_mark: : Supported and stable
-* :large_orange_diamond: : Partially supported / known to run in production, but not being targeted by the release.
-* :x: : Not supported. Run at your own risk
+* :white_check_mark: : Supported and stable.
+* :large_orange_diamond: : Partially supported / known to run in production, but not being targeted
+  by the release.
+* :x: : Not supported. Run at your own risk.
+* :warning: : Kubernetes version supporting AstarteVoyagerIngress. Please, be aware that the
+  AstarteVoyagerIngress is deprecated and the new AstarteDefaultIngress should be used.
 
 ## Development
 
 Astarte's Operator is written in Go and built upon [Operator
 SDK](https://github.com/operator-framework/operator-sdk). It depends on Go 1.15.x, requires Go
-Modules and Kubernetes >= v1.19.
+Modules and Kubernetes v1.20+.
 
 The project is built with kustomize v3.8.7 and controller-gen v0.5.0.


### PR DESCRIPTION
- Add Kubernetes 1.22 and 1.23 to the supported versions.
- Remove Kubernetes 1.19 from the test matrix.
- Update the README to reflect the changes.
- Bump cert-manager dependency.