### PR TITLE
fix: add missing env variables

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: local-registry/astarte-kubernetes-operator
+  newTag: 25.5.0-dev

--- a/internal/reconcile/astarte_generic_backend.go
+++ b/internal/reconcile/astarte_generic_backend.go
@@ -200,49 +200,105 @@ func getAstarteGenericBackendEnvVars(deploymentName string, replicaIndex, replic
 		})
 	}
 
-	eventsExchangeName := cr.Spec.RabbitMQ.EventsExchangeName
-
-	// Depending on the component, we might need to add some more stuff.
+	// Depending on the component, add dedicated env vars for it
 	switch component {
 	case apiv2alpha1.DataUpdaterPlant:
-		ret = append(ret, getAstarteDataUpdaterPlantBackendEnvVars(replicaIndex, replicas, eventsExchangeName, cr)...)
+		ret = append(ret, getAstarteDataUpdaterPlantBackendEnvVars(replicaIndex, replicas, cr)...)
 	case apiv2alpha1.TriggerEngine:
-		// Add RabbitMQ variables
-		ret = appendRabbitMQConnectionEnvVars(ret, "TRIGGER_ENGINE_AMQP_CONSUMER", cr)
+		ret = append(ret, getTriggerEngineBackendEnvVars(cr)...)
+	case apiv2alpha1.AppEngineAPI:
+		ret = append(ret, getAppEngineAPIEnvVars(cr)...)
+	case apiv2alpha1.Dashboard:
+		// Nothing special for now
+	}
 
-		if eventsExchangeName != "" {
-			ret = append(ret,
-				v1.EnvVar{
-					Name:  "TRIGGER_ENGINE_AMQP_EVENTS_EXCHANGE_NAME",
-					Value: eventsExchangeName,
-				})
-		}
+	return ret
+}
 
-		if cr.Spec.Components.AppengineAPI.RoomEventsQueueName != "" {
-			ret = append(ret,
-				v1.EnvVar{
-					Name:  "TRIGGER_ENGINE_AMQP_EVENTS_QUEUE_NAME",
-					Value: cr.Spec.Components.AppengineAPI.RoomEventsQueueName,
-				})
-		}
+func getAppEngineAPIEnvVars(cr *apiv2alpha1.Astarte) []v1.EnvVar {
+	ret := []v1.EnvVar{}
 
-		if cr.Spec.Components.TriggerEngine.EventsRoutingKey != "" {
-			ret = append(ret,
-				v1.EnvVar{
-					Name:  "TRIGGER_ENGINE_AMQP_EVENTS_ROUTING_KEY",
-					Value: cr.Spec.Components.TriggerEngine.EventsRoutingKey,
-				})
-		}
+	ret = appendRabbitMQConnectionEnvVars(ret, "APPENGINE_API_ROOMS_AMQP_CLIENT", cr)
+
+	if cr.Spec.AstarteInstanceID != "" {
+		ret = append(ret, v1.EnvVar{
+			Name:  "ASTARTE_INSTANCE_ID",
+			Value: cr.Spec.AstarteInstanceID,
+		})
+	}
+
+	// Add Cassandra Nodes
+	ret = append(ret, v1.EnvVar{
+		Name:  "CASSANDRA_NODES",
+		Value: getCassandraNodes(cr),
+	})
+
+	ret = append(ret,
+		v1.EnvVar{
+			Name:  "APPENGINE_API_MAX_RESULTS_LIMIT",
+			Value: strconv.Itoa(getAppEngineAPIMaxResultslimit(cr)),
+		},
+	)
+
+	if cr.Spec.Components.AppengineAPI.RoomEventsQueueName != "" {
+		ret = append(ret,
+			v1.EnvVar{
+				Name:  "APPENGINE_API_ROOMS_EVENTS_QUEUE_NAME",
+				Value: cr.Spec.Components.AppengineAPI.RoomEventsQueueName,
+			})
+	}
+
+	if cr.Spec.Components.AppengineAPI.RoomEventsExchangeName != "" {
+		ret = append(ret,
+			v1.EnvVar{
+				Name:  "APPENGINE_API_ROOMS_EVENTS_EXCHANGE_NAME",
+				Value: cr.Spec.Components.AppengineAPI.RoomEventsExchangeName,
+			})
 	}
 	return ret
 }
 
