### PR TITLE
Ensure the status of Flows is properly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [24.5.1] - Unreleased
 ### Fixed
 - Properly inject cassandra user credentials in the VerneMQ statefulset.
+- Ensure the status of Flows is properly computed.
 
 ## [24.5.0] - 2024-08-13
 

--- a/controllers/api/flow_controller.go
+++ b/controllers/api/flow_controller.go
@@ -130,13 +130,13 @@ func (r *FlowReconciler) computeFlowStatusResource(reqLogger logr.Logger, instan
 
 	switch {
 	case instance.Status.TotalContainerBlocks == 0:
-		instance.Status.State = apiv1alpha2.FlowStateUnknown
+		newStatus.State = apiv1alpha2.FlowStateUnknown
 	case instance.Status.FailingContainerBlocks > 0:
-		instance.Status.State = apiv1alpha2.FlowStateUnhealthy
+		newStatus.State = apiv1alpha2.FlowStateUnhealthy
 	case instance.Status.TotalContainerBlocks != instance.Status.ReadyContainerBlocks:
-		instance.Status.State = apiv1alpha2.FlowStateUnstable
+		newStatus.State = apiv1alpha2.FlowStateUnstable
 	case instance.Status.TotalContainerBlocks == instance.Status.ReadyContainerBlocks:
-		instance.Status.State = apiv1alpha2.FlowStateFlowing
+		newStatus.State = apiv1alpha2.FlowStateFlowing
 	}
 
 	return newStatus, nil


### PR DESCRIPTION
A wrong assignment prevented the proper status to be set for a Flow. The assignment is now fixed and the status properly returned.