### PR TITLE
Allow Astarte > 1.2.0 to use Erlang-based RPCs between services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - AppEngine, DUP, VerneMQ have `get` and `list` permissions on
   endpoints, pods and services.
 
+### Changed
+- AppEngine, DUP, VerneMQ use the same Erlang cookie.
+  This will not affect Astartes up to and including 1.2.0.
+
 ## [24.5.1] - 2025-01-10
 ### Fixed
 - Properly inject cassandra user credentials in the VerneMQ statefulset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [24.5.2] - Unreleased
+### Added
+- AppEngine, DUP, VerneMQ have `get` and `list` permissions on
+  endpoints, pods and services.
+
 ## [24.5.1] - 2025-01-10
 ### Fixed
 - Properly inject cassandra user credentials in the VerneMQ statefulset.

--- a/lib/controllerutils/astarte_controller.go
+++ b/lib/controllerutils/astarte_controller.go
@@ -297,6 +297,11 @@ func (r *ReconcileHelper) ReconcileAstarteResources(instance *apiv1alpha2.Astart
 		return err
 	}
 
+	// Then, make sure the prerequisite for Erlang Clustering is there
+	if err := recon.EnsureErlangClusteringCookie(instance, r.Client, r.Scheme); err != nil {
+		return err
+	}
+
 	// Give priority to PriorityClasses
 	if err := recon.EnsureAstartePriorityClasses(instance, r.Client, r.Scheme); err != nil {
 		return err

--- a/lib/reconcile/astarte_generic_api.go
+++ b/lib/reconcile/astarte_generic_api.go
@@ -82,6 +82,12 @@ func EnsureAstarteGenericAPIWithCustomProbe(cr *apiv1alpha2.Astarte, api apiv1al
 		}
 	}
 
+	if component == apiv1alpha2.AppEngineAPI {
+		if err := reconcileStandardRBACForClusteringForApp(deploymentName, GetAstarteClusteredServicePolicyRules(), cr, c, scheme); err != nil {
+			return err
+		}
+	}
+
 	deploymentSpec := appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: matchLabels,
@@ -167,6 +173,13 @@ func getAstarteGenericAPIPodSpec(deploymentName string, cr *apiv1alpha2.Astarte,
 			},
 		},
 		Volumes: getAstarteGenericAPIVolumes(cr, component),
+	}
+
+	if component == apiv1alpha2.AppEngineAPI {
+		serviceAccountName := deploymentName
+		if pointy.BoolValue(cr.Spec.RBAC, true) {
+			ps.ServiceAccountName = serviceAccountName
+		}
 	}
 
 	if component == apiv1alpha2.FlowComponent {

--- a/lib/reconcile/astarte_generic_api.go
+++ b/lib/reconcile/astarte_generic_api.go
@@ -289,6 +289,13 @@ func getAstarteGenericAPIEnvVars(deploymentName string, cr *apiv1alpha2.Astarte,
 					Value: cr.Spec.Components.AppengineAPI.RoomEventsExchangeName,
 				})
 		}
+
+		ret = append(ret,
+			v1.EnvVar{
+				Name:  "CLUSTERING_STRATEGY",
+				Value: "kubernetes",
+			})
+
 	case apiv1alpha2.HousekeepingAPI:
 		// Add Public Key Information
 		ret = append(ret, v1.EnvVar{

--- a/lib/reconcile/astarte_generic_backend.go
+++ b/lib/reconcile/astarte_generic_backend.go
@@ -318,6 +318,12 @@ func getAstarteDataUpdaterPlantBackendEnvVars(replicaIndex, replicas int, events
 			})
 	}
 
+	ret = append(ret,
+		v1.EnvVar{
+			Name:  "CLUSTERING_STRATEGY",
+			Value: "kubernetes",
+		})
+
 	return ret
 }
 

--- a/lib/reconcile/astarte_generic_backend.go
+++ b/lib/reconcile/astarte_generic_backend.go
@@ -75,6 +75,13 @@ func EnsureAstarteGenericBackendWithCustomProbe(cr *apiv1alpha2.Astarte, backend
 		return nil
 	}
 
