### PR TITLE
fix: set E2E global timeout to 1h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,14 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
+# Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
+# The default timeout is 10m, this can cause problems in the E2E test suite where we have timeouts for each step.
+# If you want to change timeouts of E2E please change it in the E2E test. The timeout here is a upper-bound protection against test without explicit timeouts that could take hours.
+.PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
+test-e2e:
+	go test ./test/e2e/ -v -ginkgo.v -timeout 1h
+ 
+
 ##@ Build
 
 .PHONY: build


### PR DESCRIPTION
By default, the 'go test' command has a 10m timeout (https://pkg.go.dev/cmd/go#hdr-Testing_flags). This goes against our E2E test suite where each step can have a timeout higher than 10m. The global timeout flag was expiring on different random steps, causing troubles while identifying the actual failing cause.

Signed-off-by: Luca Marchiori <luca.marchiori@secomind.com>