### PR TITLE
Prepare operator for next dev cycle (25.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [25.5.0] - Unreleased
 ### Changed
 - Forward port changes from release-24.5
 - Upgrade Operator SDK to v1.38.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 24.11.0-dev
+VERSION ?= 25.5.0-dev
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ Key:
 
 | Astarte Operator Version | Astarte Version | Kubernetes Version |
 |:------------------------:|:---------------:|:------------------:|
-| v22.11                   | v1.0+           | v1.22+             |
 | v23.5                    | v1.0+           | v1.22+             |
 | v24.5                    | v1.0+           | v1.24+             |
+| v25.5                    | v1.0+           | v1.24+             |
+
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,9 +13,11 @@
 | 0.10.x  | :x:                |
 | 0.11.x  | :x:                |
 | 1.0.x   | :x:                |
-| 22.11.x | :white_check_mark: |
+| 22.11.x | :x:                |
 | 23.5.x  | :white_check_mark: |
 | 24.5.x  | :white_check_mark: |
+| 25.5.x  | :white_check_mark: |
+
 
 ## Reporting a Vulnerability
 

--- a/charts/astarte-operator/Chart.yaml
+++ b/charts/astarte-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: astarte-operator
 description: The Astarte Kubernetes Operator Helm Chart.
 type: application
 
-version: "24.11.0-dev"
-appVersion: "24.11.0-dev"
+version: "25.5.0-dev"
+appVersion: "25.5.0-dev"
 kubeVersion: ">= 1.19.0-0"
 
 home: https://github.com/astarte-platform/astarte-kubernetes-operator
@@ -16,8 +16,6 @@ keywords:
   - iot
   - dataorchestration
 maintainers:
-  - name: drf
-    email: dario.freddi@ispirata.com
   - name: matt-mazzucato
     email: mattia.mazzucato@secomind.com
   - name: annopaolo

--- a/charts/astarte-operator/README.md
+++ b/charts/astarte-operator/README.md
@@ -1,6 +1,6 @@
 # astarte-operator
 
-![Version: 24.11.0-dev](https://img.shields.io/badge/Version-24.11.0--dev-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 24.11.0-dev](https://img.shields.io/badge/AppVersion-24.11.0--dev-informational?style=flat-square)
+![Version: 25.5.0-dev](https://img.shields.io/badge/Version-25.5.0--dev-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.5.0-dev](https://img.shields.io/badge/AppVersion-25.5.0--dev-informational?style=flat-square)
 
 The Astarte Kubernetes Operator Helm Chart.
 
@@ -10,7 +10,6 @@ The Astarte Kubernetes Operator Helm Chart.
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| drf | dario.freddi@ispirata.com |  |
 | matt-mazzucato | mattia.mazzucato@secomind.com |  |
 | annopaolo | arnaldo.cesco@secomind.com |  |
 
@@ -20,7 +19,7 @@ The Astarte Kubernetes Operator Helm Chart.
 
 ## Requirements
 
-Kubernetes: `>= 1.19.0-0`
+Kubernetes: `>= 1.24.0-0`
 
 ## Values
 
@@ -32,4 +31,3 @@ Kubernetes: `>= 1.19.0-0`
 | installCRDs | bool | `true` | Whether or not to install Astarte CRDs. |
 | replicaCount | int | `1` | The number of Astarte Operator replicas in your cluster. |
 | resources | object | `{"limits":{"cpu":"100m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resources to assign to each Astarte Operator instance. |
-

--- a/config/manifests/bases/astarte-kubernetes-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/astarte-kubernetes-operator.clusterserviceversion.yaml
@@ -63,8 +63,6 @@ spec:
   - name: Astarte Kubernetes Operator
     url: https://github.com/astarte-platform/astarte-kubernetes-operator
   maintainers:
-  - email: dario.freddi@ispirata.com
-    name: drf
   - email: mattia.mazzucato@secomind.com
     name: matt-mazzucato
   - email: arnaldo.cesco@secomind.com

--- a/docs/documentation/mix.exs
+++ b/docs/documentation/mix.exs
@@ -8,7 +8,7 @@ defmodule Doc.MixProject do
   def project do
     [
       app: :doc,
-      version: "24.11.0-dev",
+      version: "25.5.0-dev",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/docs/documentation/pages/administrator/001-intro_administrator.cheatmd
+++ b/docs/documentation/pages/administrator/001-intro_administrator.cheatmd
@@ -26,6 +26,7 @@ for what concerns its components and 3rd party services.
 | v22.11                   | v1.0+           | v1.22+             |
 | v23.5                    | v1.0+           | v1.22+             |
 | v24.5                    | v1.0+           | v1.24+             |
+| v25.5                    | v1.0+           | v1.24+             |
 
 **Notes**:
 * starting from Kubernetes 1.22, the AstarteVoyagerIngress resource is not supported anymore;

--- a/docs/documentation/pages/administrator/020-prerequisites.md
+++ b/docs/documentation/pages/administrator/020-prerequisites.md
@@ -54,7 +54,7 @@ default configuration (installed in namespace `cert-manager` as `cert-manager`).
 `cert-manager` in your cluster already you don't need to take any action - otherwise, you will need
 to install it.
 
-Astarte is actively tested with `cert-manager` 1.13, but should work with any 1.0+ releases of
+Astarte is actively tested with `cert-manager` 1.16.3, but should work with any 1.0+ releases of
 `cert-manager`. If your `cert-manager` release is outdated, please consider upgrading to a newer
 version according to [this guide](https://cert-manager.io/docs/installation/upgrading/).
 
@@ -70,8 +70,8 @@ $ kubectl create namespace cert-manager
 $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.14.7 \
-  --set installCRDs=true
+  --version v1.16.3 \
+  --set crds.enabled=true
 ```
 
 This will install `cert-manager` and its CRDs in the cluster.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// Version is the Operator's version
-	Version = "24.11.0-dev"
+	Version = "25.5.0-dev"
 
 	// AstarteVersionConstraintString represents the range of supported Astarte versions for this Operator.
 	// If the Astarte version falls out of this range, reconciliation will be immediately aborted.


### PR DESCRIPTION
After completing the migration of operator-sdk (https://github.com/astarte-platform/astarte-kubernetes-operator/pull/405):
- dependencies shall be bumped
- the 25.5.0-dev cycle shall be prepared
- fix inconsistencies in the docs, README, helm chart, etc