### PR TITLE
Doc: update the upgrade guide to 22.11.x

### DIFF
--- a/docs/documentation/pages/upgrade/040-upgrade_10x_2211.md
+++ b/docs/documentation/pages/upgrade/040-upgrade_10x_2211.md
@@ -1,36 +1,33 @@
-# Upgrade v1.0.x-v22.11
+# Upgrade v1.0.x-v22.11.x
 
 This page describes the required steps to upgrade your Astarte cluster from `v1.0.x` to
-`v22.11`. Your Astarte instance will **not** need to be upgraded.
+`v22.11.x`. Your Astarte instance will **not** need to be upgraded.
 The change in the versioning scheme of the Astarte Operator is meant to better keep up with
-Kubernetes release cycle (see the [related issue](https://github.com/astarte-platform/astarte-kubernetes-operator/issues/306)
-for more information).
+Kubernetes release cycle (see the [related
+issue](https://github.com/astarte-platform/astarte-kubernetes-operator/issues/306) for more
+information).
 
 Starting from the Astarte Operator `v22.11` release, the old `api.astarte-platform.org/v1alpha1`
 APIs are deprecated and will be removed in the next release.
+
 In the following, the upgrade path is described.
 
 The upcoming sections will cover the following topics:
 - upgrading the Astarte Operator,
-- making sure that the Astarte, AstarteVoyagerIngress and Flow CR are stored using `v1alpha2` API version,
-- upgrading the Astarte, AstarteVoyagerIngress and Flow CRDs to have only `v1alpha2` as storage version.
+- making sure that the Astarte, AstarteVoyagerIngress and Flow CR are stored using `v1alpha2` API
+  version,
+- upgrading the Astarte, AstarteVoyagerIngress and Flow CRDs to have only `v1alpha2` as storage
+  version.
 
 Before starting with the upgrade procedure it is strongly advised to [backup your Astarte
 resources](095-advanced-operations.html#backup-your-astarte-resources).
 
 ## Upgrade Astarte Operator
-The Astarte Operator upgrade procedure is handled by Helm. However, according to the Helm policies,
-upgrading the CRDs must be handled manually.
+The Astarte Operator upgrade procedure is handled by Helm.
 
-The current section assumes that the Operator's chart landing version is `v22.11.00`. If a more recent
-chart version is available, it is **your responsibility** referencing to the `v22.11.00` chart using
-the `--version` flag when running `helm` commands.
-
-To upgrade the Astarte CRDs, the following environment variables will be employed:
-
-- `ASTARTE_OP_TEMPLATE_DIR` is the target directory in which the chart templates will be generated,
-- `ASTARTE_OP_RELEASE_NAME` is the name of the Astarte Operator deployment,
-- `ASTARTE_OP_RELEASE_NAMESPACE` is the namespace in which the Astarte Operator resides.
+The current section assumes that the Operator's chart landing version is `v22.11.x`. It is **your
+responsibility** referencing the proper `v22.11.x` chart using the `--version` flag when running
+`helm` commands.
 
 Please, make sure that the values you set for both the Operator's name and namespace match the
 naming you already adopted when installing the Operator. A wrong naming can lead to a malfunctioning
@@ -40,41 +37,24 @@ For standard deployments the following variables should be ok. However, it is yo
 checking that the values you set are consistent with your setup:
 
 ```bash
-export ASTARTE_OP_TEMPLATE_DIR=/tmp
 export ASTARTE_OP_RELEASE_NAME=astarte-operator
 export ASTARTE_OP_RELEASE_NAMESPACE=astarte-operator
+export ASTARTE_OP_CHART_VERSION=<22.11.x>
 ```
 
 Update your local Helm charts:
 ```bash
-$ helm repo update
+helm repo update
 ```
 
-Render the Helm templates with the following:
+To upgrade the Operator use the dedicated `helm upgrade` command:
 ```bash
-helm template $ASTARTE_OP_RELEASE_NAME astarte/astarte-operator \
-    --namespace $ASTARTE_OP_RELEASE_NAMESPACE \
-    --output-dir $ASTARTE_OP_TEMPLATE_DIR
-```
-
-After these steps you will find the updated CRDs within
-`$ASTARTE_OP_TEMPLATE_DIR/$ASTARTE_OP_RELEASE_NAME/templates/crds.yaml`. Update the CRDs in your
-cluster by replacing the CRDs yaml file:
-```bash
-kubectl replace -f $ASTARTE_OP_TEMPLATE_DIR/$ASTARTE_OP_RELEASE_NAME/templates/crds.yaml
-```
-
-The previous command has updated the CRDs for Astarte, AstarteVoyagerIngress and Flow.
-
-Then, to upgrade the Operator use the dedicated `helm upgrade` command:
-```bash
-helm upgrade astarte-operator astarte/astarte-operator -n astarte-operator
+helm upgrade $ASTARTE_OP_RELEASE_NAME astarte/astarte-operator -n $ASTARTE_OP_RELEASE_NAMESPACE \
+  --version $ASTARTE_OP_CHART_VERSION
 ```
 
 The optional `--version` switch allows to specify the version to upgrade to - when not specified,
-the latest version will be fetched and used. If you choose to upgrade to a specific version of the
-chart by using the `--version` flag, please make sure to generate the updated CRDs template using
-the same chart version.
+the latest version will be fetched and used.
 
 By design, Astarte Operator's Helm charts cannot univocally be mapped to Operator's releases in a
 one-to-one relationship. However each chart is tied to a specific Operator's version, which is user
@@ -92,13 +72,14 @@ As usual, you can use the `--version` flag to point to a specific chart version.
 
 ## Make sure Astarte is stored using the `api.astarte-platform.org/v1alpha2` apiVersion
 
-To do so, simply edit the Astarte resource in the cluster.  
-Open the yaml file describing the Astarte resource with:
+To do so, simply edit the Astarte resource in the cluster. Open the yaml file describing the Astarte
+resource with:
 ```bash
 kubectl edit astarte -n astarte
 ```
 
-Find the `apiVersion` field in the Astarte Spec section and change it (if needed) to `api.astarte-platform.org/v1alpha2`.
+Find the `apiVersion` field in the Astarte Spec section and change it (if needed) to
+`api.astarte-platform.org/v1alpha2`.
 
 After having done this, you Astarte CR will look like this:
 ```yaml
@@ -124,7 +105,8 @@ Open the yaml file describing the Flow resource with:
 kubectl edit flow -n astarte
 ```
 
-Find the `apiVersion` field in the Flow Spec section and change it (if needed) to `api.astarte-platform.org/v1alpha2`.
+Find the `apiVersion` field in the Flow Spec section and change it (if needed) to
+`api.astarte-platform.org/v1alpha2`.
 
 After having done this, your Flow CR will look like this:
 ```yaml
@@ -141,20 +123,24 @@ Once the yaml file is applied, the Operator will take over ensuring the reconcil
 Flow instance. This will in turn change the version in which the Flow CR is stored in
 Kubernetes to `api.astarte-platform.org/v1alpha2`.
 
-## Make sure AstarteVoyagerIngress is stored using the `api.astarte-platform.org/v1alpha2` apiVersion
+## Make sure AstarteVoyagerIngress is stored using the `api.astarte-platform.org/v1alpha2`
+apiVersion
 
-**The AstarteVoyagerIngress is deprecated and will be removed starting from Astarte Operator v23.05.00.**
-**Please consider [switching to the new AstarteDefaultIngress](066-migrate_to_astartedefaultingress.html).**
+**The AstarteVoyagerIngress is deprecated and will be removed starting from Astarte Operator
+v23.5.0.**
+**Please consider [switching to the new
+AstarteDefaultIngress](066-migrate_to_astartedefaultingress.html).**
 
 If you already have dropped the AstarteVoyagerIngress, you can skip this section.
 
-To do so, simply edit the AstarteVoyagerIngress resource in the cluster.  
+To do so, simply edit the AstarteVoyagerIngress resource in the cluster.
 Open the yaml file describing the AstarteVoyagerIngress resource with:
 ```bash
 kubectl edit avi -n astarte
 ```
 
-Find the `apiVersion` field in the AstarteVoyagerIngress Spec section and change it (if needed) to `api.astarte-platform.org/v1alpha2`.
+Find the `apiVersion` field in the AstarteVoyagerIngress Spec section and change it (if needed) to
+`api.astarte-platform.org/v1alpha2`.
 
 After having done this, your AstarteVoyagerIngress CR will look like this:
 ```yaml
@@ -168,12 +154,12 @@ status:
 ```
 
 Once the yaml file is applied, the Operator will take over ensuring the reconciliation of your
-AstarteVoyagerIngress instance. This will in turn change the version in which the AstarteVoyagerIngress
-CR is stored in Kubernetes to `api.astarte-platform.org/v1alpha2`.
+AstarteVoyagerIngress instance. This will in turn change the version in which the
+AstarteVoyagerIngress CR is stored in Kubernetes to `api.astarte-platform.org/v1alpha2`.
 
 ## Upgrade the CRDs to the new storage version
-This step is handled by [`astartectl`](https://github.com/astarte-platform/astartectl). Ensure that `astartectl`
-is installed on your machine and its version is at least `>= v22.11.00`.
+This step is handled by [`astartectl`](https://github.com/astarte-platform/astartectl). Ensure that
+`astartectl` is installed on your machine and its version is at least `>= v22.11.00`.
 
 Performing the actual upgrade is as simple as executing the following command:
 
@@ -181,15 +167,17 @@ Performing the actual upgrade is as simple as executing the following command:
 $ astartectl cluster instances migrate storage-version
 ```
 
-If an error occurs during the migration procedure, changes made by `migrate storage-version` will be reverted,
-so that you can make sure of having performed all necessary steps described in this page before trying again.
+If an error occurs during the migration procedure, changes made by `migrate storage-version` will be
+reverted, so that you can make sure of having performed all necessary steps described in this page
+before trying again.
 
 ### What happens under the hood?
 
-When invoking the `migrate storage-version` command, `astartectl` interacts with your Astarte cluster and
-retrieves the Astarte, Flow and AVI CRDs which are installed. Then, it checks that the CRDs are in a state
-consistent with the migration step it needs to perform, i.e. that each one of them has both `v1alpha1`
-and `v1alpha2` as `storedVersions`. For example, your Astarte CRD will look like this:
+When invoking the `migrate storage-version` command, `astartectl` interacts with your Astarte
+cluster and retrieves the Astarte, Flow and AVI CRDs which are installed. Then, it checks that the
+CRDs are in a state consistent with the migration step it needs to perform, i.e. that each one of
+them has both `v1alpha1` and `v1alpha2` as `storedVersions`. For example, your Astarte CRD will look
+like this:
 
 ```yaml
 name: astartes.api.astarte-platform.org


### PR DESCRIPTION
The upgrade path to 22.11 is made more general: i.e. it targets v22.11.x. Furthermore, do not render templated CRDs and let helm update CRDs.
Contextually, wrap lines to 100 characters.