### PR TITLE
fix: add get permission for statefulsets in VerneMQ PolicyRules

### DIFF
--- a/lib/reconcile/vernemq.go
+++ b/lib/reconcile/vernemq.go
@@ -461,11 +461,18 @@ func getVerneMQVolumeMounts(dataVolumeName string, cr *apiv1alpha2.Astarte) []v1
 }
 
 func getVerneMQPolicyRules() []rbacv1.PolicyRule {
+	// Reminder: The new "statefulsets" permissions below are required for Astarte > 1.2 (current snapshot included).
+	// Old permissions will no longer be needed when we support Astarte >= 1.3.
 	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
 			Resources: []string{"pods", "services"},
 			Verbs:     []string{"list", "get"},
+		},
+		{
+			APIGroups: []string{"apps"},
+			Resources: []string{"statefulsets"},
+			Verbs:     []string{"get"},
 		},
 	}
 }


### PR DESCRIPTION
This PR implements the changes suggested by @Annopaolo. Due to an issue with the VerneMQ snapshot update to version 2.0.1, VerneMQ pods now require a service account with 'get' permission on statefulsets for clustering (even though we aren't using clustering). The specific error encountered was:

```
Permission error: Cannot access URL apis/apps/v1/namespaces/astarte/statefulsets/astarte-vernemq: "Forbidden"
403
"statefulsets.apps \"astarte-vernemq\" is forbidden: User \"system:serviceaccount:astarte:astarte-vernemq\" cannot get resource \"statefulsets\" in API group \"apps\" in the namespace \"astarte\""
```