### PR TITLE
feat: add keepalive option for xandra connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add kubernetes 1.30.x, 1.31.x, 1.32.x and 1.33.x to the test matrix of the Helm chart installation tests.
 - Added env vars required by Astarte v1.3+.
 - Unit and integration tests.
+- Add AstarteCassandraConnectionSpec.EnableKeepalive field to the Astarte CRD.
 
 ### Changed
 - Forward port changes from release-24.5

--- a/api/api/v2alpha1/astarte_types.go
+++ b/api/api/v2alpha1/astarte_types.go
@@ -368,6 +368,10 @@ type AstarteCassandraConnectionSpec struct {
 	Nodes                 []HostAndPort `json:"nodes,omitempty"`
 	// +kubebuilder:validation:Optional
 	PoolSize *int `json:"poolSize,omitempty"`
+	// Enable or disable the keepalive option for the xandra connection.
+	// Default: true
+	// +kubebuilder:validation:Optional
+	EnableKeepalive *bool `json:"enableKeepalive,omitempty"`
 }
 
 type AstarteCassandraSpec struct {

--- a/charts/astarte-operator/templates/crds/astartes.api.astarte-platform.org.yaml
+++ b/charts/astarte-operator/templates/crds/astartes.api.astarte-platform.org.yaml
@@ -88,6 +88,8 @@ spec:
                             - passwordKey
                             - usernameKey
                           type: object
+                        enableKeepalive:
+                          type: boolean
                         nodes:
                           items:
                             properties:

--- a/config/crd/bases/api.astarte-platform.org_astartes.yaml
+++ b/config/crd/bases/api.astarte-platform.org_astartes.yaml
@@ -86,6 +86,8 @@ spec:
                         - passwordKey
                         - usernameKey
                         type: object
+                      enableKeepalive:
+                        type: boolean
                       nodes:
                         items:
                           properties:

--- a/internal/reconcile/utils.go
+++ b/internal/reconcile/utils.go
@@ -498,6 +498,14 @@ func appendCassandraConnectionEnvVars(ret []v1.EnvVar, cr *apiv2alpha1.Astarte) 
 		)
 	}
 
+	// Enable or disable the keepalive option for the xandra connection. Default to true.
+	ret = append(ret,
+		v1.EnvVar{
+			Name:  "CASSANDRA_ENABLE_KEEPALIVE",
+			Value: strconv.FormatBool(pointy.BoolValue(spec.EnableKeepalive, true)),
+		},
+	)
+
 	return ret
 }
 


### PR DESCRIPTION
- Added env var to enable or disable the keepalive option for the xandra connection. Defaults to true
- Related to: https://github.com/astarte-platform/astarte/pull/1503
- Updated Astarte CRD to support the new env variable
- Updated the changelog accordingly