### PR TITLE
Docs: point to supported K8s doc in CRD reference

### DIFF
--- a/docs/autogen/config.yaml
+++ b/docs/autogen/config.yaml
@@ -7,4 +7,4 @@ processor:
 
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.
-  kubernetesVersion: 1.19
+  kubernetesVersion: 1.23


### PR DESCRIPTION
K8s documentation < 1.23 does not exist anymore. Update the CRD reference page to point to the minimum supported k8s version.