-func getAstarteDataUpdaterPlantBackendEnvVars(replicaIndex, replicas int, eventsExchangeName string, cr *apiv2alpha1.Astarte) []v1.EnvVar {
+func getTriggerEngineBackendEnvVars(cr *apiv2alpha1.Astarte) []v1.EnvVar {
 	ret := []v1.EnvVar{}
+	ret = appendRabbitMQConnectionEnvVars(ret, "TRIGGER_ENGINE_AMQP_CONSUMER", cr)
+
+	eventsExchangeName := cr.Spec.RabbitMQ.EventsExchangeName
+
+	if eventsExchangeName != "" {
+		ret = append(ret,
+			v1.EnvVar{
+				Name:  "TRIGGER_ENGINE_AMQP_EVENTS_EXCHANGE_NAME",
+				Value: eventsExchangeName,
+			})
+	}
+
+	if cr.Spec.Components.AppengineAPI.RoomEventsQueueName != "" {
+		ret = append(ret,
+			v1.EnvVar{
+				Name:  "TRIGGER_ENGINE_AMQP_EVENTS_QUEUE_NAME",
+				Value: cr.Spec.Components.AppengineAPI.RoomEventsQueueName,
+			})
+	}
+
+	if cr.Spec.Components.TriggerEngine.EventsRoutingKey != "" {
+		ret = append(ret,
+			v1.EnvVar{
+				Name:  "TRIGGER_ENGINE_AMQP_EVENTS_ROUTING_KEY",
+				Value: cr.Spec.Components.TriggerEngine.EventsRoutingKey,
+			})
+	}
+
+	return ret
+}
+
+func getAstarteDataUpdaterPlantBackendEnvVars(replicaIndex, replicas int, cr *apiv2alpha1.Astarte) []v1.EnvVar {
+	ret := []v1.EnvVar{}
+	eventsExchangeName := cr.Spec.RabbitMQ.EventsExchangeName
 
 	// Append RabbitMQ variables for both Consumer and Producer
 	ret = appendRabbitMQConnectionEnvVars(ret, "DATA_UPDATER_PLANT_AMQP_CONSUMER", cr)
 	ret = appendRabbitMQConnectionEnvVars(ret, "DATA_UPDATER_PLANT_AMQP_PRODUCER", cr)
+	ret = appendRabbitMQConnectionEnvVars(ret, "DATA_UPDATER_PLANT_AMQP_TRIGGERS_PRODUCER", cr)
 
 	if eventsExchangeName != "" {
 		ret = append(ret,

--- a/test/manifests/api_v2alpha1_astarte_1.3.yaml
+++ b/test/manifests/api_v2alpha1_astarte_1.3.yaml
@@ -44,31 +44,6 @@ spec:
       image: "docker.io/astarte/astarte_realm_management:1.3-snapshot"
     dataUpdaterPlant:
       image: "docker.io/astarte/astarte_data_updater_plant:1.3-snapshot"
-      additionalEnv:
-      - name: "DATA_UPDATER_PLANT_AMQP_TRIGGERS_PRODUCER_HOST"
-        value: "rabbitmq.rabbitmq.svc.cluster.local"
-      - name: "DATA_UPDATER_PLANT_AMQP_TRIGGERS_PRODUCER_USERNAME"
-        valueFrom:
-          secretKeyRef:
-            name: rabbitmq-connection-secret
-            key: username
-      - name: "DATA_UPDATER_PLANT_AMQP_TRIGGERS_PRODUCER_PASSWORD"
-        valueFrom:
-          secretKeyRef:
-            name: rabbitmq-connection-secret
-            key: password
-      - name: "DATA_UPDATER_PLANT_AMQP_TRIGGERS_PRODUCER_VIRTUAL_HOST"
-        value: "/"
-      - name: "DATA_UPDATER_PLANT_AMQP_TRIGGERS_PRODUCER_PORT"
-        value: "5672"
-      - name: "DATA_UPDATER_PLANT_AMQP_TRIGGERS_PRODUCER_SSL_ENABLED"
-        value: "false"
-      - name: "DATA_UPDATER_PLANT_AMQP_TRIGGERS_PRODUCER_SSL_CA_FILE"
-        value: "/etc/ssl/certs/ca.crt"
-      - name: "DATA_UPDATER_PLANT_AMQP_TRIGGERS_PRODUCER_SSL_DISABLE_SNI"
-        value: "false"
-      - name: "DATA_UPDATER_PLANT_AMQP_TRIGGERS_PRODUCER_SSL_CUSTOM_SNI"
-        value: "rabbitmq.rabbitmq.svc.cluster.local"
     appengineApi:
       image: "docker.io/astarte/astarte_appengine_api:1.3-snapshot"
     pairing:
@@ -77,37 +52,6 @@ spec:
       image: "docker.io/astarte/astarte_trigger_engine:1.3-snapshot"
     housekeeping:
       image: "docker.io/astarte/astarte_housekeeping:1.3-snapshot"
-      additionalEnv:
-        - name: "HOUSEKEEPING_AMQP_HOST"
-          value: "rabbitmq.rabbitmq.svc.cluster.local"
-        - name: "HOUSEKEEPING_AMQP_PORT"
-          value: "5672"
-        - name: "HOUSEKEEPING_AMQP_USERNAME"
-          valueFrom:
-            secretKeyRef:
-              name: rabbitmq-connection-secret
-              key: username
-        - name: "HOUSEKEEPING_AMQP_PASSWORD"
-          valueFrom:
-            secretKeyRef:
-              name: rabbitmq-connection-secret
-              key: password
-        - name: "HOUSEKEEPING_AMQP_SSL_ENABLED"
-          value: "false"
-        - name: "HOUSEKEEPING_AMQP_SSL_CA_FILE"
-          value: "/etc/ssl/certs/ca.crt"
-        - name: "HOUSEKEEPING_AMQP_SSL_DISABLE_SNI"
-          value: "false"
-        - name: "HOUSEKEEPING_AMQP_SSL_CUSTOM_SNI"
-          value: "rabbitmq.rabbitmq.svc.cluster.local"
-        - name: "VERNEMQ_CLUSTERING_KUBERNETES_SERVICE_NAME"
-          value: "example-astarte-vernemq"
-        - name: "HOUSEKEEPING_AMQP_MANAGEMENT_PORT"
-          value: "15672"
-        - name: "HOUSEKEEPING_ASTARTE_KEYSPACE_REPLICATION_STRATEGY"
-          value: "SimpleStrategy"
-        - name: "HOUSEKEEPING_ASTARTE_KEYSPACE_REPLICATION_FACTOR"
-          value: "1"
     dashboard:
       image: "docker.io/astarte/astarte-dashboard:1.2.1-rc.0"
       deploy: true


### PR DESCRIPTION
- Handle the injection of the new env variables of astarte services
- Remove env variables defined temporarily in the test manifest
- Refactor the injection of the env variables to better support squashed services

With this commit, we support changes introduced in: https://github.com/astarte-platform/astarte/blob/6ef46d6ac4db465deee718bf9e5a58f7c40129f4/CHANGELOG.md