### PR TITLE
Let VerneMQ connect to Cassandra/ScyllaDB for Astarte v1.2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgrade OperatorSDK to v1.27.0.
 - Upgrade go to v1.19.
 - Add Kubernetes 1.26 and 1.27 to the supported list. Remove tests for Kubernetes 1.22.
+- Support VerneMQ connection to Cassandra/ScyllaDB when handling Astarte v1.2+.
 
 ### Removed
 - Remove support for Astarte <= 0.11.


### PR DESCRIPTION
Astarte v1.2 introduces the support for device deletion. In order to do so, the broker must connect to the database. Thus, propagate the relevant environment variables to the broker.