### PR TITLE
Allow to use a custom CA for Cassandra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [23.5.1] - Unreleased
+### Fixed
+- It is now possible to explictly set a CA for Cassandra through a Kubernetes TLS Secret.
+
 ## [23.5] - 2023-10-04
 ### Changed
 - Restart the broker when its SSLListener secret changes. See

--- a/lib/reconcile/utils.go
+++ b/lib/reconcile/utils.go
@@ -570,6 +570,19 @@ func getAstarteCommonVolumes(cr *apiv1alpha2.Astarte) []v1.Volume {
 		}
 	}
 
+	if cr.Spec.Cassandra.Connection != nil {
+		if cr.Spec.Cassandra.Connection.SSLConfiguration.CustomCASecret.Name != "" {
+			// Mount the secret!
+			ret = append(ret, v1.Volume{
+				Name: "cassandra-ssl-ca",
+				VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{
+					SecretName: cr.Spec.Cassandra.Connection.SSLConfiguration.CustomCASecret.Name,
+					Items:      []v1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}},
+				}},
+			})
+		}
+	}
+
 	return ret
 }
 
@@ -588,6 +601,17 @@ func getAstarteCommonVolumeMounts(cr *apiv1alpha2.Astarte) []v1.VolumeMount {
 			ret = append(ret, v1.VolumeMount{
 				Name:      "rabbitmq-ssl-ca",
 				MountPath: "/rabbitmq-ssl",
+				ReadOnly:  true,
+			})
+		}
+	}
+
+	if cr.Spec.Cassandra.Connection != nil {
+		if cr.Spec.Cassandra.Connection.SSLConfiguration.CustomCASecret.Name != "" {
+			// Mount the secret!
+			ret = append(ret, v1.VolumeMount{
+				Name:      "cassandra-ssl-ca",
+				MountPath: "/cassandra-ssl",
 				ReadOnly:  true,
 			})
 		}


### PR DESCRIPTION
If one were to use a custom CA for connecting to Cassandra (e.g. when using AWS Keyspaces), the custom CA secret was not mounted inside Astarte pods. Mount the secret in `/cassandra-ssl/ca.crt`, similarly to what we currently do for RabbitMQ.

The CA certificate must be of `generic` type and contain a single key named `ca.crt`.

See #351. 