### PR TITLE
chore(ci): bump k8s and KinD versions on E2E test CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,9 +50,9 @@ jobs:
       matrix:
         kubernetesNodeImage:
         - "kindest/node:v1.33.2@sha256:c55080dc5be4f2cc242e6966fdf97bb62282e1cd818a28223cf536db8b0fddf4"
-        - "kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f"
-        - "kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87"
-        - "kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507"
+        - "kindest/node:v1.32.5@sha256:5d5a4d793d2a3d9727013b8b0cf6c95008c71abeb547759a273ef27e9c564984"
+        - "kindest/node:v1.31.9@sha256:b94a3a6c06198d17f59cca8c6f486236fa05e2fb359cbd75dabbfc348a10b211"
+        - "kindest/node:v1.30.13@sha256:cf819926d6f5ba996f7489fa18a38156f952f5dd172395da7d83f734190e95da"
       fail-fast: false
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,6 @@ jobs:
         - "kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f"
         - "kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87"
         - "kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507"
-        - "kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29"
       fail-fast: false
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,7 @@ jobs:
         sudo sysctl net/netfilter/nf_conntrack_max=131072
     - uses: container-tools/kind-action@v2
       with:
-        version: "v0.27.0"
+        version: "v0.29.0"
         node_image: "${{ matrix.kubernetesNodeImage }}"
     - name: Ensure KinD is up
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,7 @@ jobs:
     strategy:
       matrix:
         kubernetesNodeImage:
+        - "kindest/node:v1.33.2@sha256:c55080dc5be4f2cc242e6966fdf97bb62282e1cd818a28223cf536db8b0fddf4"
         - "kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f"
         - "kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87"
         - "kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Forward port changes from release-24.5
 - Upgrade Operator SDK to v1.38.
+- Add Kubernetes 1.33 to the supported list.
+- Add E2E tests for Kubernetes 1.33 and remove tests for Kubernetes 1.29.
 
 ### Fixed
 - Fix the propagation of replicaCount, installCrds, and pullPolicy values

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ Cluster](https://docs.astarte-platform.org/astarte-kubernetes-operator/snapshot/
 |--------------------|------------------------|--------------------|
 | v1.27.x            | :large_orange_diamond: | :x:                |
 | v1.28.x            | :large_orange_diamond: | :x:                |
-| v1.29.x            | :white_check_mark:     | :white_check_mark: |
+| v1.29.x            | :large_orange_diamond: | :x:                |
 | v1.30.x            | :white_check_mark:     | :white_check_mark: |
 | v1.31.x            | :white_check_mark:     | :white_check_mark: |
 | v1.32.x            | :white_check_mark:     | :white_check_mark: |
+| v1.33.x            | :white_check_mark:     | :white_check_mark: |
 
 Key:
 


### PR DESCRIPTION
- [chore: add k8s v1.33.2 to e2e tests](https://github.com/astarte-platform/astarte-kubernetes-operator/pull/426/commits/c03b71831c2b08a37bc65f599a7f92c98cd667aa) 
- [chore: remove k8s v1.29.14 from e2e tests](https://github.com/astarte-platform/astarte-kubernetes-operator/pull/426/commits/807f69e40f6d1b66e1e5c07d9422a753eeb8dde0)
- [chore: bump k8s minors of v1.32.*, 1.31.*, 1.30.* in e2e tests](https://github.com/astarte-platform/astarte-kubernetes-operator/pull/426/commits/3b3d215f00caaf8f4adabd52239522dfafefc1ca)
- [chore: bump KinD version for e2e tests](https://github.com/astarte-platform/astarte-kubernetes-operator/pull/426/commits/38a9009a12d17f7113e5c1ad720431a8f4f97d9e)
- [chore: update readme and changelog with new k8s version support](https://github.com/astarte-platform/astarte-kubernetes-operator/pull/426/commits/1a983622e9045498181c7125ce9bcb238e1d9607)