### PR TITLE
Fix statefulsets bindings to statically provisioned PVCs

### DIFF
--- a/lib/reconcile/cassandra.go
+++ b/lib/reconcile/cassandra.go
@@ -132,8 +132,8 @@ func EnsureCassandra(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.S
 	}
 
 	// Let's check upon Storage now.
-	dataVolumeName, persistentVolumeClaim := computePersistentVolumeClaim(statefulSetName+"-data", resource.NewScaledQuantity(30, resource.Giga),
-		cr.Spec.Cassandra.Storage, cr)
+	dataVolumeName, persistentVolumeClaim := computeOrGetPersistentVolumeClaim(statefulSetName+"-data", resource.NewScaledQuantity(30, resource.Giga),
+		cr.Spec.Cassandra.Storage, cr, c)
 
 	// Compute and prepare all data for building the StatefulSet
 	statefulSetSpec := appsv1.StatefulSetSpec{

--- a/lib/reconcile/cfssl.go
+++ b/lib/reconcile/cfssl.go
@@ -165,8 +165,8 @@ func ensureCFSSLStatefulSet(cr *apiv1alpha1.Astarte, c client.Client, scheme *ru
 	}
 
 	// Let's check upon Storage now.
-	dataVolumeName, persistentVolumeClaim := computePersistentVolumeClaim(statefulSetName+"-data", resource.NewScaledQuantity(4, resource.Giga),
-		cr.Spec.CFSSL.Storage, cr)
+	dataVolumeName, persistentVolumeClaim := computeOrGetPersistentVolumeClaim(statefulSetName+"-data", resource.NewScaledQuantity(4, resource.Giga),
+		cr.Spec.CFSSL.Storage, cr, c)
 
 	// Compute and prepare all data for building the StatefulSet
 	statefulSetSpec := appsv1.StatefulSetSpec{

--- a/lib/reconcile/rabbitmq.go
+++ b/lib/reconcile/rabbitmq.go
@@ -161,8 +161,8 @@ func EnsureRabbitMQ(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Sc
 	}
 
 	// Let's check upon Storage now.
-	dataVolumeName, persistentVolumeClaim := computePersistentVolumeClaim(statefulSetName+"-data", resource.NewScaledQuantity(4, resource.Giga),
-		cr.Spec.RabbitMQ.Storage, cr)
+	dataVolumeName, persistentVolumeClaim := computeOrGetPersistentVolumeClaim(statefulSetName+"-data", resource.NewScaledQuantity(4, resource.Giga),
+		cr.Spec.RabbitMQ.Storage, cr, c)
 
 	// Compute and prepare all data for building the StatefulSet
 	statefulSetSpec := appsv1.StatefulSetSpec{

--- a/lib/reconcile/vernemq.go
+++ b/lib/reconcile/vernemq.go
@@ -122,8 +122,8 @@ func EnsureVerneMQ(cr *apiv1alpha1.Astarte, c client.Client, scheme *runtime.Sch
 	}
 
 	// Let's check upon Storage now.
-	dataVolumeName, persistentVolumeClaim := computePersistentVolumeClaim(statefulSetName+"-data", resource.NewScaledQuantity(4, resource.Giga),
-		cr.Spec.VerneMQ.Storage, cr)
+	dataVolumeName, persistentVolumeClaim := computeOrGetPersistentVolumeClaim(statefulSetName+"-data", resource.NewScaledQuantity(4, resource.Giga),
+		cr.Spec.VerneMQ.Storage, cr, c)
 
 	// Compute and prepare all data for building the StatefulSet
 	statefulSetSpec := appsv1.StatefulSetSpec{


### PR DESCRIPTION
Allow statefulsets to use external PVC, but for real