### PR TITLE
Fix HPA race condition on initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix the propagation of replicaCount, installCrds, and pullPolicy values
   in values.yaml during Helm chart installation.
 - Fix E2E tests for Astarte v1.3+ and Astarte Operator v25.5+.
+- Fix HPA race condition on initialization (#397).
+  If the HPA reports 0 desired replicas, the operator will ignore the HPA and use
+  the replica count from the Astarte custom resource instead.
 
 ## [24.5.2] - Unreleased
 ### Added


### PR DESCRIPTION
When an HPA is created for a resource, it can take some time for the metrics to become available. During this time, the HPA may report a desired replica count of 0, which would cause the Astarte operator to scale down the resource to 0 replicas.

This commit adds a protection mechanism to the operator to prevent this from happening. If the HPA reports 0 desired replicas, the operator will ignore the HPA and use the replica count from the Astarte custom resource instead. This prevents the operator from scaling down the resource to 0 replicas while the HPA is initializing. ISSUE: https://github.com/astarte-platform/astarte-kubernetes-operator/issues/397