### PR TITLE
VerneMQ: it's `RELEASE_`, not `ERLANG_` cookie!

### DIFF
--- a/lib/reconcile/vernemq.go
+++ b/lib/reconcile/vernemq.go
@@ -215,7 +215,7 @@ func getVerneMQEnvVars(statefulSetName string, cr *apiv1alpha2.Astarte) []v1.Env
 			Value: "app=" + statefulSetName,
 		},
 		{
-			Name:      "ERLANG_COOKIE",
+			Name:      "RELEASE_COOKIE",
 			ValueFrom: getErlangClusteringCookieSecretReference(cr),
 		},
 	}


### PR DESCRIPTION
Make sure the right env is set to configure Erlang clustering. See https://github.com/astarte-platform/astarte_vmq_plugin/blob/184834baabf4c505b72f14e68f6586fa6f696d87/CHANGELOG.md?plain=1#L9