### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -38,7 +38,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       security-events: write
 

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,3 +1,21 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # For most projects, this workflow file will not need changing; you simply need
 # to commit it to your repository.
 #

--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     # Checkout the source
     - uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18.x'
+        go-version: '1.19.x'
     # Generate CRD docs directory for Hugo
     - run: mkdir docs/content
       working-directory: astarte-kubernetes-operator

--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -1,3 +1,21 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 name: Docs generation
 
 on:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -23,14 +23,14 @@ on:
 
 jobs:
   golangci-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     # Since v3, golangci-lint needs explicit go-setup
     - uses: actions/setup-go@v3
       with:
-        go-version: v1.18.x
+        go-version: v1.19.x
     # Run golint-ci
     - uses: golangci/golangci-lint-action@v3
       with:
-          version: v1.50
+          version: v1.52

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2020 Ispirata Srl
+# Copyright 2020-23 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/helm-sync.yaml
+++ b/.github/workflows/helm-sync.yaml
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2020 Ispirata Srl
+# Copyright 2020-23 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/helm-sync.yaml
+++ b/.github/workflows/helm-sync.yaml
@@ -28,17 +28,17 @@ on:
 
 jobs:
   check-chart:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Fetch history
       run: git fetch --prune --unshallow
-    - name: Setup Helm
-      uses: azure/setup-helm@v3
+    - uses: alexellis/setup-arkade@v3
+    - uses: alexellis/arkade-get@master
       with:
-        version: v3.4.2
+        helm: v3.4.2
     - name: Setup chart-testing
-      uses: helm/chart-testing-action@v2.1.0
+      uses: helm/chart-testing-action@v2
     - name: Set env variable for ct target branch
       run: echo "CT_TARGET_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
     - name: Set env variable to prevent chart bump errors
@@ -56,7 +56,7 @@ jobs:
           echo "::set-output name=changed::true"
         fi
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: check-chart
     steps:
     - uses: actions/checkout@v3
@@ -67,7 +67,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18.x'
+        go-version: '1.19.x'
     # Checkout the Helm repository
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2020 Ispirata Srl
+# Copyright 2020-23 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -23,17 +23,17 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Fetch history
       run: git fetch --prune --unshallow
-    - name: Setup Helm
-      uses: azure/setup-helm@v3
+    - uses: alexellis/setup-arkade@v3
+    - uses: alexellis/arkade-get@master
       with:
-        version: v3.4.2
+        helm: v3.4.2
     - name: Setup chart-testing
-      uses: helm/chart-testing-action@v2.1.0
+      uses: helm/chart-testing-action@v2
     - name: Set env variable for ct target branch
       run: echo "CT_TARGET_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       if: ${{ github.event_name == 'push' }}
@@ -61,8 +61,8 @@ jobs:
         sudo sysctl net/netfilter/nf_conntrack_max=131072
     - uses: container-tools/kind-action@v2
       with:
-        version: "v0.17.0"
-        node_image: "kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
+        version: "v0.19.0"
+        node_image: "kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b"
     - name: Build test image
       run: |
         docker build -t astarte-operator-ci:test -f Dockerfile .

--- a/.github/workflows/image-test.yaml
+++ b/.github/workflows/image-test.yaml
@@ -21,7 +21,7 @@ on: [pull_request, push]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Build test image

--- a/.github/workflows/image-test.yaml
+++ b/.github/workflows/image-test.yaml
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2020 Ispirata Srl
+# Copyright 2020-23 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,34 +19,53 @@
 name: "Operator e2e tests"
 on:
   pull_request:
+    paths:
+    - 'apis/**'
+    - 'controllers/**'
+    - 'lib/**'
+    - 'test/**'
+    - 'version/**'
+    # The workflow itself
+    - '.github/workflows/test.yaml'
+    # And in case dependencies are changed
+    - 'go.mod'
   push:
+    paths:
+    - 'apis/**'
+    - 'controllers/**'
+    - 'lib/**'
+    - 'test/**'
+    - 'version/**'
+    # The workflow itself
+    - '.github/workflows/test.yaml'
+    # And in case dependencies are changed
+    - 'go.mod'
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         testSuite:
         - "10"
         - "11"
         kubernetesNodeImage:
