### PR TITLE
Fix cpu limits computation

### DIFF
--- a/internal/misc/utils.go
+++ b/internal/misc/utils.go
@@ -215,7 +215,7 @@ func GetResourcesForAstarteComponent(cr *apiv2alpha1.Astarte, requestedResources
 	realRequests[v1.ResourceMemory] = *memoryRequests
 
 	// Ensure limits aren't out of boundaries if we changed the requests
-	if cpuLimits.Cmp(*cpuLimits) < 0 {
+	if cpuLimits.Cmp(*cpuRequests) < 0 {
 		cpuLimits = cpuRequests
 	}
 	if memoryLimits.Cmp(*memoryRequests) < 0 {


### PR DESCRIPTION
Compare limits and requests so that a meaningful value for limits can be set when assigning resources to astarte components.