### PR TITLE
Forward port changes from release 22.11

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -60,7 +60,7 @@ jobs:
         echo "DOCS_DIRNAME=$DOCS_DIRNAME" >> $GITHUB_ENV
     - name: Apply docs dirname to Hugo config
       run: |
-          echo "baseURL: https://docs.astarte-platform.org/$DOCS_DIRNAME" >> docs/hugo/config.yaml
+          echo "baseURL: https://docs.astarte-platform.org/$DOCS_DIRNAME/crds" >> docs/hugo/config.yaml
       working-directory: astarte-kubernetes-operator
     # Run hugo to build docs page
     - name: Build CRD docs
@@ -79,10 +79,12 @@ jobs:
     - name: Copy Docs
       run: |
         rm -rf docs/$DOCS_DIRNAME
-        mkdir -p docs/$DOCS_DIRNAME
         mkdir -p docs/$DOCS_DIRNAME/crds
         cp -r astarte-kubernetes-operator/docs/generated/* docs/$DOCS_DIRNAME/crds
         cp -r astarte-kubernetes-operator/docs/documentation/doc/* docs/$DOCS_DIRNAME
+    - name: Enforce the usage of CalVer in the generated doc pages
+      run: |
+        sed -i 's/22\.11\.0\b/22.11.00/g' docs/$DOCS_DIRNAME/*.html
     - name: Commit files
       working-directory: ./docs
       run: |

--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -82,9 +82,6 @@ jobs:
         mkdir -p docs/$DOCS_DIRNAME/crds
         cp -r astarte-kubernetes-operator/docs/generated/* docs/$DOCS_DIRNAME/crds
         cp -r astarte-kubernetes-operator/docs/documentation/doc/* docs/$DOCS_DIRNAME
-    - name: Enforce the usage of CalVer in the generated doc pages
-      run: |
-        sed -i 's/22\.11\.0\b/22.11.00/g' docs/$DOCS_DIRNAME/*.html
     - name: Commit files
       working-directory: ./docs
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 23.05.00-dev
+VERSION ?= 23.5.0-dev
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/charts/astarte-operator/Chart.yaml
+++ b/charts/astarte-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: astarte-operator
 description: The Astarte Kubernetes Operator Helm Chart.
 type: application
 
-version: "23.05.00-dev"
-appVersion: "23.05.00-dev"
+version: "23.5.0-dev"
+appVersion: "23.5.0-dev"
 kubeVersion: ">= 1.19.0-0"
 
 home: https://github.com/astarte-platform/astarte-kubernetes-operator

--- a/docs/documentation/mix.exs
+++ b/docs/documentation/mix.exs
@@ -1,14 +1,14 @@
 defmodule Doc.MixProject do
   use Mix.Project
 
-  @source_ref "release-22.11"
+  @source_ref "release-23.5"
   @source_version String.replace_prefix(@source_ref, "release-", "")
                   |> String.replace("master", "snapshot")
 
   def project do
     [
       app: :doc,
-      version: "23.05.0-dev",
+      version: "23.5.0-dev",
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/docs/documentation/mix.exs
+++ b/docs/documentation/mix.exs
@@ -1,6 +1,10 @@
 defmodule Doc.MixProject do
   use Mix.Project
 
+  @source_ref "release-22.11"
+  @source_version String.replace_prefix(@source_ref, "release-", "")
+                  |> String.replace("master", "snapshot")
+
   def project do
     [
       app: :doc,
@@ -9,7 +13,9 @@ defmodule Doc.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       name: "Astarte Operator",
-      homepage_url: "http://astarte-platform.org",
+      homepage_url:
+        "https://docs.astarte-platform.org/astarte-kubernetes-operator/#{@source_version}/",
+      source_url: "https://github.com/astarte-platform/astarte-kubernetes-operator",
       docs: docs()
     ]
   end
@@ -23,13 +29,11 @@ defmodule Doc.MixProject do
     [
       main: "001-intro_administrator",
       logo: "images/mascot.png",
-      source_url: "https://git.ispirata.com/Astarte-NG/%{path}#L%{line}",
-      # It's in the docs repo root
-      # TODO define the file in docs repo
-      # javascript_config_path: "../astarte_operator_common_vars.js",
+      javascript_config_path: "../common_vars.js",
       extras: Path.wildcard("pages/*/*.{cheatmd,md}"),
       assets: "images/",
       api_reference: false,
+      source_ref: "#{@source_ref}/docs/documentation",
       groups_for_extras: [
         "Administrator Guide": ~r"/administrator/",
         "Upgrade Guide": ~r"/upgrade/",

--- a/docs/documentation/pages/crds/001-intro_crds.md
+++ b/docs/documentation/pages/crds/001-intro_crds.md
@@ -2,4 +2,4 @@
 
 The Astarte Operator extends the Kubernetes API through the definition of Custom Resources.
 
-To browse the CRD documentation, [follow this link](./crds.html).
+To browse the CRD documentation, [follow this link](./crds/index.html).

--- a/version/version.go
+++ b/version/version.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// Version is the Operator's version
-	Version = "23.05.00-dev"
+	Version = "23.5.0-dev"
 
 	// AstarteVersionConstraintString represents the range of supported Astarte versions for this Operator.
 	// If the Astarte version falls out of this range, reconciliation will be immediately aborted.


### PR DESCRIPTION
Contextually, bump version numbers to prepare the next development cycle and make sure that versions follow the format discussed in #329.