### PR TITLE
Fix issues with values.yaml propagation during Helm installation

### DIFF
--- a/charts/astarte-operator/templates/crds/astartedefaultingresses.ingress.astarte-platform.org.yaml
+++ b/charts/astarte-operator/templates/crds/astartedefaultingresses.ingress.astarte-platform.org.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -213,3 +214,4 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end }}

--- a/charts/astarte-operator/templates/crds/astartes.api.astarte-platform.org.yaml
+++ b/charts/astarte-operator/templates/crds/astartes.api.astarte-platform.org.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -21333,3 +21334,4 @@ spec:
       storage: false
       subresources:
         status: {}
+{{- end }}

--- a/charts/astarte-operator/templates/crds/flows.api.astarte-platform.org.yaml
+++ b/charts/astarte-operator/templates/crds/flows.api.astarte-platform.org.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -649,3 +650,4 @@ spec:
       storage: false
       subresources:
         status: {}
+{{- end }}

--- a/charts/astarte-operator/templates/manager.yaml
+++ b/charts/astarte-operator/templates/manager.yaml
@@ -8,7 +8,7 @@ metadata:
   name: '{{ .Release.Name }}-controller-manager'
   namespace: '{{ .Release.Namespace }}'
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       control-plane: controller-manager
@@ -23,6 +23,7 @@ spec:
         command:
         - /manager
         image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+        imagePullPolicy: '{{ .Values.image.pullPolicy }}'
         name: manager
         ports:
         - containerPort: 9443


### PR DESCRIPTION
Fix issues where replicaCount, installCrds, and
pullPolicy in values.yaml do not propagate correctly during Helm chart installation.
Ensure these values apply properly to resolve deployment issues.