### PR TITLE
New development cycle targets v22.11 instead of v1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 1.1.0-dev
+VERSION ?= 22.11.00-dev
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/charts/astarte-operator/Chart.yaml
+++ b/charts/astarte-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: astarte-operator
 description: The Astarte Kubernetes Operator Helm Chart.
 type: application
 
-version: 1.1.0-dev.0
-appVersion: 1.1.0-dev
+version: 22.11.00-dev.0
+appVersion: 22.11.00-dev
 kubeVersion: ">= 1.19.0-0"
 
 home: https://github.com/astarte-platform/astarte-kubernetes-operator

--- a/charts/astarte-operator/values.yaml
+++ b/charts/astarte-operator/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: astarte/astarte-kubernetes-operator
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "1.1.0-dev"
+  tag: "22.11.00-dev"
 
 # -- Resources to assign to each Astarte Operator instance.
 resources:

--- a/version/version.go
+++ b/version/version.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// Version is the Operator's version
-	Version = "1.1.0-dev"
+	Version = "22.11.00-dev"
 
 	// AstarteVersionConstraintString represents the range of supported Astarte versions for this Operator.
 	// If the Astarte version falls out of this range, reconciliation will be immediately aborted.


### PR DESCRIPTION
According to #306, the new release cycle is for v22.11.