### PR TITLE
Workflows: fix CRDs docs generation

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -70,7 +70,7 @@ jobs:
       working-directory: astarte-kubernetes-operator
     # Install Hugo
     - run: |
-        curl -Lo hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v0.121.1/hugo_extended_0.121.1_Linux-64bit.tar.gz
+        curl -Lo hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v0.127.0/hugo_extended_0.127.0_Linux-64bit.tar.gz
         tar -zxvf hugo.tar.gz hugo
       working-directory: astarte-kubernetes-operator
     # Checkout the hugo-book theme


### PR DESCRIPTION
The hugo-book theme is now incompatible with Hugo 0.121.1 (lol).
Update Hugo to 0.127.0 (lel) to make it work again.