### PR TITLE
Astarte CRD: add the astarteInstanceID field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Added
 - Add a v1alpha3 API version for the api.astarte-platform.org group.
+- Add the `astarteInstanceID` to the astarte spec.
 
 ### Changed
 - Use the imperative form for fields in the spec, i.e.: `enabled` --> `enable` in Astarte v1alpha3.

--- a/apis/api/v1alpha2/astarte_types.go
+++ b/apis/api/v1alpha2/astarte_types.go
@@ -690,6 +690,13 @@ type AstarteSpec struct {
 	Components AstarteComponentsSpec `json:"components"`
 	// +optional
 	AstarteSystemKeyspace AstarteSystemKeyspaceSpec `json:"astarteSystemKeyspace,omitempty"`
+	// AstarteInstanceID is the unique ID that is associated with an Astarte instance. This parameter
+	// is used to let different Astarte instances employ a shared database infrastructure.
+	// Once set, the AstarteInstanceID cannot be changed. Defaults to "".
+	// +kubebuilder:validation:Pattern:=`^[a-z]?[a-z0-9]{0,47}$`
+	// +kubebuilder:default:=""
+	// +optional
+	AstarteInstanceID string `json:"astarteInstanceID,omitempty"`
 	// ManualMaintenanceMode pauses all reconciliation activities but still computes the resource
 	// status. It should be used only when the managed Astarte resources requires manual intervention
 	// and the Operator cannot break out of the problem by itself. Do not set this field unless you

--- a/apis/api/v1alpha3/astarte_types.go
+++ b/apis/api/v1alpha3/astarte_types.go
@@ -58,6 +58,13 @@ type AstarteSpec struct {
 	Components AstarteComponentsSpec `json:"components"`
 	// +optional
 	AstarteSystemKeyspace AstarteSystemKeyspaceSpec `json:"astarteSystemKeyspace,omitempty"`
+	// AstarteInstanceID is the unique ID that is associated with an Astarte instance. This parameter
+	// is used to let different Astarte instances employ a shared database infrastructure.
+	// Once set, the AstarteInstanceID cannot be changed. Defaults to "".
+	// +kubebuilder:validation:Pattern:=`^[a-z]?[a-z0-9]{0,47}$`
+	// +kubebuilder:default:=""
+	// +optional
+	AstarteInstanceID string `json:"astarteInstanceID,omitempty"`
 	// ManualMaintenanceMode pauses all reconciliation activities but still computes the resource
 	// status. It should be used only when the managed Astarte resources requires manual intervention
 	// and the Operator cannot break out of the problem by itself. Do not set this field unless you

--- a/apis/api/v1alpha3/zz_generated.conversion.go
+++ b/apis/api/v1alpha3/zz_generated.conversion.go
@@ -1514,6 +1514,7 @@ func autoConvert_v1alpha3_AstarteSpec_To_v1alpha2_AstarteSpec(in *AstarteSpec, o
 	if err := Convert_v1alpha3_AstarteSystemKeyspaceSpec_To_v1alpha2_AstarteSystemKeyspaceSpec(&in.AstarteSystemKeyspace, &out.AstarteSystemKeyspace, s); err != nil {
 		return err
 	}
+	out.AstarteInstanceID = in.AstarteInstanceID
 	out.ManualMaintenanceMode = in.ManualMaintenanceMode
 	return nil
 }
@@ -1555,6 +1556,7 @@ func autoConvert_v1alpha2_AstarteSpec_To_v1alpha3_AstarteSpec(in *v1alpha2.Astar
 	if err := Convert_v1alpha2_AstarteSystemKeyspaceSpec_To_v1alpha3_AstarteSystemKeyspaceSpec(&in.AstarteSystemKeyspace, &out.AstarteSystemKeyspace, s); err != nil {
 		return err
 	}
+	out.AstarteInstanceID = in.AstarteInstanceID
 	out.ManualMaintenanceMode = in.ManualMaintenanceMode
 	return nil
 }

--- a/charts/astarte-operator/templates/crds/astartes.api.astarte-platform.org.yaml
+++ b/charts/astarte-operator/templates/crds/astartes.api.astarte-platform.org.yaml
@@ -59,6 +59,11 @@ spec:
                 apiVersion:
                   description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                   type: string
+                astarteInstanceID:
+                  default: ""
+                  description: AstarteInstanceID is the unique ID that is associated with an Astarte instance. This parameter is used to let different Astarte instances employ a shared database infrastructure. Once set, the AstarteInstanceID cannot be changed. Defaults to "".
+                  pattern: ^[a-z]?[a-z0-9]{0,47}$
+                  type: string
                 astarteSystemKeyspace:
                   description: astarteSystemKeyspace configures the main system keyspace for Astarte. As of now, these settings have effect only upon cluster initialization, and will be ignored otherwise.
                   properties:
@@ -13802,6 +13807,11 @@ spec:
                   type: object
                 apiVersion:
                   description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                  type: string
+                astarteInstanceID:
+                  default: ""
+                  description: AstarteInstanceID is the unique ID that is associated with an Astarte instance. This parameter is used to let different Astarte instances employ a shared database infrastructure. Once set, the AstarteInstanceID cannot be changed. Defaults to "".
+                  pattern: ^[a-z]?[a-z0-9]{0,47}$
                   type: string
                 astarteSystemKeyspace:
                   description: astarteSystemKeyspace configures the main system keyspace for Astarte. As of now, these settings have effect only upon cluster initialization, and will be ignored otherwise.

--- a/config/crd/bases/api.astarte-platform.org_astartes.yaml
+++ b/config/crd/bases/api.astarte-platform.org_astartes.yaml
@@ -61,6 +61,14 @@ spec:
                   of an object. Servers should convert recognized schemas to the latest
                   internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                 type: string
+              astarteInstanceID:
+                default: ""
+                description: AstarteInstanceID is the unique ID that is associated
+                  with an Astarte instance. This parameter is used to let different
+                  Astarte instances employ a shared database infrastructure. Once
+                  set, the AstarteInstanceID cannot be changed. Defaults to "".
+                pattern: ^[a-z]?[a-z0-9]{0,47}$
+                type: string
               astarteSystemKeyspace:
                 description: astarteSystemKeyspace configures the main system keyspace
                   for Astarte. As of now, these settings have effect only upon cluster
@@ -24518,6 +24526,14 @@ spec:
                 description: 'APIVersion defines the versioned schema of this representation
                   of an object. Servers should convert recognized schemas to the latest
                   internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              astarteInstanceID:
+                default: ""
+                description: AstarteInstanceID is the unique ID that is associated
+                  with an Astarte instance. This parameter is used to let different
+                  Astarte instances employ a shared database infrastructure. Once
+                  set, the AstarteInstanceID cannot be changed. Defaults to "".
+                pattern: ^[a-z]?[a-z0-9]{0,47}$
                 type: string
               astarteSystemKeyspace:
                 description: astarteSystemKeyspace configures the main system keyspace

--- a/lib/reconcile/astarte_generic_api.go
+++ b/lib/reconcile/astarte_generic_api.go
@@ -236,6 +236,13 @@ func getAstarteGenericAPIEnvVars(deploymentName string, cr *apiv1alpha2.Astarte,
 	// Depending on the component, we might need to add some more stuff.
 	switch component {
 	case apiv1alpha2.AppEngineAPI:
+		if cr.Spec.AstarteInstanceID != "" {
+			ret = append(ret, v1.EnvVar{
+				Name:  "ASTARTE_INSTANCE_ID",
+				Value: cr.Spec.AstarteInstanceID,
+			})
+		}
+
 		ret = appendCassandraConnectionEnvVars(ret, cr)
 
 		// Add Cassandra Nodes
@@ -305,6 +312,12 @@ func getAstarteFlowEnvVars(cr *apiv1alpha2.Astarte) []v1.EnvVar {
 			Name:  "FLOW_REALM_PUBLIC_KEY_PROVIDER",
 			Value: "astarte",
 		},
+	}
+	if cr.Spec.AstarteInstanceID != "" {
+		ret = append(ret, v1.EnvVar{
+			Name:  "ASTARTE_INSTANCE_ID",
+			Value: cr.Spec.AstarteInstanceID,
+		})
 	}
 
 	// Append RabbitMQ variables

--- a/lib/reconcile/astarte_generic_backend.go
+++ b/lib/reconcile/astarte_generic_backend.go
@@ -186,6 +186,13 @@ func getAstarteGenericBackendEnvVars(deploymentName string, replicaIndex, replic
 		Value: getCassandraNodes(cr),
 	})
 
+	if cr.Spec.AstarteInstanceID != "" {
+		ret = append(ret, v1.EnvVar{
+			Name:  "ASTARTE_INSTANCE_ID",
+			Value: cr.Spec.AstarteInstanceID,
+		})
+	}
+
 	eventsExchangeName := cr.Spec.RabbitMQ.EventsExchangeName
 
 	// Depending on the component, we might need to add some more stuff.

--- a/lib/reconcile/vernemq.go
+++ b/lib/reconcile/vernemq.go
@@ -216,6 +216,13 @@ func getVerneMQEnvVars(statefulSetName string, cr *apiv1alpha2.Astarte) []v1.Env
 		},
 	}
 
+	if cr.Spec.AstarteInstanceID != "" {
+		envVars = append(envVars, v1.EnvVar{
+			Name:  "DOCKER_VERNEMQ_ASTARTE_VMQ_PLUGIN__ASTARTE_INSTANCE_ID",
+			Value: cr.Spec.AstarteInstanceID,
+		})
+	}
+
 	// Append RabbitMQ variables (trailing _, as we need two)
 	envVars = appendRabbitMQConnectionEnvVars(envVars, "DOCKER_VERNEMQ_ASTARTE_VMQ_PLUGIN__AMQP_", cr)
 	// Also append env vars for RPC


### PR DESCRIPTION
Add the `astarteInstanceID` field to the Astarte spec.  The parameter is used to let different Astarte instances employ a shared database infrastructure.