### PR TITLE
Update permissions

### DIFF
--- a/charts/astarte-operator/templates/rbac.yaml
+++ b/charts/astarte-operator/templates/rbac.yaml
@@ -153,7 +153,6 @@ rules:
   resources:
   - configmaps
   - endpoints
-  - events
   - persistentvolumeclaims
   - pods
   - secrets
@@ -181,6 +180,16 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
   - watch
 - apiGroups:
   - ingress.astarte-platform.org
@@ -218,7 +227,7 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - '*'
+  - ingresses
   verbs:
   - create
   - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -112,7 +112,6 @@ rules:
   resources:
   - configmaps
   - endpoints
-  - events
   - persistentvolumeclaims
   - pods
   - secrets
@@ -140,6 +139,16 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
   - watch
 - apiGroups:
   - ingress.astarte-platform.org
@@ -177,7 +186,7 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - '*'
+  - ingresses
   verbs:
   - create
   - delete

--- a/controllers/api/astarte_controller.go
+++ b/controllers/api/astarte_controller.go
@@ -50,7 +50,8 @@ type AstarteReconciler struct {
 
 // +kubebuilder:rbac:groups=api.astarte-platform.org,resources=astartes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=api.astarte-platform.org,resources=astartes/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=core,resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;configmaps;secrets;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=apps,resourceNames=astarte-operator,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/ingress/astartedefaultingress_controller.go
+++ b/controllers/ingress/astartedefaultingress_controller.go
@@ -54,7 +54,7 @@ type AstarteDefaultIngressReconciler struct {
 //+kubebuilder:rbac:groups=ingress.astarte-platform.org,resources=astartedefaultingresses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ingress.astarte-platform.org,resources=astartedefaultingresses/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=ingress.astarte-platform.org,resources=astartedefaultingresses/finalizers,verbs=update
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services;services/finalizers;configmaps,verbs=get;list;watch;create;update;patch;delete
 
 func (r *AstarteDefaultIngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
Restrict the permissions for the operator's clusterrole. In particular:
- do not use wildcard to grant access to all resources,
- do not allow deletion of events.