### PR TITLE
Next cycle is 24.5

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -61,8 +61,8 @@ jobs:
         sudo sysctl net/netfilter/nf_conntrack_max=131072
     - uses: container-tools/kind-action@v2
       with:
-        version: "v0.20.0"
-        node_image: "kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
+        version: "v0.23.0"
+        node_image: "kindest/node:v1.29.4@sha256:3abb816a5b1061fb15c6e9e60856ec40d56b7b52bcea5f5f1350bc6e2320b6f8"
     - name: Build test image
       run: |
         docker build -t astarte-operator-ci:test -f Dockerfile .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,14 +47,14 @@ jobs:
     strategy:
       matrix:
         testSuite:
-        - "10"
         - "11"
+        - "12"
         kubernetesNodeImage:
-        - "kindest/node:v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8"
-        - "kindest/node:v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb"
-        - "kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
-        - "kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31"
-        - "kindest/node:v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570"
+        - "kindest/node:v1.26.15@sha256:84333e26cae1d70361bb7339efb568df1871419f2019c80f9a12b7e2d485fe19"
+        - "kindest/node:v1.27.13@sha256:17439fa5b32290e3ead39ead1250dca1d822d94a10d26f1981756cd51b24b9d8"
+        - "kindest/node:v1.28.9@sha256:dca54bc6a6079dd34699d53d7d4ffa2e853e46a20cd12d619a09207e35300bd0"
+        - "kindest/node:v1.29.4@sha256:3abb816a5b1061fb15c6e9e60856ec40d56b7b52bcea5f5f1350bc6e2320b6f8"
+        - "kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e"
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
         sudo sysctl net/netfilter/nf_conntrack_max=131072
     - uses: container-tools/kind-action@v2
       with:
