### PR TITLE
Ingress: force HTTPS if SSL is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Add Kubernetes 1.22 and 1.23 to the supported list. Remove tests for Kubernetes 1.19.
 
+### Fixed
+- Force HTTPS for API and dashboard when SSL is enabled.
+
 ## [1.0.2] - 2022-04-01
 
 ## [1.0.1] - 2021-12-17

--- a/lib/defaultingress/api_ingress.go
+++ b/lib/defaultingress/api_ingress.go
@@ -81,7 +81,7 @@ func EnsureAPIIngress(cr *ingressv1alpha1.AstarteDefaultIngress, parent *apiv1al
 	misc.LogCreateOrUpdateOperationResult(log, result, cr, configMap)
 
 	// Start with the Ingress Annotations
-	annotations := getAPIIngressAnnotations(cr)
+	annotations := getAPIIngressAnnotations(cr, parent)
 
 	// Then build the Ingress Spec
 	ingressSpec := getAPIIngressSpec(cr, parent)
@@ -113,9 +113,10 @@ func getConfigMapName(cr *ingressv1alpha1.AstarteDefaultIngress) string {
 	return cr.Name + "-api-ingress-config"
 }
 
-func getAPIIngressAnnotations(cr *ingressv1alpha1.AstarteDefaultIngress) map[string]string {
+func getAPIIngressAnnotations(cr *ingressv1alpha1.AstarteDefaultIngress, parent *apiv1alpha1.Astarte) map[string]string {
+	apiSslRedirect := pointy.BoolValue(parent.Spec.API.SSL, true) || pointy.BoolValue(cr.Spec.Dashboard.SSL, true)
 	annotations := map[string]string{
-		"nginx.ingress.kubernetes.io/ssl-redirect":   "false",
+		"nginx.ingress.kubernetes.io/ssl-redirect":   strconv.FormatBool(apiSslRedirect),
 		"nginx.ingress.kubernetes.io/use-regex":      "true",
 		"nginx.ingress.kubernetes.io/rewrite-target": "/$2",
 		"nginx.ingress.kubernetes.io/configuration-snippet": "more_set_headers \"X-Frame-Options: SAMEORIGIN\";\n" +


### PR DESCRIPTION
Force HTTPS for API and Dashboard if SSL is enabled for one of them.
HTTP will be used only if SSL is disabled for both.