### PR TITLE
Restart the broker when its SSLListener secret changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Restart the broker when its SSLListener secret changes. See
+  [#317](https://github.com/astarte-platform/astarte-kubernetes-operator/issues/317).
 ### Removed
 - Remove support for Astarte <= 0.11.
 

--- a/charts/astarte-operator/templates/rbac.yaml
+++ b/charts/astarte-operator/templates/rbac.yaml
@@ -162,7 +162,6 @@ rules:
   - configmaps
   - endpoints
   - persistentvolumeclaims
-  - pods
   - secrets
   - serviceaccounts
   - services
@@ -198,6 +197,19 @@ rules:
   - get
   - list
   - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ingress.astarte-platform.org

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -121,7 +121,6 @@ rules:
   - configmaps
   - endpoints
   - persistentvolumeclaims
-  - pods
   - secrets
   - serviceaccounts
   - services
@@ -157,6 +156,19 @@ rules:
   - get
   - list
   - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ingress.astarte-platform.org

--- a/controllers/api/astarte_controller.go
+++ b/controllers/api/astarte_controller.go
@@ -25,15 +25,20 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/astarte-platform/astarte-kubernetes-operator/lib/controllerutils"
 	"github.com/astarte-platform/astarte-kubernetes-operator/version"
@@ -215,5 +220,32 @@ func (r *AstarteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&batchv1.Job{}).
+		Watches(
+			&source.Kind{Type: &v1.Secret{}},
+			handler.EnqueueRequestsFromMapFunc(tlsSecretToAstarteReconcileRequestFn(r.Client)),
+		).
 		Complete(r)
+}
+
+func tlsSecretToAstarteReconcileRequestFn(c client.Client) func(obj client.Object) []reconcile.Request {
+	return func(obj client.Object) []reconcile.Request {
+		ret := []reconcile.Request{}
+		astarteList := &apiv1alpha2.AstarteList{}
+		_ = c.List(context.Background(), astarteList, client.InNamespace(obj.GetNamespace()))
+
+		if len(astarteList.Items) == 0 {
+			return ret
+		}
+
+		for _, item := range astarteList.Items {
+			ret = append(ret, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      item.GetName(),
+					Namespace: item.GetNamespace(),
+				},
+			})
+		}
+
+		return ret
+	}
 }

--- a/controllers/api/astarte_controller.go
+++ b/controllers/api/astarte_controller.go
@@ -51,7 +51,8 @@ type AstarteReconciler struct {
 
 // +kubebuilder:rbac:groups=api.astarte-platform.org,resources=astartes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=api.astarte-platform.org,resources=astartes/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=core,resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;configmaps;secrets;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=services;services/finalizers;endpoints;persistentvolumeclaims;configmaps;secrets;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=apps,resourceNames=astarte-operator,resources=deployments/finalizers,verbs=update


### PR DESCRIPTION
When the TLS certificate is deleted or created, VerneMQ pods are restarted so that they correctly retrieve the new file (if present). In order to do that, the operator is now also able to delete collections of pods.
Fix #317.