### PR TITLE
test: enhance unit test for webhooks and general refactor

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -125,12 +125,12 @@ jobs:
     - name: Check Helm release is deployed
       id: check-helm-release
       run: |
-        kubectl wait --for=create --timeout=120s deployment/astarte-operator-controller-manager
+        kubectl wait --for=create --timeout=5m deployment/astarte-operator-controller-manager
 
     - name: Check Astarte Operator is running
       id: check-operator-running
       run: |
-        kubectl wait --for=condition=available --timeout=120s deployment/astarte-operator-controller-manager
+        kubectl wait --for=condition=available --timeout=5m deployment/astarte-operator-controller-manager
 
     - name: Dump debug info
       run: |

--- a/api/api/v2alpha1/astarte_types_test.go
+++ b/api/api/v2alpha1/astarte_types_test.go
@@ -1,0 +1,165 @@
+/*
+This file is part of Astarte.
+
+Copyright 2020-25 SECO Mind Srl.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:goconst
+package v2alpha1
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.openly.dev/pointy"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Astarte types testing", Ordered, func() {
+	const (
+		CustomSecretName       = "custom-secret"
+		CustomUsernameKey      = "usr"
+		CustomPasswordKey      = "pwd"
+		CustomAstarteName      = "my-astarte"
+		CustomAstarteNamespace = "default"
+		CustomRabbitMQHost     = "custom-rabbitmq-host"
+		CustomRabbitMQPort     = 5673
+		CustomVerneMQHost      = "vernemq.example.com"
+		CustomVerneMQPort      = 8884
+		AstarteVersion         = "1.3.0"
+	)
+
+	var cr *Astarte
+	var log logr.Logger
+
+	BeforeAll(func() {
+		log = log.WithValues("test", "astarte_types.go")
+		log.Info("Starting controllerutils tests")
+		if CustomAstarteNamespace != "default" {
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CustomAstarteNamespace,
+				},
+			}
+
+			Eventually(func() error {
+				return k8sClient.Create(context.Background(), ns)
+			}, "10s", "250ms").Should(Succeed())
+		}
+	})
+
+	AfterAll(func() {
+		if CustomAstarteNamespace != "default" {
+			astartes := &AstarteList{}
+			Expect(k8sClient.List(context.Background(), astartes, &client.ListOptions{Namespace: CustomAstarteNamespace})).To(Succeed())
+
+			for _, a := range astartes.Items {
+				Expect(k8sClient.Delete(context.Background(), &a)).To(Succeed())
+			}
+
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteNamespace}, &v1.Namespace{})
+			}, "10s", "250ms").ShouldNot(Succeed())
+		}
+	})
+
+	BeforeEach(func() {
+		// Create and initialize a basic Astarte CR
+		cr = &Astarte{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      CustomAstarteName,
+				Namespace: CustomAstarteNamespace,
+			},
+			Spec: AstarteSpec{
+				Version: AstarteVersion,
+				RabbitMQ: AstarteRabbitMQSpec{
+					Connection: &AstarteRabbitMQConnectionSpec{
+						HostAndPort: HostAndPort{
+							Host: CustomRabbitMQHost,
+							Port: pointy.Int32(CustomRabbitMQPort),
+						},
+					},
+				},
+				VerneMQ: AstarteVerneMQSpec{
+					HostAndPort: HostAndPort{
+						Host: CustomVerneMQHost,
+						Port: pointy.Int32(CustomVerneMQPort),
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(context.Background(), cr)).To(Succeed())
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+		}, "10s", "250ms").Should(Succeed())
+	})
+
+	AfterEach(func() {
+		astartes := &AstarteList{}
+		Expect(k8sClient.List(context.Background(), astartes, &client.ListOptions{Namespace: CustomAstarteNamespace})).To(Succeed())
+		for _, a := range astartes.Items {
+			Expect(k8sClient.Delete(context.Background(), &a)).To(Succeed())
+
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: a.Name, Namespace: a.Namespace}, &Astarte{})
+			}, "10s", "250ms").ShouldNot(Succeed())
+		}
+
+	})
+
+	Describe("Test AstartePodPriorities.IsEnabled()", func() {
+		It("should return true if AstartePodPrioritiesSpec is enabled", func() {
+			cr.Spec.Features.AstartePodPriorities = &AstartePodPrioritiesSpec{
+				Enable: true,
+			}
+
+			enabled := cr.Spec.Features.AstartePodPriorities.IsEnabled()
+			Expect(enabled).To(BeTrue())
+		})
+		It("should return false if AstartePodPrioritiesSpec is disabled", func() {
+			cr.Spec.Features.AstartePodPriorities = &AstartePodPrioritiesSpec{
+				Enable: false,
+			}
+			disabled := cr.Spec.Features.AstartePodPriorities.IsEnabled()
+			Expect(disabled).To(BeFalse())
+		})
+		It("should return false if AstartePodPrioritiesSpec is nil", func() {
+			cr.Spec.Features.AstartePodPriorities = nil
+			disabled := cr.Spec.Features.AstartePodPriorities.IsEnabled()
+			Expect(disabled).To(BeFalse())
+		})
+	})
+
+	Describe("Test CFSSL.GetPodLabels()", func() {
+		It("should return a map with the correct pod labels", func() {
+			// Set some labels to AstarteCFSSLSpec
+			cr.Spec.CFSSL = AstarteCFSSLSpec{
+				PodLabels: map[string]string{
+					"cfssl-label": "cfssl",
+				},
+			}
+			// Check the returned map
+			labels := cr.Spec.CFSSL.GetPodLabels()
+			Expect(labels).ToNot(BeNil())
+			Expect(labels).To(HaveKeyWithValue("cfssl-label", "cfssl"))
+		})
+	})
+})

--- a/api/api/v2alpha1/astarte_webhook.go
+++ b/api/api/v2alpha1/astarte_webhook.go
@@ -16,6 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:goconst
 package v2alpha1
 
 import (

--- a/api/api/v2alpha1/astarte_webhook_test.go
+++ b/api/api/v2alpha1/astarte_webhook_test.go
@@ -16,699 +16,824 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:goconst
 package v2alpha1
 
 import (
-	"fmt"
-	"testing"
+	"context"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.openly.dev/pointy"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Astarte Webhook", func() {
+var _ = Describe("Misc utils testing", Ordered, func() {
+	const (
+		CustomSecretName       = "custom-secret"
+		CustomUsernameKey      = "usr"
+		CustomPasswordKey      = "pwd"
+		CustomAstarteName      = "my-astarte"
+		CustomAstarteNamespace = "default"
+		CustomRabbitMQHost     = "custom-rabbitmq-host"
+		CustomRabbitMQPort     = 5673
+		CustomVerneMQHost      = "vernemq.example.com"
+		CustomVerneMQPort      = 8884
+		AstarteVersion         = "1.3.0"
+	)
 
-	Context("When creating Astarte under Defaulting Webhook", func() {
-		It("Should fill in the default value if a required field is empty", func() {
+	var cr *Astarte
+	var log logr.Logger
 
-			// TODO(user): Add your logic here
+	BeforeAll(func() {
+		log.Info("Starting controllerutils tests")
+		if CustomAstarteNamespace != "default" {
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CustomAstarteNamespace,
+				},
+			}
 
+			Eventually(func() error {
+				return k8sClient.Create(context.Background(), ns)
+			}, "10s", "250ms").Should(Succeed())
+		}
+	})
+
+	AfterAll(func() {
+		if CustomAstarteNamespace != "default" {
+			astartes := &AstarteList{}
+			Expect(k8sClient.List(context.Background(), astartes, &client.ListOptions{Namespace: CustomAstarteNamespace})).To(Succeed())
+
+			for _, a := range astartes.Items {
+				Expect(k8sClient.Delete(context.Background(), &a)).To(Succeed())
+			}
+
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteNamespace}, &v1.Namespace{})
+			}, "10s", "250ms").ShouldNot(Succeed())
+		}
+	})
+
+	BeforeEach(func() {
+		// Create and initialize a basic Astarte CR
+		cr = &Astarte{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      CustomAstarteName,
+				Namespace: CustomAstarteNamespace,
+			},
+			Spec: AstarteSpec{
+				Version: AstarteVersion,
+				RabbitMQ: AstarteRabbitMQSpec{
+					Connection: &AstarteRabbitMQConnectionSpec{
+						HostAndPort: HostAndPort{
+							Host: CustomRabbitMQHost,
+							Port: pointy.Int32(CustomRabbitMQPort),
+						},
+					},
+				},
+				VerneMQ: AstarteVerneMQSpec{
+					HostAndPort: HostAndPort{
+						Host: CustomVerneMQHost,
+						Port: pointy.Int32(CustomVerneMQPort),
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(context.Background(), cr)).To(Succeed())
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+		}, "10s", "250ms").Should(Succeed())
+	})
+
+	AfterEach(func() {
+		astartes := &AstarteList{}
+		Expect(k8sClient.List(context.Background(), astartes, &client.ListOptions{Namespace: CustomAstarteNamespace})).To(Succeed())
+		for _, a := range astartes.Items {
+			Expect(k8sClient.Delete(context.Background(), &a)).To(Succeed())
+
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: a.Name, Namespace: a.Namespace}, &Astarte{})
+			}, "10s", "250ms").ShouldNot(Succeed())
+		}
+
+	})
+
+	Describe("TestValidateSSLListener", func() {
+		It("should return no errors when SSL Listener is disabled", func() {
+			cr.Spec.VerneMQ.SSLListener = pointy.Bool(false)
+			errs := cr.validateSSLListener()
+			Expect(errs).ToNot(BeNil())
+			Expect(errs).To(BeEmpty())
+		})
+
+		It("should return an error when SSL Listener is enabled and SSLListenerCertSecretName is empty", func() {
+			cr.Spec.VerneMQ.SSLListener = pointy.Bool(true)
+			cr.Spec.VerneMQ.SSLListenerCertSecretName = ""
+			errs := cr.validateSSLListener()
+			Expect(errs).ToNot(BeNil())
+			Expect(errs).To(HaveLen(1))
+		})
+
+		It("should return an error when SSL Listener is valid but there is no a secret", func() {
+			cr.Spec.VerneMQ.SSLListener = pointy.Bool(true)
+			cr.Spec.VerneMQ.SSLListenerCertSecretName = CustomSecretName
+			errs := cr.validateSSLListener()
+			Expect(errs).ToNot(BeNil())
+			Expect(errs).To(HaveLen(1))
+		})
+
+		It("should return no errors when SSL Listener is valid and the secret is deployed", func() {
+			cr.Spec.VerneMQ.SSLListener = pointy.Bool(true)
+			cr.Spec.VerneMQ.SSLListenerCertSecretName = CustomSecretName
+
+			// Create the secret
+			secret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      CustomSecretName,
+					Namespace: CustomAstarteNamespace,
+				},
+				Data: map[string][]byte{
+					"cert": []byte("my-cert"),
+					"key":  []byte("my-key"),
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), secret)).To(Succeed())
+
+			// Ensure the secret is created
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomSecretName, Namespace: CustomAstarteNamespace}, &v1.Secret{})
+			}, "10s", "250ms").Should(Succeed())
+
+			errs := cr.validateSSLListener()
+			Expect(errs).ToNot(BeNil())
+			Expect(errs).To(BeEmpty())
+
+			// Cleanup the secret
+			Expect(k8sClient.Delete(context.Background(), secret)).To(Succeed())
+
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomSecretName, Namespace: CustomAstarteNamespace}, &v1.Secret{})
+			}, "10s", "250ms").ShouldNot(Succeed())
 		})
 	})
 
-	Context("When creating Astarte under Validating Webhook", func() {
-		It("Should deny if a required field is empty", func() {
-
-			// TODO(user): Add your logic here
-
-		})
-
-		It("Should admit if all required fields are provided", func() {
-
-			// TODO(user): Add your logic here
-
-		})
-	})
-
-})
-
-func TestValidateSSLListener(t *testing.T) {
-	testCases := []struct {
-		description    string
-		verneSpec      AstarteVerneMQSpec
-		expectedErrors int
-	}{
-		{
-			description: "SSL Listener disabled",
-			verneSpec: AstarteVerneMQSpec{
-				SSLListener: pointy.Bool(false),
-			},
-			expectedErrors: 0,
-		},
-		{
-			description: "SSL Listener enabled and empty SSLListenerCertSecretName",
-			verneSpec: AstarteVerneMQSpec{
-				SSLListener:               pointy.Bool(true),
-				SSLListenerCertSecretName: "",
-			},
-			expectedErrors: 1,
-		},
-		{
-			description: "SSL Listener enabled and no SSLListenerCertSecretName",
-			verneSpec: AstarteVerneMQSpec{
-				SSLListener: pointy.Bool(true),
-			},
-			expectedErrors: 1,
-		},
-	}
-
-	// TODO: Test against k8s api to check if the secret exists
-
-	g := NewWithT(t)
-	r := &Astarte{}
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			r.Spec.VerneMQ = tc.verneSpec
-			errs := r.validateSSLListener()
-			g.Expect(errs).ToNot(BeNil())
-			g.Expect(errs).To(HaveLen(tc.expectedErrors))
-		})
-	}
-}
-
-func TestValidateUpdateAstarteInstanceID(t *testing.T) {
-	testCases := []struct {
-		description          string
-		oldAstarteInstanceID string
-		newAstarteInstanceID string
-		expectError          bool
-	}{
-		{
-			description:          "should return an error when trying to change the instanceID",
-			oldAstarteInstanceID: "old-instance-id",
-			newAstarteInstanceID: "new-instance-id",
-			expectError:          true,
-		},
-		{
-			description:          "should NOT return an error when the instanceID is unchanged",
-			oldAstarteInstanceID: "same-instance-id",
-			newAstarteInstanceID: "same-instance-id",
-			expectError:          false,
-		},
-		{
-			description:          "should NOT return an error when the instanceID is empty in both old and new spec",
-			oldAstarteInstanceID: "",
-			newAstarteInstanceID: "",
-			expectError:          false,
-		},
-	}
-
-	g := NewWithT(t)
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
+	Describe("TestValidateUpdateAstarteInstanceID", func() {
+		It("should return an error when trying to change the instanceID", func() {
 			oldAstarte := &Astarte{
 				Spec: AstarteSpec{
-					AstarteInstanceID: tc.oldAstarteInstanceID,
+					AstarteInstanceID: "old-instance-id",
 				},
 			}
 			newAstarte := &Astarte{
 				Spec: AstarteSpec{
-					AstarteInstanceID: tc.newAstarteInstanceID,
+					AstarteInstanceID: "new-instance-id",
 				},
 			}
 
 			err := newAstarte.validateUpdateAstarteInstanceID(oldAstarte)
-			if tc.expectError {
-				g.Expect(err).ToNot(BeNil())
-			} else {
-				g.Expect(err).To(BeNil())
-			}
+			Expect(err).ToNot(BeNil())
 		})
-	}
 
-}
+		It("should NOT return an error when the instanceID is unchanged", func() {
+			oldAstarte := &Astarte{
+				Spec: AstarteSpec{
+					AstarteInstanceID: "same-instance-id",
+				},
+			}
+			newAstarte := &Astarte{
+				Spec: AstarteSpec{
+					AstarteInstanceID: "same-instance-id",
+				},
+			}
 
-func TestValidatePodLabelsForClusteredResources(t *testing.T) {
-	testCases := []struct {
-		name        string
-		labels      map[string]string
-		expectError bool
-	}{
-		{
-			name: "with allowed custom labels",
-			labels: map[string]string{
-				"custom-label":           "lbl",
-				"my.custom.domain/label": "value",
-			},
-			expectError: false,
-		},
-		{
-			name: "with unallowed reserved labels",
-			labels: map[string]string{
-				"app":          "my-app",
-				"component":    "my-component",
-				"astarte-role": "my-role",
-				"flow-role":    "my-role",
-			},
-			expectError: true,
-		},
-		{
-			name:        "with no labels",
-			labels:      nil,
-			expectError: false,
-		},
-	}
+			err := newAstarte.validateUpdateAstarteInstanceID(oldAstarte)
+			Expect(err).To(BeNil())
+		})
 
-	testComponents := map[string]AstarteSpec{
-		"DataUpdaterPlant": {Components: AstarteComponentsSpec{DataUpdaterPlant: AstarteDataUpdaterPlantSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}}},
-		"TriggerEngine":    {Components: AstarteComponentsSpec{TriggerEngine: AstarteTriggerEngineSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}}},
-		"Flow":             {Components: AstarteComponentsSpec{Flow: AstarteGenericAPIComponentSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}}},
-		"Housekeeping":     {Components: AstarteComponentsSpec{Housekeeping: AstarteGenericAPIComponentSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}}},
-		"RealmManagement":  {Components: AstarteComponentsSpec{RealmManagement: AstarteGenericAPIComponentSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}}},
-		"Pairing":          {Components: AstarteComponentsSpec{Pairing: AstarteGenericAPIComponentSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}}},
-		"VerneMQ":          {VerneMQ: AstarteVerneMQSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}},
-	}
+		It("should NOT return an error when the instanceID is empty in both old and new spec", func() {
+			oldAstarte := &Astarte{
+				Spec: AstarteSpec{
+					AstarteInstanceID: "",
+				},
+			}
+			newAstarte := &Astarte{
+				Spec: AstarteSpec{
+					AstarteInstanceID: "",
+				},
+			}
 
-	for componentName, baseSpec := range testComponents {
-		for _, tc := range testCases {
-			t.Run(fmt.Sprintf("%s %s", componentName, tc.name), func(t *testing.T) {
-				g := NewWithT(t)
+			err := newAstarte.validateUpdateAstarteInstanceID(oldAstarte)
+			Expect(err).To(BeNil())
+		})
+	})
 
-				r := &Astarte{Spec: baseSpec}
+	Describe("TestValidatePodLabelsForClusteredResources", func() {
+		testComponents := map[string]AstarteSpec{
+			"DataUpdaterPlant": {Components: AstarteComponentsSpec{DataUpdaterPlant: AstarteDataUpdaterPlantSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}}},
+			"TriggerEngine":    {Components: AstarteComponentsSpec{TriggerEngine: AstarteTriggerEngineSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}}},
+			"Flow":             {Components: AstarteComponentsSpec{Flow: AstarteGenericAPIComponentSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}}},
+			"Housekeeping":     {Components: AstarteComponentsSpec{Housekeeping: AstarteGenericAPIComponentSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}}},
+			"RealmManagement":  {Components: AstarteComponentsSpec{RealmManagement: AstarteGenericAPIComponentSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}}},
+			"Pairing":          {Components: AstarteComponentsSpec{Pairing: AstarteGenericAPIComponentSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}}},
+			"VerneMQ":          {VerneMQ: AstarteVerneMQSpec{AstarteGenericClusteredResource: AstarteGenericClusteredResource{}}},
+		}
+
+		allowedLabels := map[string]string{
+			"custom-label":           "lbl",
+			"my.custom.domain/label": "value",
+		}
+
+		notAllowedLabels := map[string]string{
+			"app":          "my-app",
+			"component":    "my-component",
+			"astarte-role": "my-role",
+			"flow-role":    "my-role",
+		}
+
+		It("should not return errors when using allowed custom labels", func() {
+			for componentName, baseSpec := range testComponents {
+				cr := &Astarte{Spec: baseSpec}
 
 				switch componentName {
 				case "DataUpdaterPlant":
-					r.Spec.Components.DataUpdaterPlant.PodLabels = tc.labels
+					cr.Spec.Components.DataUpdaterPlant.PodLabels = allowedLabels
 				case "TriggerEngine":
-					r.Spec.Components.TriggerEngine.PodLabels = tc.labels
+					cr.Spec.Components.TriggerEngine.PodLabels = allowedLabels
 				case "Flow":
-					r.Spec.Components.Flow.PodLabels = tc.labels
+					cr.Spec.Components.Flow.PodLabels = allowedLabels
 				case "Housekeeping":
-					r.Spec.Components.Housekeeping.PodLabels = tc.labels
+					cr.Spec.Components.Housekeeping.PodLabels = allowedLabels
 				case "RealmManagement":
-					r.Spec.Components.RealmManagement.PodLabels = tc.labels
+					cr.Spec.Components.RealmManagement.PodLabels = allowedLabels
 				case "Pairing":
-					r.Spec.Components.Pairing.PodLabels = tc.labels
+					cr.Spec.Components.Pairing.PodLabels = allowedLabels
 				case "VerneMQ":
-					r.Spec.VerneMQ.PodLabels = tc.labels
+					cr.Spec.VerneMQ.PodLabels = allowedLabels
 				}
 
-				err := r.validatePodLabelsForClusteredResources()
-				g.Expect(err).ToNot(BeNil())
-
-				if tc.expectError {
-					g.Expect(err).ToNot(BeEmpty())
-				} else {
-					g.Expect(err).To(BeEmpty())
-				}
-			})
-		}
-	}
-}
-
-func TestValidatePodLabelsForClusteredResource(t *testing.T) {
-	testCases := []struct {
-		name        string
-		labels      map[string]string
-		expectError bool
-	}{
-		{
-			name: "with allowed custom labels",
-			labels: map[string]string{
-				"custom-label":           "lbl",
-				"my.custom.domain/label": "value",
-			},
-			expectError: false,
-		},
-		{
-			name: "with unallowed reserved labels",
-			labels: map[string]string{
-				"app":          "my-app",
-				"component":    "my-component",
-				"astarte-role": "my-role",
-				"flow-role":    "my-role",
-			},
-			expectError: true,
-		},
-		{
-			name:        "with no labels",
-			labels:      nil,
-			expectError: false,
-		},
-	}
-
-	g := NewWithT(t)
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := &AstarteGenericClusteredResource{
-				PodLabels: tc.labels,
-			}
-			err := validatePodLabelsForClusteredResource(PodLabelsGetter(r))
-			g.Expect(err).ToNot(BeNil())
-			if tc.expectError {
-				g.Expect(err).ToNot(BeEmpty())
-			} else {
-				g.Expect(err).To(BeEmpty())
+				err := cr.validatePodLabelsForClusteredResources()
+				Expect(err).ToNot(BeNil())
+				Expect(err).To(BeEmpty())
 			}
 		})
-	}
-}
 
-func TestValidateAutoscalerForClusteredResources(t *testing.T) {
-	// TODO: implement this test
-}
+		It("should return errors when using unallowed reserved labels", func() {
+			for componentName, baseSpec := range testComponents {
+				cr := &Astarte{Spec: baseSpec}
 
-func TestValidateAutoscalerForClusteredResourcesExcluding(t *testing.T) {
-	// TODO: implement this test
-}
+				switch componentName {
+				case "DataUpdaterPlant":
+					cr.Spec.Components.DataUpdaterPlant.PodLabels = notAllowedLabels
+				case "TriggerEngine":
+					cr.Spec.Components.TriggerEngine.PodLabels = notAllowedLabels
+				case "Flow":
+					cr.Spec.Components.Flow.PodLabels = notAllowedLabels
+				case "Housekeeping":
+					cr.Spec.Components.Housekeeping.PodLabels = notAllowedLabels
+				case "RealmManagement":
+					cr.Spec.Components.RealmManagement.PodLabels = notAllowedLabels
+				case "Pairing":
+					cr.Spec.Components.Pairing.PodLabels = notAllowedLabels
+				case "VerneMQ":
+					cr.Spec.VerneMQ.PodLabels = notAllowedLabels
+				}
 
-func TestValidateAstartePriorityClasses(t *testing.T) {
-	testCases := []struct {
-		description       string
-		enable            bool
-		highPriorityValue int
-		midPriorityValue  int
-		lowPriorityValue  int
-		expectError       bool
-	}{
-		{
-			description:       "should not return an error when pod priorities are disabled and values are in correct order",
-			enable:            false,
-			lowPriorityValue:  100,
-			midPriorityValue:  500,
-			highPriorityValue: 1000,
-			expectError:       false,
-		},
-		{
-			description:       "should not return an error when pod priorities are disabled and values are not in correct order",
-			enable:            false,
-			lowPriorityValue:  1000,
-			midPriorityValue:  500,
-			highPriorityValue: 0,
-			expectError:       false,
-		},
-		{
-			description:       "should return an error when pod priorities are enabled and values are not in correct order",
-			enable:            true,
-			lowPriorityValue:  1000,
-			midPriorityValue:  1000,
-			highPriorityValue: 500,
-			expectError:       true,
-		},
-		{
-			description:       "should not return an error when pod priorities are enabled and values are in correct order",
-			enable:            true,
-			lowPriorityValue:  100,
-			midPriorityValue:  500,
-			highPriorityValue: 1000,
-			expectError:       false,
-		},
-	}
+				err := cr.validatePodLabelsForClusteredResources()
+				Expect(err).ToNot(BeNil())
+				Expect(err).ToNot(BeEmpty())
+			}
+		})
 
-	g := NewWithT(t)
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
+		It("should not return errors when no labels are set", func() {
+			for componentName, baseSpec := range testComponents {
+				cr := &Astarte{Spec: baseSpec}
+
+				switch componentName {
+				case "DataUpdaterPlant":
+					cr.Spec.Components.DataUpdaterPlant.PodLabels = nil
+				case "TriggerEngine":
+					cr.Spec.Components.TriggerEngine.PodLabels = nil
+				case "Flow":
+					cr.Spec.Components.Flow.PodLabels = nil
+				case "Housekeeping":
+					cr.Spec.Components.Housekeeping.PodLabels = nil
+				case "RealmManagement":
+					cr.Spec.Components.RealmManagement.PodLabels = nil
+				case "Pairing":
+					cr.Spec.Components.Pairing.PodLabels = nil
+				case "VerneMQ":
+					cr.Spec.VerneMQ.PodLabels = nil
+				}
+
+				err := cr.validatePodLabelsForClusteredResources()
+				Expect(err).ToNot(BeNil())
+				Expect(err).To(BeEmpty())
+			}
+		})
+	})
+
+	Describe("TestValidatePodLabelsForClusteredResource", func() {
+		It("should return no errors when using allowed custom labels", func() {
+			r := &AstarteGenericClusteredResource{
+				PodLabels: map[string]string{
+					"custom-label":           "lbl",
+					"my.custom.domain/label": "value",
+				},
+			}
+			err := validatePodLabelsForClusteredResource(PodLabelsGetter(r))
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(BeEmpty())
+		})
+
+		It("should return errors when using unallowed reserved labels", func() {
+			r := &AstarteGenericClusteredResource{
+				PodLabels: map[string]string{
+					"app":          "my-app",
+					"component":    "my-component",
+					"astarte-role": "my-role",
+					"flow-role":    "my-role",
+				},
+			}
+			err := validatePodLabelsForClusteredResource(PodLabelsGetter(r))
+			Expect(err).ToNot(BeNil())
+			Expect(err).ToNot(BeEmpty())
+		})
+
+		It("should not return errors when no labels are set", func() {
+			r := &AstarteGenericClusteredResource{
+				PodLabels: nil,
+			}
+			err := validatePodLabelsForClusteredResource(PodLabelsGetter(r))
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(BeEmpty())
+		})
+	})
+
+	Describe("TestValidateAutoscalerForClusteredResources", func() {
+	})
+
+	Describe("TestValidateAutoscalerForClusteredResourcesExcluding", func() {
+	})
+
+	Describe("TestValidateAstartePriorityClasses", func() {
+		It("should not return an error when pod priorities are disabled and values are in correct order", func() {
 			astarte := &Astarte{
 				Spec: AstarteSpec{
 					Features: AstarteFeatures{
 						AstartePodPriorities: &AstartePodPrioritiesSpec{
-							Enable:              tc.enable,
-							AstarteHighPriority: &tc.highPriorityValue,
-							AstarteMidPriority:  &tc.midPriorityValue,
-							AstarteLowPriority:  &tc.lowPriorityValue,
+							Enable:              false,
+							AstarteHighPriority: pointy.Int(1000),
+							AstarteMidPriority:  pointy.Int(500),
+							AstarteLowPriority:  pointy.Int(100),
 						},
 					},
 				},
 			}
 
 			err := astarte.validateAstartePriorityClasses()
-
-			if tc.expectError {
-				g.Expect(err).ToNot(BeNil())
-				g.Expect(err.Field).To(Equal("spec.features.astarte{Low|Medium|High}Priority"))
-			} else {
-				g.Expect(err).To(BeNil())
-			}
+			Expect(err).To(BeNil())
 		})
-	}
-}
 
-func TestValidatePriorityClassesValues(t *testing.T) {
-	testCases := []struct {
-		description       string
-		highPriorityValue int
-		midPriorityValue  int
-		lowPriorityValue  int
-		expectError       bool
-	}{
-		{
-			description:       "should not return an error when priorities are in correct order",
-			highPriorityValue: 1000,
-			midPriorityValue:  500,
-			lowPriorityValue:  100,
-			expectError:       false,
-		},
-		{
-			description:       "should return an error when high priority is less than mid priority",
-			highPriorityValue: 400,
-			midPriorityValue:  500,
-			lowPriorityValue:  100,
-			expectError:       true,
-		},
-		{
-			description:       "should return an error when mid priority is less than low priority",
-			highPriorityValue: 1000,
-			midPriorityValue:  50,
-			lowPriorityValue:  100,
-			expectError:       true,
-		},
-		{
-			description:       "should not return an error when priorities are equal",
-			highPriorityValue: 500,
-			midPriorityValue:  500,
-			lowPriorityValue:  100,
-			expectError:       false,
-		},
-	}
+		It("should not return an error when pod priorities are disabled and values are not in correct order", func() {
+			astarte := &Astarte{
+				Spec: AstarteSpec{
+					Features: AstarteFeatures{
+						AstartePodPriorities: &AstartePodPrioritiesSpec{
+							Enable:              false,
+							AstarteHighPriority: pointy.Int(0),
+							AstarteMidPriority:  pointy.Int(500),
+							AstarteLowPriority:  pointy.Int(1000),
+						},
+					},
+				},
+			}
 
-	g := NewWithT(t)
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
+			err := astarte.validateAstartePriorityClasses()
+			Expect(err).To(BeNil())
+		})
+
+		It("should return an error when pod priorities are enabled and values are not in correct order", func() {
 			astarte := &Astarte{
 				Spec: AstarteSpec{
 					Features: AstarteFeatures{
 						AstartePodPriorities: &AstartePodPrioritiesSpec{
 							Enable:              true,
-							AstarteHighPriority: &tc.highPriorityValue,
-							AstarteMidPriority:  &tc.midPriorityValue,
-							AstarteLowPriority:  &tc.lowPriorityValue,
+							AstarteHighPriority: pointy.Int(500),
+							AstarteMidPriority:  pointy.Int(500),
+							AstarteLowPriority:  pointy.Int(1000),
+						},
+					},
+				},
+			}
+
+			err := astarte.validateAstartePriorityClasses()
+			Expect(err).ToNot(BeNil())
+			Expect(err.Field).To(Equal("spec.features.astarte{Low|Medium|High}Priority"))
+		})
+
+		It("should not return an error when pod priorities are enabled and values are in correct order", func() {
+			astarte := &Astarte{
+				Spec: AstarteSpec{
+					Features: AstarteFeatures{
+						AstartePodPriorities: &AstartePodPrioritiesSpec{
+							Enable:              true,
+							AstarteHighPriority: pointy.Int(1000),
+							AstarteMidPriority:  pointy.Int(500),
+							AstarteLowPriority:  pointy.Int(100),
+						},
+					},
+				},
+			}
+
+			err := astarte.validateAstartePriorityClasses()
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Describe("TestValidatePriorityClassesValues", func() {
+		It("should not return an error when priorities are in correct order", func() {
+			astarte := &Astarte{
+				Spec: AstarteSpec{
+					Features: AstarteFeatures{
+						AstartePodPriorities: &AstartePodPrioritiesSpec{
+							Enable:              true,
+							AstarteHighPriority: pointy.Int(1000),
+							AstarteMidPriority:  pointy.Int(500),
+							AstarteLowPriority:  pointy.Int(100),
 						},
 					},
 				},
 			}
 
 			err := astarte.validatePriorityClassesValues()
+			Expect(err).To(BeNil())
+		})
 
-			if tc.expectError {
-				g.Expect(err).ToNot(BeNil())
-				g.Expect(err.Field).To(Equal("spec.features.astarte{Low|Medium|High}Priority"))
-			} else {
-				g.Expect(err).To(BeNil())
+		It("should return an error when high priority is less than mid priority", func() {
+			astarte := &Astarte{
+				Spec: AstarteSpec{
+					Features: AstarteFeatures{
+						AstartePodPriorities: &AstartePodPrioritiesSpec{
+							Enable:              true,
+							AstarteHighPriority: pointy.Int(400),
+							AstarteMidPriority:  pointy.Int(500),
+							AstarteLowPriority:  pointy.Int(100),
+						},
+					},
+				},
+			}
+
+			err := astarte.validatePriorityClassesValues()
+			Expect(err).ToNot(BeNil())
+			Expect(err.Field).To(Equal("spec.features.astarte{Low|Medium|High}Priority"))
+		})
+
+		It("should return an error when mid priority is less than low priority", func() {
+			astarte := &Astarte{
+				Spec: AstarteSpec{
+					Features: AstarteFeatures{
+						AstartePodPriorities: &AstartePodPrioritiesSpec{
+							Enable:              true,
+							AstarteHighPriority: pointy.Int(1000),
+							AstarteMidPriority:  pointy.Int(50),
+							AstarteLowPriority:  pointy.Int(100),
+						},
+					},
+				},
+			}
+
+			err := astarte.validatePriorityClassesValues()
+			Expect(err).ToNot(BeNil())
+			Expect(err.Field).To(Equal("spec.features.astarte{Low|Medium|High}Priority"))
+		})
+
+		It("should not return an error when priorities are equal", func() {
+			astarte := &Astarte{
+				Spec: AstarteSpec{
+					Features: AstarteFeatures{
+						AstartePodPriorities: &AstartePodPrioritiesSpec{
+							Enable:              true,
+							AstarteHighPriority: pointy.Int(500),
+							AstarteMidPriority:  pointy.Int(500),
+							AstarteLowPriority:  pointy.Int(100),
+						},
+					},
+				},
+			}
+
+			err := astarte.validatePriorityClassesValues()
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Describe("TestValidateUpdateAstarteSystemKeyspace", func() {
+		oldAstarte := &Astarte{}
+		newAstarte := &Astarte{}
+
+		BeforeEach(func() {
+			oldAstarte = &Astarte{
+				Spec: AstarteSpec{
+					Cassandra: AstarteCassandraSpec{
+						AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{},
+					},
+				},
+			}
+
+			newAstarte = &Astarte{
+				Spec: AstarteSpec{
+					Cassandra: AstarteCassandraSpec{
+						AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{},
+					},
+				},
 			}
 		})
-	}
 
-}
+		AfterEach(func() {
+			oldAstarte = nil
+			newAstarte = nil
+		})
 
-func TestValidateUpdateAstarteSystemKeyspace(t *testing.T) {
-	testCases := []struct {
-		description string
-		oldKeyspace AstarteSystemKeyspaceSpec
-		newKeyspace AstarteSystemKeyspaceSpec
-		expectError bool
-	}{
-		{
-			description: "should return an error when trying to change the keyspace",
-			oldKeyspace: AstarteSystemKeyspaceSpec{
+		It("should return an error when trying to change the keyspace", func() {
+			oldAstarte.Spec.Cassandra.AstarteSystemKeyspace = AstarteSystemKeyspaceSpec{
 				ReplicationStrategy:   "SimpleStrategy",
 				ReplicationFactor:     1,
 				DataCenterReplication: "dc1:3,dc2:2",
-			},
-			newKeyspace: AstarteSystemKeyspaceSpec{
+			}
+			newAstarte.Spec.Cassandra.AstarteSystemKeyspace = AstarteSystemKeyspaceSpec{
 				ReplicationStrategy:   "NetworkTopologyStrategy",
 				ReplicationFactor:     2,
 				DataCenterReplication: "dc1:2,dc2:3",
-			},
-			expectError: true,
-		},
-		{
-			description: "should NOT return an error when the keyspace is unchanged",
-			oldKeyspace: AstarteSystemKeyspaceSpec{
-				ReplicationStrategy:   "SimpleStrategy",
-				ReplicationFactor:     1,
-				DataCenterReplication: "dc1:3,dc2:2",
-			},
-			newKeyspace: AstarteSystemKeyspaceSpec{
-				ReplicationStrategy:   "SimpleStrategy",
-				ReplicationFactor:     1,
-				DataCenterReplication: "dc1:3,dc2:2",
-			},
-			expectError: false,
-		},
-		{
-			description: "should NOT return an error when the keyspace is empty in both old and new spec",
-			oldKeyspace: AstarteSystemKeyspaceSpec{},
-			newKeyspace: AstarteSystemKeyspaceSpec{},
-			expectError: false,
-		},
-	}
-
-	g := NewWithT(t)
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			oldAstarte := &Astarte{
-				Spec: AstarteSpec{
-					Cassandra: AstarteCassandraSpec{
-						AstarteSystemKeyspace: tc.oldKeyspace,
-					},
-				},
-			}
-			newAstarte := &Astarte{
-				Spec: AstarteSpec{
-					Cassandra: AstarteCassandraSpec{
-						AstarteSystemKeyspace: tc.newKeyspace,
-					},
-				},
 			}
 
 			err := newAstarte.validateUpdateAstarteSystemKeyspace(oldAstarte)
-			if tc.expectError {
-				g.Expect(err).ToNot(BeNil())
-				g.Expect(err.Field).To(Equal("spec.cassandra.astarteSystemKeyspace"))
-			} else {
-				g.Expect(err).To(BeNil())
-			}
+			Expect(err).ToNot(BeNil())
+			Expect(err.Field).To(Equal("spec.cassandra.astarteSystemKeyspace"))
 		})
-	}
-}
 
-func TestValidateCFSSLDefinition(t *testing.T) {
-	testCases := []struct {
-		description string
-		cfsslSpec   AstarteCFSSLSpec
-		expectError bool
-	}{
-		{
-			description: "should return an error when Deploy is false and URL is empty",
-			cfsslSpec: AstarteCFSSLSpec{
-				Deploy: pointy.Bool(false),
-				URL:    "",
-			},
-			expectError: true,
-		},
-		{
-			description: "should NOT return an error when Deploy is false and URL is provided",
-			cfsslSpec: AstarteCFSSLSpec{
-				Deploy: pointy.Bool(false),
-				URL:    "http://my-cfssl.com",
-			},
-			expectError: false,
-		},
-		{
-			description: "should NOT return an error when Deploy is true and URL is empty",
-			cfsslSpec: AstarteCFSSLSpec{
-				Deploy: pointy.Bool(true),
-				URL:    "",
-			},
-			expectError: false,
-		},
-		{
-			description: "should NOT return an error when Deploy is true and URL is provided",
-			cfsslSpec: AstarteCFSSLSpec{
-				Deploy: pointy.Bool(true),
-				URL:    "http://my-cfssl.com",
-			},
-			expectError: false,
-		},
-		{
-			description: "should NOT return an error when Deploy is nil (defaults to true) and URL is empty",
-			cfsslSpec: AstarteCFSSLSpec{
-				Deploy: nil,
-				URL:    "",
-			},
-			expectError: false,
-		},
-	}
+		It("should NOT return an error when the keyspace is unchanged", func() {
+			oldAstarte.Spec.Cassandra.AstarteSystemKeyspace = AstarteSystemKeyspaceSpec{
+				ReplicationStrategy:   "SimpleStrategy",
+				ReplicationFactor:     1,
+				DataCenterReplication: "dc1:3,dc2:2",
+			}
 
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			g := NewWithT(t)
-			astarte := &Astarte{
+			newAstarte.Spec.Cassandra.AstarteSystemKeyspace = AstarteSystemKeyspaceSpec{
+				ReplicationStrategy:   "SimpleStrategy",
+				ReplicationFactor:     1,
+				DataCenterReplication: "dc1:3,dc2:2",
+			}
+
+			err := newAstarte.validateUpdateAstarteSystemKeyspace(oldAstarte)
+			Expect(err).To(BeNil())
+		})
+
+		It("should NOT return an error when the keyspace is empty in both old and new spec", func() {
+			oldAstarte.Spec.Cassandra.AstarteSystemKeyspace = AstarteSystemKeyspaceSpec{}
+			newAstarte.Spec.Cassandra.AstarteSystemKeyspace = AstarteSystemKeyspaceSpec{}
+
+			err := newAstarte.validateUpdateAstarteSystemKeyspace(oldAstarte)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Describe("TestValidateCFSSLDefinition", func() {
+		cr := &Astarte{}
+		BeforeEach(func() {
+			cr = &Astarte{
 				Spec: AstarteSpec{
-					CFSSL: tc.cfsslSpec,
+					CFSSL: AstarteCFSSLSpec{},
 				},
 			}
-
-			err := astarte.validateCFSSLDefinition()
-
-			if tc.expectError {
-				g.Expect(err).ToNot(BeNil())
-				g.Expect(err.Field).To(Equal("spec.cfssl.url"))
-			} else {
-				g.Expect(err).To(BeNil())
-			}
 		})
-	}
-}
 
-func TestValidateCreateAstarteSystemKeyspace(t *testing.T) {
-	testCases := []struct {
-		description  string
-		astarte      *Astarte
-		expectedErrs int
-	}{
-		{
-			description: "It should not return with SimpleStrategy and valid odd replication factor",
-			astarte: &Astarte{
-				Spec: AstarteSpec{Cassandra: AstarteCassandraSpec{
-					AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{
-						ReplicationStrategy: "SimpleStrategy",
-						ReplicationFactor:   3,
-					},
-				}},
-			},
-			expectedErrs: 0,
-		},
-		{
-			description: "NetworkTopologyStrategy with single valid DC",
-			astarte: &Astarte{
-				Spec: AstarteSpec{Cassandra: AstarteCassandraSpec{
-					AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{
-						ReplicationStrategy:   "NetworkTopologyStrategy",
-						DataCenterReplication: "dc1:3",
-					},
-				}},
-			},
-			expectedErrs: 0,
-		},
-		{
-			description: "NetworkTopologyStrategy with multiple valid DCs",
-			astarte: &Astarte{
-				Spec: AstarteSpec{Cassandra: AstarteCassandraSpec{
-					AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{
-						ReplicationStrategy:   "NetworkTopologyStrategy",
-						DataCenterReplication: "dc1:3,dc2:5,dc3:1",
-					},
-				}},
-			},
-			expectedErrs: 0,
-		},
-		{
-			description: "SimpleStrategy with invalid even replication factor",
-			astarte: &Astarte{
-				Spec: AstarteSpec{Cassandra: AstarteCassandraSpec{
-					AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{
-						ReplicationStrategy: "SimpleStrategy",
-						ReplicationFactor:   2,
-					},
-				}},
-			},
-			expectedErrs: 1,
-		},
-		{
-			description: "NetworkTopologyStrategy with invalid format (no colon)",
-			astarte: &Astarte{
-				Spec: AstarteSpec{Cassandra: AstarteCassandraSpec{
-					AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{
-						ReplicationStrategy:   "NetworkTopologyStrategy",
-						DataCenterReplication: "dc1",
-					},
-				}},
-			},
-			expectedErrs: 1,
-		},
-		{
-			description: "NetworkTopologyStrategy with invalid format (too many colons)",
-			astarte: &Astarte{
-				Spec: AstarteSpec{Cassandra: AstarteCassandraSpec{
-					AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{
-						ReplicationStrategy:   "NetworkTopologyStrategy",
-						DataCenterReplication: "dc1:3:bad",
-					},
-				}},
-			},
-			expectedErrs: 1,
-		},
-		{
-			description: "NetworkTopologyStrategy with non-integer replication factor",
-			astarte: &Astarte{
-				Spec: AstarteSpec{Cassandra: AstarteCassandraSpec{
-					AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{
-						ReplicationStrategy:   "NetworkTopologyStrategy",
-						DataCenterReplication: "dc1:three",
-					},
-				}},
-			},
-			expectedErrs: 2,
-		},
-		{
-			description: "NetworkTopologyStrategy with even replication factor",
-			astarte: &Astarte{
-				Spec: AstarteSpec{Cassandra: AstarteCassandraSpec{
-					AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{
-						ReplicationStrategy:   "NetworkTopologyStrategy",
-						DataCenterReplication: "dc1:4",
-					},
-				}},
-			},
-			expectedErrs: 1,
-		},
-		{
-			description: "NetworkTopologyStrategy with mixed valid and invalid DCs",
-			astarte: &Astarte{
-				Spec: AstarteSpec{Cassandra: AstarteCassandraSpec{
-					AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{
-						ReplicationStrategy:   "NetworkTopologyStrategy",
-						DataCenterReplication: "dc1:3,dc2:4", // dc2 is invalid
-					},
-				}},
-			},
-			expectedErrs: 1,
-		},
-		{
-			description: "NetworkTopologyStrategy with multiple invalid entries",
-			astarte: &Astarte{
-				Spec: AstarteSpec{Cassandra: AstarteCassandraSpec{
-					AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{
-						ReplicationStrategy:   "NetworkTopologyStrategy",
-						DataCenterReplication: "dc1:2,dc2:not-a-number,dc3:5",
-					},
-				}},
-			},
-			expectedErrs: 3,
-		},
-		{
-			description: "NetworkTopologyStrategy with empty DataCenterReplication string",
-			astarte: &Astarte{
-				Spec: AstarteSpec{Cassandra: AstarteCassandraSpec{
-					AstarteSystemKeyspace: AstarteSystemKeyspaceSpec{
-						ReplicationStrategy:   "NetworkTopologyStrategy",
-						DataCenterReplication: "",
-					},
-				}},
-			},
-			expectedErrs: 1,
-		},
-	}
-
-	g := NewWithT(t)
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			r := tc.astarte
-			err := r.validateCreateAstarteSystemKeyspace()
-			g.Expect(err).ToNot(BeNil())
-			g.Expect(err).To(HaveLen(tc.expectedErrs))
+		AfterEach(func() {
+			cr = nil
 		})
-	}
-}
+
+		It("should return an error when Deploy is false and URL is empty", func() {
+			cr.Spec.CFSSL.Deploy = pointy.Bool(false)
+			cr.Spec.CFSSL.URL = ""
+
+			err := cr.validateCFSSLDefinition()
+			Expect(err).ToNot(BeNil())
+			Expect(err.Field).To(Equal("spec.cfssl.url"))
+		})
+
+		It("should NOT return an error when Deploy is false and URL is provided", func() {
+			cr.Spec.CFSSL.Deploy = pointy.Bool(false)
+			cr.Spec.CFSSL.URL = "http://my-cfssl.com"
+			err := cr.validateCFSSLDefinition()
+			Expect(err).To(BeNil())
+		})
+
+		It("should NOT return an error when Deploy is true and URL is empty", func() {
+			cr.Spec.CFSSL.Deploy = pointy.Bool(true)
+			cr.Spec.CFSSL.URL = ""
+
+			err := cr.validateCFSSLDefinition()
+			Expect(err).To(BeNil())
+		})
+
+		It("should NOT return an error when Deploy is true and URL is provided", func() {
+			cr.Spec.CFSSL.Deploy = pointy.Bool(true)
+			cr.Spec.CFSSL.URL = "http://my-cfssl.com"
+
+			err := cr.validateCFSSLDefinition()
+			Expect(err).To(BeNil())
+		})
+
+		It("should NOT return an error when Deploy is nil (defaults to true) and URL is empty", func() {
+			cr.Spec.CFSSL.Deploy = nil
+			cr.Spec.CFSSL.URL = ""
+
+			err := cr.validateCFSSLDefinition()
+			Expect(err).To(BeNil())
+		})
+
+		It("should NOT return an error when Deploy is nil (defaults to true) and URL is provided", func() {
+			cr.Spec.CFSSL.Deploy = nil
+			cr.Spec.CFSSL.URL = "http://my-cfssl.com"
+			err := cr.validateCFSSLDefinition()
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Describe("TestValidateCreateAstarteSystemKeyspace", func() {
+		cr := &Astarte{}
+
+		It("should not return error with SimpleStrategy and valid odd replication factor", func() {
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationStrategy = "SimpleStrategy"
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationFactor = 3
+
+			err := cr.validateCreateAstarteSystemKeyspace()
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(BeEmpty())
+		})
+
+		It("should not return an error with NetworkTopologyStrategy and a single valid DC", func() {
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationStrategy = "NetworkTopologyStrategy"
+			cr.Spec.Cassandra.AstarteSystemKeyspace.DataCenterReplication = "dc1:3"
+
+			err := cr.validateCreateAstarteSystemKeyspace()
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(BeEmpty())
+		})
+
+		It("should not return an error with NetworkTopologyStrategy and multiple valid DCs", func() {
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationStrategy = "NetworkTopologyStrategy"
+			cr.Spec.Cassandra.AstarteSystemKeyspace.DataCenterReplication = "dc1:3,dc2:5,dc3:1"
+
+			err := cr.validateCreateAstarteSystemKeyspace()
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(BeEmpty())
+		})
+
+		It("should return an error with SimpleStrategy and invalid even replication factor", func() {
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationStrategy = "SimpleStrategy"
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationFactor = 2
+
+			err := cr.validateCreateAstarteSystemKeyspace()
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(HaveLen(1))
+		})
+
+		It("should return an error with NetworkTopologyStrategy and invalid format (no colon)", func() {
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationStrategy = "NetworkTopologyStrategy"
+			cr.Spec.Cassandra.AstarteSystemKeyspace.DataCenterReplication = "dc1"
+
+			err := cr.validateCreateAstarteSystemKeyspace()
+			Expect(err).To(HaveLen(1))
+		})
+
+		It("should return an error with NetworkTopologyStrategy and invalid format (too many colons)", func() {
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationStrategy = "NetworkTopologyStrategy"
+			cr.Spec.Cassandra.AstarteSystemKeyspace.DataCenterReplication = "dc1:3:bad"
+
+			err := cr.validateCreateAstarteSystemKeyspace()
+			Expect(err).To(HaveLen(1))
+		})
+
+		It("should return errors with NetworkTopologyStrategy and non-integer replication factor", func() {
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationStrategy = "NetworkTopologyStrategy"
+			cr.Spec.Cassandra.AstarteSystemKeyspace.DataCenterReplication = "dc1:three"
+			err := cr.validateCreateAstarteSystemKeyspace()
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(HaveLen(2))
+		})
+
+		It("should return an error with NetworkTopologyStrategy and even replication factor", func() {
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationStrategy = "NetworkTopologyStrategy"
+			cr.Spec.Cassandra.AstarteSystemKeyspace.DataCenterReplication = "dc1:4"
+			err := cr.validateCreateAstarteSystemKeyspace()
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(HaveLen(1))
+
+		})
+
+		It("should return an error with NetworkTopologyStrategy and mixed valid and invalid DCs", func() {
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationStrategy = "NetworkTopologyStrategy"
+			cr.Spec.Cassandra.AstarteSystemKeyspace.DataCenterReplication = "dc1:3,dc2:4" // dc2 is invalid
+			err := cr.validateCreateAstarteSystemKeyspace()
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(HaveLen(1))
+
+		})
+
+		It("should return multiple errors with NetworkTopologyStrategy and multiple invalid entries", func() {
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationStrategy = "NetworkTopologyStrategy"
+			cr.Spec.Cassandra.AstarteSystemKeyspace.DataCenterReplication = "dc1:2,dc2:not-a-number,dc3:5"
+			err := cr.validateCreateAstarteSystemKeyspace()
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(HaveLen(3))
+
+		})
+
+		It("should return an error with empty replication strategy", func() {
+			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationStrategy = "NetworkTopologyStrategy"
+			cr.Spec.Cassandra.AstarteSystemKeyspace.DataCenterReplication = ""
+			err := cr.validateCreateAstarteSystemKeyspace()
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(HaveLen(1))
+
+		})
+	})
+
+	Describe("TestValidateCreate", func() {
+
+	})
+
+	Describe("TestValidateUpdate", func() {
+
+	})
+
+	Describe("TestValidateAstarte", func() {
+
+	})
+
+	Describe("TestValidateDelete", func() {
+		// The function is not implemented, expect nil, nil
+		It("should return nil, nil", func() {
+			w, err := cr.ValidateDelete()
+			Expect(w).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("TestValidateCreateAstarteInstanceID", func() {
+		It("should return error if it cannot list astarte instances", func() {
+			// Todo: find a way to simulate this
+		})
+
+		It("should return error if other Astarte instances exists with same instanceID", func() {
+			// Instance a new CR with a custom instanceID (1)
+			cr1 := cr.DeepCopy()
+			cr1.ResourceVersion = ""
+			cr1.Name = "first-astarte"
+			cr1.Spec.AstarteInstanceID = "myuniqueinstanceid"
+			Expect(k8sClient.Create(context.Background(), cr1)).To(Succeed())
+			// Ensure the instance is created
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "first-astarte", Namespace: CustomAstarteNamespace}, cr1)
+			}, "10s", "250ms").Should(Succeed())
+
+			// Try to validate a new CR with the same instanceID (2)
+			cr2 := cr.DeepCopy()
+			cr2.ResourceVersion = ""
+			cr2.Name = "second-astarte"
+			cr2.Spec.AstarteInstanceID = "myuniqueinstanceid"
+
+			err := cr2.validateCreateAstarteInstanceID()
+			Expect(err).ToNot(BeNil())
+			Expect(err.Field).To(Equal("spec.astarteInstanceID"))
+
+			// Cleanup the first instance
+			Expect(k8sClient.Delete(context.Background(), cr1)).To(Succeed())
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "first-astarte", Namespace: CustomAstarteNamespace}, cr1)
+			}, "10s", "250ms").ShouldNot(Succeed())
+
+			// No need to cleanup the second instance, as it was never created
+		})
+
+		It("should not return error if no other Astarte instances exists with same instanceID", func() {
+			newCr := cr.DeepCopy()
+			newCr.Spec.AstarteInstanceID = "myuniqueinstanceid"
+			newCr.Name = "another-astarte"
+
+			err := newCr.validateCreateAstarteInstanceID()
+			Expect(err).To(BeNil())
+
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+			}, "10s", "250ms").Should(Succeed())
+
+			// No need to cleanup the instance, as it was never created
+		})
+	})
+})

--- a/api/api/v2alpha1/suite_test.go
+++ b/api/api/v2alpha1/suite_test.go
@@ -33,7 +33,9 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	// +kubebuilder:scaffold:imports
-	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/client-go/kubernetes/scheme"
+
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -85,26 +87,25 @@ var _ = BeforeSuite(func() {
 	var err error
 	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	scheme := apimachineryruntime.NewScheme()
-	err = AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
+	err = AddToScheme(scheme.Scheme)
+	Expect(err).ToNot(HaveOccurred())
 
-	err = admissionv1.AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
+	err = admissionv1.AddToScheme(scheme.Scheme)
+	Expect(err).ToNot(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
-	Expect(err).NotTo(HaveOccurred())
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
 	// start webhook server using Manager
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme,
+		Scheme: scheme.Scheme,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Host:    webhookInstallOptions.LocalServingHost,
 			Port:    webhookInstallOptions.LocalServingPort,
@@ -113,17 +114,17 @@ var _ = BeforeSuite(func() {
 		LeaderElection: false,
 		Metrics:        metricsserver.Options{BindAddress: "0"},
 	})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	err = (&Astarte{}).SetupWebhookWithManager(mgr)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()
 		err = mgr.Start(ctx)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 	}()
 
 	// wait for the webhook server to get ready
@@ -143,5 +144,5 @@ var _ = AfterSuite(func() {
 	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 })

--- a/api/flow/v2alpha1/webhook_suite_test.go
+++ b/api/flow/v2alpha1/webhook_suite_test.go
@@ -85,20 +85,20 @@ var _ = BeforeSuite(func() {
 	var err error
 	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
 	scheme := apimachineryruntime.NewScheme()
 	err = AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	err = admissionv1.AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
 	// start webhook server using Manager
@@ -113,17 +113,17 @@ var _ = BeforeSuite(func() {
 		LeaderElection: false,
 		Metrics:        metricsserver.Options{BindAddress: "0"},
 	})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	err = (&Flow{}).SetupWebhookWithManager(mgr)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()
 		err = mgr.Start(ctx)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 	}()
 
 	// wait for the webhook server to get ready
@@ -143,5 +143,5 @@ var _ = AfterSuite(func() {
 	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 })

--- a/api/ingress/v1alpha1/webhook_suite_test.go
+++ b/api/ingress/v1alpha1/webhook_suite_test.go
@@ -85,20 +85,20 @@ var _ = BeforeSuite(func() {
 	var err error
 	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
 	scheme := apimachineryruntime.NewScheme()
 	err = AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	err = admissionv1.AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
 	// start webhook server using Manager
@@ -113,17 +113,17 @@ var _ = BeforeSuite(func() {
 		LeaderElection: false,
 		Metrics:        metricsserver.Options{BindAddress: "0"},
 	})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	err = (&AstarteDefaultIngress{}).SetupWebhookWithManager(mgr)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()
 		err = mgr.Start(ctx)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 	}()
 
 	// wait for the webhook server to get ready
@@ -143,5 +143,5 @@ var _ = AfterSuite(func() {
 	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 })

--- a/internal/controller/api/astarte_controller_test.go
+++ b/internal/controller/api/astarte_controller_test.go
@@ -121,12 +121,12 @@ var _ = Describe("Astarte Controller", func() {
 			By("getting the created resource")
 			resource := &apiv2alpha1.Astarte{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			// ... and then delete it
 			By("deleting the created resource")
 			err = k8sClient.Delete(ctx, resource)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should successfully reconcile the resource", func() {
@@ -134,14 +134,14 @@ var _ = Describe("Astarte Controller", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should not reconcile an unsupported astarte version", func() {
 			By("Updating the resource to an unsupported version")
 			resource := &apiv2alpha1.Astarte{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			resource.Spec.Version = "4.0.1"
 			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
@@ -158,7 +158,7 @@ var _ = Describe("Astarte Controller", func() {
 			By("Updating the resource to be in manual maintenance mode")
 			resource := &apiv2alpha1.Astarte{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 
 			resource.Spec.ManualMaintenanceMode = true
 			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
@@ -167,7 +167,7 @@ var _ = Describe("Astarte Controller", func() {
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should not requeue when the resource is not found and there are no errors", func() {
@@ -178,7 +178,7 @@ var _ = Describe("Astarte Controller", func() {
 					Namespace: "default",
 				},
 			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Requeue).To(BeFalse())
 		})
 

--- a/internal/controller/api/suite_test.go
+++ b/internal/controller/api/suite_test.go
@@ -71,16 +71,16 @@ var _ = BeforeSuite(func() {
 	var err error
 	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
 	err = apiv2alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
 })
@@ -88,5 +88,5 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 })

--- a/internal/controller/flow/flow_controller_test.go
+++ b/internal/controller/flow/flow_controller_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Flow Controller", func() {
 			// // TODO(user): Cleanup logic after each test, like removing the resource instance.
 			// resource := &flowv2alpha1.Flow{}
 			// err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			// Expect(err).NotTo(HaveOccurred())
+			// Expect(err).ToNot(HaveOccurred())
 
 			// By("Cleanup the specific resource instance Flow")
 			// Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
@@ -67,7 +67,7 @@ var _ = Describe("Flow Controller", func() {
 			// _, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 			// 	NamespacedName: typeNamespacedName,
 			// })
-			// Expect(err).NotTo(HaveOccurred())
+			// Expect(err).ToNot(HaveOccurred())
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})

--- a/internal/controller/flow/suite_test.go
+++ b/internal/controller/flow/suite_test.go
@@ -71,16 +71,16 @@ var _ = BeforeSuite(func() {
 	var err error
 	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
 	err = flowv2alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
 })
@@ -88,5 +88,5 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 })

--- a/internal/controller/ingress/astartedefaultingress_controller_test.go
+++ b/internal/controller/ingress/astartedefaultingress_controller_test.go
@@ -60,7 +60,7 @@ var _ = Describe("AstarteDefaultIngress Controller", func() {
 			// // TODO(user): Cleanup logic after each test, like removing the resource instance.
 			// resource := &ingressv1alpha1.AstarteDefaultIngress{}
 			// err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			// Expect(err).NotTo(HaveOccurred())
+			// Expect(err).ToNot(HaveOccurred())
 
 			// By("Cleanup the specific resource instance AstarteDefaultIngress")
 			// Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
@@ -75,7 +75,7 @@ var _ = Describe("AstarteDefaultIngress Controller", func() {
 			// _, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 			// 	NamespacedName: typeNamespacedName,
 			// })
-			// Expect(err).NotTo(HaveOccurred())
+			// Expect(err).ToNot(HaveOccurred())
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})

--- a/internal/controller/ingress/suite_test.go
+++ b/internal/controller/ingress/suite_test.go
@@ -71,16 +71,16 @@ var _ = BeforeSuite(func() {
 	var err error
 	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
 	err = ingressv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
 })
@@ -88,5 +88,5 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 })

--- a/internal/controllerutils/astarte_controller_test.go
+++ b/internal/controllerutils/astarte_controller_test.go
@@ -1,0 +1,131 @@
+/*
+This file is part of Astarte.
+
+Copyright 2020-25 SECO Mind Srl.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:goconst
+package controllerutils
+
+import (
+	"context"
+
+	"github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.openly.dev/pointy"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("controllerutils tests", Ordered, func() {
+	const (
+		CustomSecretName       = "custom-secret"
+		CustomUsernameKey      = "usr"
+		CustomPasswordKey      = "pwd"
+		CustomAstarteName      = "my-astarte"
+		CustomAstarteNamespace = "default"
+		CustomRabbitMQHost     = "custom-rabbitmq-host"
+		CustomRabbitMQPort     = 5673
+		CustomVerneMQHost      = "vernemq.example.com"
+		CustomVerneMQPort      = 8884
+		AstarteVersion         = "1.3.0"
+	)
+
+	var cr *v2alpha1.Astarte
+	var log logr.Logger
+
+	BeforeAll(func() {
+		log = log.WithValues("test", "controllerutils")
+		log.Info("Starting controllerutils tests")
+		if CustomAstarteNamespace != "default" {
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CustomAstarteNamespace,
+				},
+			}
+
+			Eventually(func() error {
+				return k8sClient.Create(context.Background(), ns)
+			}, "10s", "250ms").Should(Succeed())
+		}
+	})
+
+	AfterAll(func() {
+		if CustomAstarteNamespace != "default" {
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CustomAstarteNamespace,
+				},
+			}
+			Expect(k8sClient.Delete(context.Background(), ns)).To(Succeed())
+
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteNamespace}, &v1.Namespace{})
+			}, "10s", "250ms").ShouldNot(Succeed())
+		}
+	})
+
+	BeforeEach(func() {
+		// Create and initialize a basic Astarte CR
+		cr = &v2alpha1.Astarte{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      CustomAstarteName,
+				Namespace: CustomAstarteNamespace,
+			},
+			Spec: v2alpha1.AstarteSpec{
+				Version: AstarteVersion,
+				RabbitMQ: v2alpha1.AstarteRabbitMQSpec{
+					Connection: &v2alpha1.AstarteRabbitMQConnectionSpec{
+						HostAndPort: v2alpha1.HostAndPort{
+							Host: CustomRabbitMQHost,
+							Port: pointy.Int32(CustomRabbitMQPort),
+						},
+					},
+				},
+				VerneMQ: v2alpha1.AstarteVerneMQSpec{
+					HostAndPort: v2alpha1.HostAndPort{
+						Host: CustomVerneMQHost,
+						Port: pointy.Int32(CustomVerneMQPort),
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(context.Background(), cr)).To(Succeed())
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+		}, "10s", "250ms").Should(Succeed())
+	})
+
+	AfterEach(func() {
+		astartes := &v2alpha1.AstarteList{}
+		Expect(k8sClient.List(context.Background(), astartes, &client.ListOptions{Namespace: CustomAstarteNamespace})).To(Succeed())
+		for _, a := range astartes.Items {
+			Expect(k8sClient.Delete(context.Background(), &a)).To(Succeed())
+
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: a.Name, Namespace: a.Namespace}, &v2alpha1.Astarte{})
+			}, "10s", "250ms").ShouldNot(Succeed())
+		}
+	})
+
+	Describe("TestFunction", func() {
+
+	})
+})

--- a/internal/controllerutils/suite_test.go
+++ b/internal/controllerutils/suite_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package misc
+package controllerutils
 
 import (
 	"context"
@@ -48,10 +48,9 @@ var ctx context.Context
 var cancel context.CancelFunc
 var testEnv *envtest.Environment
 
-func TestMisc(t *testing.T) {
+func TestControllerUtils(t *testing.T) {
 	RegisterFailHandler(Fail)
-
-	RunSpecs(t, "Misc Suite")
+	RunSpecs(t, "TestControllerUtils Suite")
 }
 
 var _ = BeforeSuite(func() {
@@ -76,6 +75,7 @@ var _ = BeforeSuite(func() {
 	var err error
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
+
 	Expect(cfg).NotTo(BeNil())
 
 	err = apiv2alpha1.AddToScheme(scheme.Scheme)
@@ -84,7 +84,6 @@ var _ = BeforeSuite(func() {
 	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 

--- a/internal/reconcile/suite_test.go
+++ b/internal/reconcile/suite_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package misc
+package reconcile
 
 import (
 	"context"
@@ -51,7 +51,7 @@ var testEnv *envtest.Environment
 func TestMisc(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecs(t, "Misc Suite")
+	RunSpecs(t, "Reconcile Suite")
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
- Instead of case-based testing we switch to Ginkgo, which is the recommended way of implementing tests within the operator. This allow use to reduce redundancy and use Envtest with ease.
- Refactored unit test to use the same structure overall
- Updated the timeout in the CI test as needed