+	// Ensure we reconcile with the RBAC Roles, if needed.
+	if pointy.BoolValue(cr.Spec.RBAC, true) {
+		if err := reconcileStandardRBACForClusteringForApp(deploymentName, GetAstarteClusteredServicePolicyRules(), cr, c, scheme); err != nil {
+			return err
+		}
+	}
+
 	// First of all, check if we need to regenerate the cookie.
 	if err := ensureErlangCookieSecret(deploymentName+"-cookie", cr, c, scheme); err != nil {
 		return err
@@ -122,8 +129,14 @@ func EnsureAstarteGenericBackendWithCustomProbe(cr *apiv1alpha2.Astarte, backend
 
 func getAstarteGenericBackendPodSpec(deploymentName string, replicaIndex, replicas int, cr *apiv1alpha2.Astarte, backend apiv1alpha2.AstarteGenericClusteredResource,
 	component apiv1alpha2.AstarteComponent, customProbe *v1.Probe) v1.PodSpec {
+	serviceAccountName := deploymentName
+	if pointy.BoolValue(cr.Spec.RBAC, false) {
+		serviceAccountName = ""
+	}
+
 	ps := v1.PodSpec{
 		TerminationGracePeriodSeconds: pointy.Int64(30),
+		ServiceAccountName:            serviceAccountName,
 		ImagePullSecrets:              cr.Spec.ImagePullSecrets,
 		Affinity:                      getAffinityForClusteredResource(deploymentName, backend),
 		Containers: []v1.Container{

--- a/lib/reconcile/common.go
+++ b/lib/reconcile/common.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -110,4 +111,15 @@ func EnsureGenericErlangConfiguration(cr *apiv1alpha2.Astarte, c client.Client, 
 
 	_, err := misc.ReconcileConfigMap(genericErlangConfigurationMapName, genericErlangConfigurationMapData, cr, c, scheme, log)
 	return err
+}
+
+func GetAstarteClusteredServicePolicyRules() []rbacv1.PolicyRule {
+	// This is needed for Astarte > 1.2.0, as DUP/AppEngine/VerneMQ are clustered using Erlang.
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods", "endpoints"},
+			Verbs:     []string{"list", "get"},
+		},
+	}
 }

--- a/lib/reconcile/common.go
+++ b/lib/reconcile/common.go
@@ -113,6 +113,13 @@ func EnsureGenericErlangConfiguration(cr *apiv1alpha2.Astarte, c client.Client, 
 	return err
 }
 
+// EnsureErlangClusteringCookie reconciles the Erlang Cookie Secret needed for Astarte services RPCs
+func EnsureErlangClusteringCookie(cr *apiv1alpha2.Astarte, c client.Client, scheme *runtime.Scheme) error {
+	secretName := cr.Name + "-erlang-clustering-cookie"
+
+	return ensureErlangCookieSecret(secretName, cr, c, scheme)
+}
+
 func GetAstarteClusteredServicePolicyRules() []rbacv1.PolicyRule {
 	// This is needed for Astarte > 1.2.0, as DUP/AppEngine/VerneMQ are clustered using Erlang.
 	return []rbacv1.PolicyRule{

--- a/lib/reconcile/utils.go
+++ b/lib/reconcile/utils.go
@@ -46,7 +46,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/astarte-platform/astarte-kubernetes-operator/apis/api/v1alpha2"
 	apiv1alpha2 "github.com/astarte-platform/astarte-kubernetes-operator/apis/api/v1alpha2"
 	"github.com/astarte-platform/astarte-kubernetes-operator/lib/misc"
 	"github.com/astarte-platform/astarte-kubernetes-operator/version"
@@ -359,13 +358,22 @@ func getAstarteCommonEnvVars(deploymentName string, cr *apiv1alpha2.Astarte, bac
 			Name:  "RELEASE_NAME",
 			Value: component.DockerImageName(),
 		},
-		{
+	}
+
+	// We need extra care for Erlang cookie, as some services share the same one
+	if component == apiv1alpha2.AppEngineAPI || component == apiv1alpha2.DataUpdaterPlant {
+		ret = append(ret, v1.EnvVar{
+			Name:      "ERLANG_COOKIE",
+			ValueFrom: getErlangClusteringCookieSecretReference(cr),
+		})
+	} else {
+		ret = append(ret, v1.EnvVar{
 			Name: "ERLANG_COOKIE",
 			ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{
 				LocalObjectReference: v1.LocalObjectReference{Name: deploymentName + "-cookie"},
 				Key:                  "erlang-cookie",
 			}},
-		},
+		})
 	}
 
 	// Add Port (needed for all components, since we also have metrics)
@@ -545,6 +553,17 @@ func appendRabbitMQConnectionEnvVars(ret []v1.EnvVar, prefix string, cr *apiv1al
 
 	// Here we go
 	return ret
+}
+
+func getErlangClusteringCookieSecretReference(cr *apiv1alpha2.Astarte) *v1.EnvVarSource {
+	return &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{Name: getErlangClusteringCookieSecretName(cr)},
+		Key:                  "erlang-cookie",
+	}}
+}
+
+func getErlangClusteringCookieSecretName(cr *apiv1alpha2.Astarte) string {
+	return cr.Name + "-erlang-clustering-cookie"
 }
 
 func getAstarteCommonVolumes(cr *apiv1alpha2.Astarte) []v1.Volume {

--- a/lib/reconcile/utils.go
+++ b/lib/reconcile/utils.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/astarte-platform/astarte-kubernetes-operator/apis/api/v1alpha2"
 	apiv1alpha2 "github.com/astarte-platform/astarte-kubernetes-operator/apis/api/v1alpha2"
 	"github.com/astarte-platform/astarte-kubernetes-operator/lib/misc"
 	"github.com/astarte-platform/astarte-kubernetes-operator/version"

--- a/lib/reconcile/vernemq.go
+++ b/lib/reconcile/vernemq.go
@@ -468,7 +468,7 @@ func getVerneMQPolicyRules() []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
-			Resources: []string{"pods", "services"},
+			Resources: []string{"pods", "services", "endpoints"},
 			Verbs:     []string{"list", "get"},
 		},
 		{

--- a/lib/reconcile/vernemq.go
+++ b/lib/reconcile/vernemq.go
@@ -214,6 +214,10 @@ func getVerneMQEnvVars(statefulSetName string, cr *apiv1alpha2.Astarte) []v1.Env
 			Name:  "DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR",
 			Value: "app=" + statefulSetName,
 		},
+		{
+			Name:      "ERLANG_COOKIE",
+			ValueFrom: getErlangClusteringCookieSecretReference(cr),
+		},
 	}
 
 	if cr.Spec.AstarteInstanceID != "" {


### PR DESCRIPTION
In order to allow Erlang-based RPCs, DUP, AppEngine and VerneMQ require more RBAC permissions (necessary for node discorvery) and to share the same Erlang cookie (necessary for distribution). Add that.

This will not have visible effects on Astartes up to (and including) 1.2.0.