### PR TITLE
Prepare 23.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [23.5] - 2023-10-04
 ### Changed
 - Restart the broker when its SSLListener secret changes. See
   [#317](https://github.com/astarte-platform/astarte-kubernetes-operator/issues/317).

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 23.5.0-dev
+VERSION ?= 23.5.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/charts/astarte-operator/Chart.yaml
+++ b/charts/astarte-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: astarte-operator
 description: The Astarte Kubernetes Operator Helm Chart.
 type: application
 
-version: "23.5.0-dev"
-appVersion: "23.5.0-dev"
+version: "23.5.0"
+appVersion: "23.5.0"
 kubeVersion: ">= 1.19.0-0"
 
 home: https://github.com/astarte-platform/astarte-kubernetes-operator

--- a/charts/astarte-operator/values.yaml
+++ b/charts/astarte-operator/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: astarte/astarte-kubernetes-operator
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "snapshot"
+  tag: "23.5.0"
 
 # -- Resources to assign to each Astarte Operator instance.
 resources:

--- a/docs/documentation/mix.exs
+++ b/docs/documentation/mix.exs
@@ -8,7 +8,7 @@ defmodule Doc.MixProject do
   def project do
     [
       app: :doc,
-      version: "23.5.0-dev",
+      version: "23.5.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/docs/documentation/pages/upgrade/000-upgrade_index.md
+++ b/docs/documentation/pages/upgrade/000-upgrade_index.md
@@ -14,3 +14,5 @@ Find below the upgrade guides for your Astarte cluster:
 + to upgrade from v0.11 to v1.0, click [here](020-upgrade_011_10.html)
 + to upgrade from v1.0.0 to v1.0.x, click [here](030-upgrade_100_10x.html)
 + to upgrade from v1.0.x to v22.11, click [here](040-upgrade_10x_2211.html)
++ to upgrade from v22.11.x to v23.5, click [here](050-upgrade_2211_235.html)
+

--- a/docs/documentation/pages/upgrade/050-upgrade_2211_235.md
+++ b/docs/documentation/pages/upgrade/050-upgrade_2211_235.md
@@ -1,0 +1,63 @@
+# Upgrade v22.11.x-23.5x
+
+This page describes the required steps to upgrade your Astarte cluster from `v22.11.x` to
+`v23.5.x`. Your Astarte instance will **not** need to be upgraded.
+
+Starting from the Astarte Operator `v22.11` release, the old `api.astarte-platform.org/v1alpha1`
+APIs are deprecated and will be removed in the next release (`v23.11`).
+
+In the following, the upgrade path is described.
+
+The upcoming sections will cover the following topics:
+- upgrading the Astarte Operator,
+
+Before starting with the upgrade procedure it is strongly advised to [backup your Astarte
+resources](095-advanced-operations.html#backup-your-astarte-resources).
+
+## Upgrade Astarte Operator
+The Astarte Operator upgrade procedure is handled by Helm.
+
+The current section assumes that the Operator's chart landing version is `v23.5.x`. It is **your
+responsibility** referencing the proper `v23.5.x` chart using the `--version` flag when running
+`helm` commands.
+
+Please, make sure that the values you set for both the Operator's name and namespace match the
+naming you already adopted when installing the Operator. A wrong naming can lead to a malfunctioning
+Astarte cluster.
+
+For standard deployments the following variables should be ok. However, it is your responsibility
+checking that the values you set are consistent with your setup:
+
+```bash
+export ASTARTE_OP_RELEASE_NAME=astarte-operator
+export ASTARTE_OP_RELEASE_NAMESPACE=astarte-operator
+export ASTARTE_OP_CHART_VERSION=<23.5.x>
+```
+
+Update your local Helm charts:
+```bash
+helm repo update
+```
+
+To upgrade the Operator use the dedicated `helm upgrade` command:
+```bash
+helm upgrade $ASTARTE_OP_RELEASE_NAME astarte/astarte-operator -n $ASTARTE_OP_RELEASE_NAMESPACE \
+  --version $ASTARTE_OP_CHART_VERSION
+```
+
+The optional `--version` switch allows to specify the version to upgrade to - when not specified,
+the latest version will be fetched and used.
+
+By design, Astarte Operator's Helm charts cannot univocally be mapped to Operator's releases in a
+one-to-one relationship. However each chart is tied to a specific Operator's version, which is user
+configurable.
+
+Therefore, upgrading a chart leads to an Operator's upgrade if and only if the Operator's tag
+referenced by the chart is changed. You can check the Operator's tag bound to the chart simply
+running:
+
+```bash
+helm show values astarte/astarte-operator
+```
+
+As usual, you can use the `--version` flag to point to a specific chart version.

--- a/version/version.go
+++ b/version/version.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// Version is the Operator's version
-	Version = "23.5.0-dev"
+	Version = "23.5.0"
 
 	// AstarteVersionConstraintString represents the range of supported Astarte versions for this Operator.
 	// If the Astarte version falls out of this range, reconciliation will be immediately aborted.

--- a/version/version.go
+++ b/version/version.go
@@ -30,7 +30,7 @@ const (
 
 	// AstarteVersionConstraintString represents the range of supported Astarte versions for this Operator.
 	// If the Astarte version falls out of this range, reconciliation will be immediately aborted.
-	AstarteVersionConstraintString = ">= 1.0.0, < 1.2.0"
+	AstarteVersionConstraintString = ">= 1.0.0, < 1.3.0"
 
 	// SnapshotVersion represents the name of the master/snapshot version, which can or cannot be installed
 	// by this cluster


### PR DESCRIPTION
- Add upgrade guide from `22.11`
- Update supported Astarte version range to include `1.2`
- Bump version and add release date to CHANGELOG.md