-        - "kindest/node:v1.22.15@sha256:7d9708c4b0873f0fe2e171e2b1b7f45ae89482617778c1c875f1053d4cef2e41"
-        - "kindest/node:v1.23.13@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61"
-        - "kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315"
-        - "kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
+        - "kindest/node:v1.23.17@sha256:f77f8cf0b30430ca4128cc7cfafece0c274a118cd0cdb251049664ace0dee4ff"
+        - "kindest/node:v1.24.13@sha256:cea86276e698af043af20143f4bf0509e730ec34ed3b7fa790cc0bea091bc5dd"
+        - "kindest/node:v1.25.9@sha256:c08d6c52820aa42e533b70bce0c2901183326d86dcdcbedecc9343681db45161"
+        - "kindest/node:v1.26.4@sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e"
+        - "kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b"
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        # Ensure we're on Go 1.18
-        go-version: '1.18.x'
-    - uses: stefanprodan/kube-tools@v1.5.0
+        go-version: '1.19.x'
+    - uses: alexellis/setup-arkade@v3
+    - uses: alexellis/arkade-get@master
       with:
-        kubectl: 1.22.0
+        kubectl: v1.24.0
         kustomize: 3.8.7
-        helm: 2.16.7
-        helmv3: 3.8.0
     - name: Set nf_conntrack_max value
       # This step is required to avoid CrashLoopBackOff for kube-proxy
       # see https://github.com/kubernetes-sigs/kind/issues/2240#issuecomment-838510890
@@ -54,7 +73,7 @@ jobs:
         sudo sysctl net/netfilter/nf_conntrack_max=131072
     - uses: container-tools/kind-action@v2
       with:
-        version: "v0.17.0"
+        version: "v0.19.0"
         node_image: "${{ matrix.kubernetesNodeImage }}"
     - name: Ensure KinD is up
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2020 Ispirata Srl
+# Copyright 2020-23 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Restart the broker when its SSLListener secret changes. See
   [#317](https://github.com/astarte-platform/astarte-kubernetes-operator/issues/317).
 - Upgrade OperatorSDK to v1.27.0.
+- Upgrade go to v1.19.
+- Add Kubernetes 1.26 and 1.27 to the supported list. Remove tests for Kubernetes 1.22.
 
 ### Removed
 - Remove support for Astarte <= 0.11.

--- a/README.md
+++ b/README.md
@@ -65,14 +65,15 @@ Cluster](https://docs.astarte-platform.org/astarte-kubernetes-operator/snapshot/
 
 ## Kubernetes support
 
-| Kubernetes Version | Supported                        | Tested by CI                     |
-| ------------------ | -------------------------------- | -------------------------------- |
-| v1.20.x            | :large_orange_diamond: :warning: | :x:                              |
-| v1.21.x            | :large_orange_diamond: :warning: | :x:                              |
-| v1.22.x            | :white_check_mark:               | :white_check_mark:               |
-| v1.23.x            | :white_check_mark:               | :white_check_mark:               |
-| v1.24.x            | :white_check_mark:               | :white_check_mark:               |
-| v1.25.x            | :white_check_mark:               | :white_check_mark:               |
+| Kubernetes Version | Supported                        | Tested by CI       |
+|--------------------|----------------------------------|--------------------|
+| v1.21.x            | :large_orange_diamond: :warning: | :x:                |
+| v1.22.x            | :large_orange_diamond:           | :x:                |
+| v1.23.x            | :large_orange_diamond:           | :white_check_mark: |
+| v1.24.x            | :white_check_mark:               | :white_check_mark: |
+| v1.25.x            | :white_check_mark:               | :white_check_mark: |
+| v1.26.x            | :white_check_mark:               | :white_check_mark: |
+| v1.27.x            | :white_check_mark:               | :white_check_mark: |
 
 Key:
 


### PR DESCRIPTION
- Bump runners to ubuntu 22.04;
- Ensure we're using go 1.19;
- Bump kind images and add newer versions to test matrices: add k8s v1.26, v1.27 to the test matrix, drop v1.22;
- Use setup-arkade action for setting up tools (mainly replaces the deprecated `stefanprod/kube-tools`, but can be used in general to setup the needed tools);
- Run e2e tests only when needed;
- Update licenses in workflow files.
