### PR TITLE
test: add cassandra spec to unit tests

### DIFF
--- a/api/api/v2alpha1/astarte_types_test.go
+++ b/api/api/v2alpha1/astarte_types_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:goconst
+//nolint:goconst,dupl
 package v2alpha1
 
 import (
@@ -101,6 +101,16 @@ var _ = Describe("Astarte types testing", Ordered, func() {
 					HostAndPort: HostAndPort{
 						Host: CustomVerneMQHost,
 						Port: pointy.Int32(CustomVerneMQPort),
+					},
+				},
+				Cassandra: AstarteCassandraSpec{
+					Connection: &AstarteCassandraConnectionSpec{
+						Nodes: []HostAndPort{
+							{
+								Host: "cassandra.example.com",
+								Port: pointy.Int32(9042),
+							},
+						},
 					},
 				},
 			},

--- a/api/api/v2alpha1/astarte_webhook_test.go
+++ b/api/api/v2alpha1/astarte_webhook_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:goconst
+//nolint:goconst,dupl
 package v2alpha1
 
 import (
@@ -100,6 +100,16 @@ var _ = Describe("Misc utils testing", Ordered, func() {
 					HostAndPort: HostAndPort{
 						Host: CustomVerneMQHost,
 						Port: pointy.Int32(CustomVerneMQPort),
+					},
+				},
+				Cassandra: AstarteCassandraSpec{
+					Connection: &AstarteCassandraConnectionSpec{
+						Nodes: []HostAndPort{
+							{
+								Host: "cassandra.example.com",
+								Port: pointy.Int32(9042),
+							},
+						},
 					},
 				},
 			},

--- a/internal/controllerutils/astarte_controller_test.go
+++ b/internal/controllerutils/astarte_controller_test.go
@@ -104,6 +104,16 @@ var _ = Describe("controllerutils tests", Ordered, func() {
 						Port: pointy.Int32(CustomVerneMQPort),
 					},
 				},
+				Cassandra: v2alpha1.AstarteCassandraSpec{
+					Connection: &v2alpha1.AstarteCassandraConnectionSpec{
+						Nodes: []v2alpha1.HostAndPort{
+							{
+								Host: "cassandra.example.com",
+								Port: pointy.Int32(9042),
+							},
+						},
+					},
+				},
 			},
 		}
 

--- a/internal/misc/utils_test.go
+++ b/internal/misc/utils_test.go
@@ -106,6 +106,16 @@ var _ = Describe("Misc utils testing", Ordered, func() {
 						Port: pointy.Int32(CustomVerneMQPort),
 					},
 				},
+				Cassandra: v2alpha1.AstarteCassandraSpec{
+					Connection: &v2alpha1.AstarteCassandraConnectionSpec{
+						Nodes: []v2alpha1.HostAndPort{
+							{
+								Host: "cassandra.example.com",
+								Port: pointy.Int32(9042),
+							},
+						},
+					},
+				},
 			},
 		}
 


### PR DESCRIPTION
- This helps to avoid nil pointer dereference when the cr is instantiated
- See https://github.com/astarte-platform/astarte-kubernetes-operator/issues/461