-        version: "v0.20.0"
+        version: "v0.23.0"
         node_image: "${{ matrix.kubernetesNodeImage }}"
     - name: Ensure KinD is up
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 23.11.0-dev
+VERSION ?= 24.5.0-dev
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ Cluster](https://docs.astarte-platform.org/astarte-kubernetes-operator/snapshot/
 
 | Kubernetes Version | Supported              | Tested by CI       |
 |--------------------|------------------------|--------------------|
-| v1.24.x            | :large_orange_diamond: | :x:                |
-| v1.25.x            | :white_check_mark:     | :white_check_mark: |
+| v1.25.x            | :large_orange_diamond: | :x:                |
 | v1.26.x            | :white_check_mark:     | :white_check_mark: |
 | v1.27.x            | :white_check_mark:     | :white_check_mark: |
 | v1.28.x            | :white_check_mark:     | :white_check_mark: |
 | v1.29.x            | :white_check_mark:     | :white_check_mark: |
+| v1.30.x            | :white_check_mark:     | :white_check_mark: |
 
 Key:
 
@@ -85,11 +85,9 @@ Key:
 
 | Astarte Operator Version | Astarte Version | Kubernetes Version |
 |:------------------------:|:---------------:|:------------------:|
-| v1.0.0                   | v0.11 - v1.0    | v1.19+             |
-| v1.0.x                   | v0.11 - v1.0    | v1.19+             |
 | v22.11                   | v1.0+           | v1.22+             |
 | v23.5                    | v1.0+           | v1.22+             |
-| v23.11                   | v1.0+           | v1.24+             |
+| v24.5                    | v1.0+           | v1.24+             |
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@
 | 1.0.x   | :x:                |
 | 22.11.x | :white_check_mark: |
 | 23.5.x  | :white_check_mark: |
-| 23.11.x | :white_check_mark: |
+| 24.5.x  | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/charts/astarte-operator/Chart.yaml
+++ b/charts/astarte-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: astarte-operator
 description: The Astarte Kubernetes Operator Helm Chart.
 type: application
 
-version: "23.11.0-dev"
-appVersion: "23.11.0-dev"
+version: "24.5.0-dev"
+appVersion: "24.5.0-dev"
 kubeVersion: ">= 1.19.0-0"
 
 home: https://github.com/astarte-platform/astarte-kubernetes-operator

--- a/docs/documentation/mix.exs
+++ b/docs/documentation/mix.exs
@@ -1,14 +1,14 @@
 defmodule Doc.MixProject do
   use Mix.Project
 
-  @source_ref "release-23.11"
+  @source_ref "release-24.5"
   @source_version String.replace_prefix(@source_ref, "release-", "")
                   |> String.replace("master", "snapshot")
 
   def project do
     [
       app: :doc,
-      version: "23.11.0-dev",
+      version: "24.5.0-dev",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/docs/documentation/pages/upgrade/050-upgrade_2211_235.md
+++ b/docs/documentation/pages/upgrade/050-upgrade_2211_235.md
@@ -4,7 +4,7 @@ This page describes the required steps to upgrade your Astarte cluster from `v22
 `v23.5.x`. Your Astarte instance will **not** need to be upgraded.
 
 Starting from the Astarte Operator `v22.11` release, the old `api.astarte-platform.org/v1alpha1`
-APIs are deprecated and will be removed in the next release (`v23.11`).
+APIs are deprecated and will be removed in the next release (`v24.5`).
 
 In the following, the upgrade path is described.
 

--- a/test/e2e11/deploy_astarte_1.1_test.go
+++ b/test/e2e11/deploy_astarte_1.1_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/astarte-platform/astarte-kubernetes-operator/test/utils"
 )
 
-var target11Version string = "1.1.0-alpha.0"
+var target11Version string = "1.1.1"
 
 var _ = Describe("Astarte controller", func() {
 	Context("When deploying an Astarte resource", func() {

--- a/test/e2e12/astarte_test.go
+++ b/test/e2e12/astarte_test.go
@@ -16,7 +16,7 @@
   limitations under the License.
 */
 
-package e2e10
+package e2e12
 
 import (
 	"path/filepath"
@@ -46,9 +46,9 @@ var testEnv *envtest.Environment
 
 const namespace string = "astarte-test"
 
-func TestAstarte10Deployment(t *testing.T) {
+func TestAstarte12Deployment(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Astarte 1.0 Controller e2e Test Suite")
+	RunSpecs(t, "Astarte 1.2 Controller e2e Test Suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/test/e2e12/deploy_astarte_1.2_test.go
+++ b/test/e2e12/deploy_astarte_1.2_test.go
@@ -16,7 +16,7 @@
   limitations under the License.
 */
 
-package e2e10
+package e2e12
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"github.com/astarte-platform/astarte-kubernetes-operator/test/utils"
 )
 
-var target10Version string = "1.0.4"
+var target12Version string = "1.2.0"
 
 var _ = Describe("Astarte controller", func() {
 	Context("When deploying an Astarte resource", func() {
@@ -36,7 +36,7 @@ var _ = Describe("Astarte controller", func() {
 			By("By creating a new Astarte")
 			exampleAstarte := utils.AstarteTestResource.DeepCopy()
 			exampleAstarte.ObjectMeta.Namespace = namespace
-			exampleAstarte.Spec.Version = target10Version
+			exampleAstarte.Spec.Version = target12Version
 			ctx := context.Background()
 			Expect(k8sClient.Create(ctx, exampleAstarte)).Should(Succeed())
 
@@ -51,7 +51,7 @@ var _ = Describe("Astarte controller", func() {
 			}, utils.DefaultTimeout, utils.DefaultRetryInterval).Should(BeEquivalentTo(v1alpha2.AstarteClusterHealthGreen))
 
 			By("By ensuring all Astarte services are up and running")
-			Expect(utils.EnsureAstarteServicesReadinessUpTo10(namespace, k8sClient)).Should(Succeed())
+			Expect(utils.EnsureAstarteServicesReadinessUpTo12(namespace, k8sClient)).Should(Succeed())
 		})
 		It("Should clean up the cluster after Astarte deletion", func() {
 			By("By deleting the Astarte Resource and waiting for services to go down")

--- a/test/utils/astarte_resource.go
+++ b/test/utils/astarte_resource.go
@@ -117,6 +117,24 @@ var AstarteTestResource *operator.Astarte = &operator.Astarte{
 					v1.ResourceMemory: *resource.NewScaledQuantity(2, resource.Giga),
 				},
 			},
+			Housekeeping: operator.AstarteGenericComponentSpec{
+				API: operator.AstarteGenericAPISpec{
+					AstarteGenericClusteredResource: operator.AstarteGenericClusteredResource{
+						Resources: &v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU: *resource.NewScaledQuantity(400, resource.Milli),
+							},
+						},
+					},
+				},
+				Backend: operator.AstarteGenericClusteredResource{
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU: *resource.NewScaledQuantity(400, resource.Milli),
+						},
+					},
+				},
+			},
 			// TODO: We need to add this here to ensure we don't starve the CI. Remove when it is taken into account
 			// in global resource allocation.
 			// TODO we need to explicitly set Flow's tag. Handle this case as soon as Flow images are tagged

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -42,6 +42,12 @@ const (
 	DefaultCleanupTimeout time.Duration = time.Second * 5
 )
 
+// EnsureAstarteServicesReadinessUpTo12 ensures all existing Astarte components up to 1.2
+func EnsureAstarteServicesReadinessUpTo12(namespace string, c client.Client) error {
+	// No changes in components deployment, just check the previous stuff
+	return EnsureAstarteServicesReadinessUpTo11(namespace, c)
+}
+
 // EnsureAstarteServicesReadinessUpTo11 ensures all existing Astarte components up to 1.1
 func EnsureAstarteServicesReadinessUpTo11(namespace string, c client.Client) error {
 	// No changes in components deployment, just check the previous stuff

--- a/version/version.go
+++ b/version/version.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// Version is the Operator's version
-	Version = "23.11.0-dev"
+	Version = "24.5.0-dev"
 
 	// AstarteVersionConstraintString represents the range of supported Astarte versions for this Operator.
 	// If the Astarte version falls out of this range, reconciliation will be immediately aborted.


### PR DESCRIPTION
Prepare for the next release cycle.

This PR takes care of bumping versions here and there. Since the new operator will be capable of handling Astarte 1.2 instances, adapt tests to reflect this change and ensure that Astarte 1.2 is properly managed.

In addition, tweak the resources allocated for the housekeeping services in the context of the astarte instance used for e2e tests: this change is needed for housekeeping to be up and running.