### PR TITLE
RabbitMQ: Add deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Use the imperative form for fields in the spec, i.e.: `enabled` --> `enable` in Astarte v1alpha3.
 - Do not remove CRDs when uninstalling the Operator's Helm chart.
+- Add deprecation notice for RabbitMQ managed by Astarte Operator.
 
 ### Removed
 - Remove support for AstarteVoyagerIngress resources.

--- a/docs/documentation/pages/administrator/020-prerequisites.md
+++ b/docs/documentation/pages/administrator/020-prerequisites.md
@@ -39,6 +39,14 @@ for avoiding confusing situations as outlined
 In the end, you won't need to create NGINX ingresses yourself: the Astarte Operator itself will take
 care of this task.
 
+## RabbitMQ
+
+For production environments, consider using RabbitMQ deployed by the [RabbitMQ Cluster Operator]
+(https://www.rabbitmq.com/kubernetes/operator/operator-overview) or any other managed solution that 
+you prefer. The Astarte Operator includes only basic management of RabbitMQ, which is deprecated since 
+v24.5 and as such it should not be relied upon when dealing with production environments. Futher details 
+can be found [here](https://github.com/astarte-platform/astarte-kubernetes-operator/issues/287).
+
 ## Voyager (deprecated)
 
 Until Astarte v1.0.0, the only supported Managed Ingress was the

--- a/lib/reconcile/rabbitmq.go
+++ b/lib/reconcile/rabbitmq.go
@@ -106,6 +106,9 @@ func EnsureRabbitMQ(cr *apiv1alpha2.Astarte, c client.Client, scheme *runtime.Sc
 		return nil
 	}
 
+	// Add deprication notice for rabbitmq deployed by astarte operator
+	log.Info("RabbitMQ support via Astarte Operator will be discontinued. Consider RabbitMQ Cluster Operator or other managed services for production environments.")
+
 	// First of all, check if we need to regenerate the cookie.
 	if err := ensureErlangCookieSecret(statefulSetName+"-cookie", cr, c, scheme); err != nil {
 		return err

--- a/lib/reconcile/rabbitmq.go
+++ b/lib/reconcile/rabbitmq.go
@@ -106,7 +106,7 @@ func EnsureRabbitMQ(cr *apiv1alpha2.Astarte, c client.Client, scheme *runtime.Sc
 		return nil
 	}
 
-	// Add deprication notice for rabbitmq deployed by astarte operator
+	// Add deprecation notice for rabbitmq deployed by astarte operator
 	log.Info("RabbitMQ support via Astarte Operator will be discontinued. Consider RabbitMQ Cluster Operator or other managed services for production environments.")
 
 	// First of all, check if we need to regenerate the cookie.


### PR DESCRIPTION
From future versions, Astarte Operator will no longer provide support for deploying the built-in RabbitMQ.

This change will ensure better maintenance and continuous updates of RabbitMQ in your environment.