### PR TITLE
Update tools used in CI

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     # Checkout the source
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: astarte-kubernetes-operator
     # Checkout the docs repository
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: astarte-platform/docs
         ssh-key: ${{ secrets.DOCS_DEPLOY_KEY }}
@@ -33,7 +33,7 @@ jobs:
     # Setup Go for crd-ref-docs (ubuntu-20.04 defaults to go 1.15)
     # see https://github.com/actions/virtual-environments/issues/2447
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '1.18.x'
     # Generate CRD docs directory for Hugo
@@ -49,7 +49,7 @@ jobs:
       working-directory: astarte-kubernetes-operator
     # Checkout the hugo-book theme
     - name: Checkout hugo-book
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         repository: alex-shpak/hugo-book

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -25,9 +25,9 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Since v3, golangci-lint needs explicit go-setup
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: v1.18.x
     # Run golint-ci

--- a/.github/workflows/helm-sync.yaml
+++ b/.github/workflows/helm-sync.yaml
@@ -30,11 +30,11 @@ jobs:
   check-chart:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Fetch history
       run: git fetch --prune --unshallow
     - name: Setup Helm
-      uses: azure/setup-helm@v1
+      uses: azure/setup-helm@v3
       with:
         version: v3.4.2
     - name: Setup chart-testing
@@ -59,17 +59,17 @@ jobs:
     runs-on: ubuntu-20.04
     needs: check-chart
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: operator
     # Setup Go for helm-docs (ubuntu-20.04 defaults to go 1.15)
     # see https://github.com/actions/virtual-environments/issues/2447
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '1.18.x'
     # Checkout the Helm repository
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: astarte-platform/helm
         path: helm

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -84,7 +84,7 @@ jobs:
         kubectl create namespace cert-manager
         helm repo add jetstack https://charts.jetstack.io
         helm repo update
-        helm install cert-manager jetstack/cert-manager --namespace cert-manager --version v1.1.0 --set installCRDs=true
+        helm install cert-manager jetstack/cert-manager --namespace cert-manager --version v1.10.0 --set installCRDs=true
     - name: Sleep for 20 seconds (wait for cert-manager to come up)
       uses: jakejarvis/wait-action@master
       with:

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -25,11 +25,11 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Fetch history
       run: git fetch --prune --unshallow
     - name: Setup Helm
-      uses: azure/setup-helm@v1
+      uses: azure/setup-helm@v3
       with:
         version: v3.4.2
     - name: Setup chart-testing

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -59,10 +59,10 @@ jobs:
       # see https://github.com/kubernetes-sigs/kind/issues/2240#issuecomment-838510890
       run: |
         sudo sysctl net/netfilter/nf_conntrack_max=131072
-    - uses: container-tools/kind-action@v1
+    - uses: container-tools/kind-action@v2
       with:
-        version: "v0.11.1"
-        node_image: "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
+        version: "v0.17.0"
+        node_image: "kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
     - name: Build test image
       run: |
         docker build -t astarte-operator-ci:test -f Dockerfile .

--- a/.github/workflows/image-test.yaml
+++ b/.github/workflows/image-test.yaml
@@ -23,7 +23,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build test image
       run: |
         docker build -t astarte-operator-ci:test -f Dockerfile .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,8 +36,8 @@ jobs:
         - "kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         # Ensure we're on Go 1.18
         go-version: '1.18.x'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,10 +30,10 @@ jobs:
         - "011"
         - "10"
         kubernetesNodeImage:
-        - "kindest/node:v1.20.15@sha256:393bb9096c6c4d723bb17bceb0896407d7db581532d11ea2839c80b28e5d8deb"
-        - "kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c"
-        - "kindest/node:v1.22.7@sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166"
-        - "kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
+        - "kindest/node:v1.22.15@sha256:7d9708c4b0873f0fe2e171e2b1b7f45ae89482617778c1c875f1053d4cef2e41"
+        - "kindest/node:v1.23.13@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61"
+        - "kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315"
+        - "kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
@@ -52,9 +52,9 @@ jobs:
       # see https://github.com/kubernetes-sigs/kind/issues/2240#issuecomment-838510890
       run: |
         sudo sysctl net/netfilter/nf_conntrack_max=131072
-    - uses: container-tools/kind-action@v1
+    - uses: container-tools/kind-action@v2
       with:
-        version: "v0.11.1"
+        version: "v0.17.0"
         node_image: "${{ matrix.kubernetesNodeImage }}"
     - name: Ensure KinD is up
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - v1alpha2 is the storage version for resources in the api.astarte-platform.org group.
 - Upgrade go to v1.18.
 - Upgrade OperatorSDK to v1.23.0.
+- Add Kubernetes 1.24 and 1.25 to the supported list. Remove tests for Kubernetes 1.20 and 1.21.
 
 ### Added
 - Add API reference docs generation.

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ Astarte's Documentation.
 
 | Kubernetes Version | Supported                        | Tested by CI                     |
 | ------------------ | -------------------------------- | -------------------------------- |
-| v1.18.x            | :x:                              | :x:                              |
-| v1.19.x            | :large_orange_diamond: :warning: | :large_orange_diamond: :warning: |
-| v1.20.x            | :white_check_mark: :warning:     | :white_check_mark: :warning:     |
-| v1.21.x            | :white_check_mark: :warning:     | :white_check_mark: :warning:     |
+| v1.20.x            | :large_orange_diamond: :warning: | :x:                              |
+| v1.21.x            | :large_orange_diamond: :warning: | :x:                              |
 | v1.22.x            | :white_check_mark:               | :white_check_mark:               |
 | v1.23.x            | :white_check_mark:               | :white_check_mark:               |
+| v1.24.x            | :white_check_mark:               | :white_check_mark:               |
+| v1.25.x            | :white_check_mark:               | :white_check_mark:               |
 
 Key:
 


### PR DESCRIPTION
Workflows are updated:
- use cert-manager 1.10
- bump kind to v0.17.0
- drop tests for k8s 1.20 and 1.21
- add tests targeting k8s 1.24 and 1.25
- bump checkout, setup-go and setup-helm actions to v3

Contextually, update the k8s support matrix within the README.