### PR TITLE
chore(test): rename teardown utilities functions on tests

### DIFF
--- a/api/api/v2alpha1/astarte_types_test.go
+++ b/api/api/v2alpha1/astarte_types_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Astarte types testing", Ordered, Serial, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -59,7 +59,7 @@ var _ = Describe("Astarte types testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test AstartePodPriorities.IsEnabled()", func() {

--- a/api/api/v2alpha1/astarte_webhook_test.go
+++ b/api/api/v2alpha1/astarte_webhook_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -66,7 +66,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("TestValidateSSLListener", func() {

--- a/internal/controller/api/astarte_controller_test.go
+++ b/internal/controller/api/astarte_controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 
 	AfterAll(func() {
 		// Do not delete the namespace here to avoid 'NamespaceTerminating' flakiness in subsequent specs
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Context("When reconciling a resource", func() {
@@ -79,7 +79,7 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 		})
 
 		AfterEach(func() {
-			integrationutils.TeardownResources(ctx, k8sClient, CustomAstarteNamespace)
+			integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 		})
 
 		It("should successfully reconcile the resource", func() {
@@ -164,7 +164,7 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 		})
 
 		AfterEach(func() {
-			integrationutils.TeardownResources(ctx, k8sClient, CustomAstarteNamespace)
+			integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 		})
 
 		It("should handle finalization", func() {
@@ -203,7 +203,7 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 		})
 
 		AfterEach(func() {
-			integrationutils.TeardownResources(ctx, k8sClient, CustomAstarteNamespace)
+			integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 		})
 
 		It("should add a finalizer to an Astarte resource", func() {

--- a/internal/controller/api/astarte_finalizer_test.go
+++ b/internal/controller/api/astarte_finalizer_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Astarte Finalizer testing", Ordered, Serial, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -61,7 +61,7 @@ var _ = Describe("Astarte Finalizer testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test HandleFinalization", func() {

--- a/internal/controllerutils/astarte_controller_test.go
+++ b/internal/controllerutils/astarte_controller_test.go
@@ -39,7 +39,7 @@ var _ = Describe("controllerutils tests", Ordered, Serial, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -51,7 +51,7 @@ var _ = Describe("controllerutils tests", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("TestFunction", func() {

--- a/internal/misc/utils_test.go
+++ b/internal/misc/utils_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -70,7 +70,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("ReconcileConfigMap", func() {

--- a/internal/reconcile/astarte_dashboard_test.go
+++ b/internal/reconcile/astarte_dashboard_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Astarte Dashboard reconcile tests", Ordered, Serial, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -58,7 +58,7 @@ var _ = Describe("Astarte Dashboard reconcile tests", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test EnsureAstarteDashboard", func() {

--- a/internal/reconcile/astarte_data_updater_plant_test.go
+++ b/internal/reconcile/astarte_data_updater_plant_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -61,7 +61,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 	Describe("Test EnsureAstarteDataUpdaterPlant", func() {
 		It("should return error if it is not possible to list current DUP Deployments", func() {

--- a/internal/reconcile/astarte_generic_api_test.go
+++ b/internal/reconcile/astarte_generic_api_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -62,7 +62,7 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test EnsureAstarteGenericAPIComponent", func() {

--- a/internal/reconcile/astarte_generic_backend_test.go
+++ b/internal/reconcile/astarte_generic_backend_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Astarte Generic Backend testing", Ordered, Serial, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -62,7 +62,7 @@ var _ = Describe("Astarte Generic Backend testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test EnsureAstarteGenericBackend", func() {

--- a/internal/reconcile/astarte_priorityclass_test.go
+++ b/internal/reconcile/astarte_priorityclass_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Astarte PriorityClass reconcile tests", Ordered, Serial, func(
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -58,7 +58,7 @@ var _ = Describe("Astarte PriorityClass reconcile tests", Ordered, Serial, func(
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("EnsureAstartePriorityClasses", func() {

--- a/internal/reconcile/cfssl_test.go
+++ b/internal/reconcile/cfssl_test.go
@@ -46,7 +46,7 @@ var _ = Describe("CFSSL testing", Ordered, Serial, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -58,7 +58,7 @@ var _ = Describe("CFSSL testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test EnsureCFSSL", func() {

--- a/internal/reconcile/common_test.go
+++ b/internal/reconcile/common_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Common reconcile testing", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -55,7 +55,7 @@ var _ = Describe("Common reconcile testing", Ordered, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test EnsureHousekeepingKey", func() {

--- a/internal/reconcile/utils_test.go
+++ b/internal/reconcile/utils_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -71,7 +71,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test getAstarteCommonEnvVars", func() {

--- a/internal/reconcile/vernemq_test.go
+++ b/internal/reconcile/vernemq_test.go
@@ -51,7 +51,7 @@ var _ = Describe("VerneMQ testing", Ordered, Serial, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownNamespace(k8sClient, CustomAstarteNamespace)
+		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
 	})
 
 	BeforeEach(func() {
@@ -69,7 +69,7 @@ var _ = Describe("VerneMQ testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResources(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test EnsureVerneMQ", func() {

--- a/test/integration/integration_utils.go
+++ b/test/integration/integration_utils.go
@@ -42,19 +42,20 @@ const AstarteHighPriorityName string = "astarte-high-priority-non-preemptive"
 const AstarteMidPriorityName string = "astarte-mid-priority-non-preemptive"
 const AstarteLowPriorityName string = "astarte-low-priority-non-preemptive"
 
-func TeardownResources(ctx context.Context, k8sClient client.Client, namespace string) {
-	teardownAstarte(ctx, k8sClient, namespace)
-	teardownDeployments(ctx, k8sClient, namespace)
-	teardownStatefulSets(ctx, k8sClient, namespace)
-	teardownConfigMaps(ctx, k8sClient, namespace)
-	teardownSecrets(ctx, k8sClient, namespace)
-	teardownPVCs(ctx, k8sClient, namespace)
-	teardownServices(ctx, k8sClient, namespace)
-	teardownRBAC(k8sClient, namespace)
-	teardownPriorityClasses(k8sClient)
+func TeardownResourcesInNamespace(ctx context.Context, k8sClient client.Client, namespace string) {
+	deleteAstartesInNamespace(ctx, k8sClient, namespace)
+	deleteDeploymentsInNamespace(ctx, k8sClient, namespace)
+	deleteStatefulSetsInNamespace(ctx, k8sClient, namespace)
+	deleteConfigMapsInNamespace(ctx, k8sClient, namespace)
+	deleteSecretsInNamespace(ctx, k8sClient, namespace)
+	deletePVCsInNamespace(ctx, k8sClient, namespace)
+	deleteServicesInNamespace(ctx, k8sClient, namespace)
+	deleteRBACInNamespace(k8sClient, namespace)
+	deletePriorityClasses(k8sClient)
 }
 
-func teardownAstarte(ctx context.Context, k8sClient client.Client, namespace string) {
+// deleteAstartesInNamespace deletes all Astarte custom resources in the given namespace
+func deleteAstartesInNamespace(ctx context.Context, k8sClient client.Client, namespace string) {
 	// Since we cannot import the api package here due to circular dependencies, we use unstructured.UnstructuredList
 	// instead of: &v2alpha1.AstarteList{}
 	astartes := &unstructured.UnstructuredList{}
@@ -91,7 +92,8 @@ func teardownAstarte(ctx context.Context, k8sClient client.Client, namespace str
 	}
 }
 
-func teardownDeployments(ctx context.Context, k8sClient client.Client, namespace string) {
+// deleteDeploymentsInNamespace deletes all Deployment resources in the given namespace.
+func deleteDeploymentsInNamespace(ctx context.Context, k8sClient client.Client, namespace string) {
 	deployments := &appsv1.DeploymentList{}
 	Expect(k8sClient.List(context.Background(), deployments, &client.ListOptions{Namespace: namespace})).To(Succeed())
 
@@ -106,7 +108,8 @@ func teardownDeployments(ctx context.Context, k8sClient client.Client, namespace
 	}
 }
 
-func teardownStatefulSets(ctx context.Context, k8sClient client.Client, namespace string) {
+// deleteStatefulSetsInNamespace deletes all StatefulSet resources in the given namespace.
+func deleteStatefulSetsInNamespace(ctx context.Context, k8sClient client.Client, namespace string) {
 	statefulsets := &appsv1.StatefulSetList{}
 	Expect(k8sClient.List(context.Background(), statefulsets, &client.ListOptions{Namespace: namespace})).To(Succeed())
 
@@ -121,7 +124,8 @@ func teardownStatefulSets(ctx context.Context, k8sClient client.Client, namespac
 	}
 }
 
-func teardownConfigMaps(ctx context.Context, k8sClient client.Client, namespace string) {
+// deleteConfigMapsInNamespace deletes all ConfigMap resources in the given namespace.
+func deleteConfigMapsInNamespace(ctx context.Context, k8sClient client.Client, namespace string) {
 	configMaps := &v1.ConfigMapList{}
 	Expect(k8sClient.List(context.Background(), configMaps, &client.ListOptions{Namespace: namespace})).To(Succeed())
 
@@ -136,7 +140,8 @@ func teardownConfigMaps(ctx context.Context, k8sClient client.Client, namespace 
 	}
 }
 
-func teardownSecrets(ctx context.Context, k8sClient client.Client, namespace string) {
+// deleteSecretsInNamespace deletes all Secret resources in the given namespace.
+func deleteSecretsInNamespace(ctx context.Context, k8sClient client.Client, namespace string) {
 	secrets := &v1.SecretList{}
 
 	Expect(k8sClient.List(context.Background(), secrets, &client.ListOptions{Namespace: namespace})).To(Succeed())
@@ -152,7 +157,8 @@ func teardownSecrets(ctx context.Context, k8sClient client.Client, namespace str
 	}
 }
 
-func teardownPVCs(ctx context.Context, k8sClient client.Client, namespace string) {
+// deletePVCsInNamespace deletes all PersistentVolumeClaim resources in the given namespace.
+func deletePVCsInNamespace(ctx context.Context, k8sClient client.Client, namespace string) {
 	pvcs := &v1.PersistentVolumeClaimList{}
 	Expect(k8sClient.List(context.Background(), pvcs, &client.ListOptions{Namespace: namespace})).To(Succeed())
 
@@ -167,7 +173,8 @@ func teardownPVCs(ctx context.Context, k8sClient client.Client, namespace string
 	}
 }
 
-func teardownServices(ctx context.Context, k8sClient client.Client, namespace string) {
+// deleteServicesInNamespace deletes all Service resources in the given namespace.
+func deleteServicesInNamespace(ctx context.Context, k8sClient client.Client, namespace string) {
 	services := &v1.ServiceList{}
 	Expect(k8sClient.List(context.Background(), services, &client.ListOptions{Namespace: namespace})).To(Succeed())
 	for _, s := range services.Items {
@@ -183,7 +190,8 @@ func teardownServices(ctx context.Context, k8sClient client.Client, namespace st
 	}
 }
 
-func teardownRBAC(k8sClient client.Client, namespace string) {
+// deleteRBACInNamespace deletes all RBAC resources in the given namespace.
+func deleteRBACInNamespace(k8sClient client.Client, namespace string) {
 	serviceAccounts := &v1.ServiceAccountList{}
 	Expect(k8sClient.List(context.Background(), serviceAccounts, &client.ListOptions{Namespace: namespace})).To(Succeed())
 	for _, sa := range serviceAccounts.Items {
@@ -236,7 +244,8 @@ func teardownRBAC(k8sClient client.Client, namespace string) {
 	}, Timeout, Interval).Should(Equal(0))
 }
 
-func teardownPriorityClasses(k8sClient client.Client) {
+// deletePriorityClasses deletes all PriorityClass resources in the cluster.
+func deletePriorityClasses(k8sClient client.Client) {
 	// Cleanup of priorityclasses that might remain from tests
 	for _, name := range []string{AstarteHighPriorityName, AstarteMidPriorityName, AstarteLowPriorityName} {
 		pc := &schedulingv1.PriorityClass{}
@@ -253,7 +262,7 @@ func teardownPriorityClasses(k8sClient client.Client) {
 	}
 }
 
-func TeardownNamespace(k8sClient client.Client, namespace string) {
+func DeleteNamespace(k8sClient client.Client, namespace string) {
 	if namespace != "default" {
 		// Just give the namespace deletion a try, do not repeat on timeout
 		// as it would return "namespace terminating" errors


### PR DESCRIPTION
- Renamed teardown helper functions in `integration_utils.go` for clarity and consistency (e.g., `teardownAstarte` to `deleteAstartesInNamespace` etc.)
- Improved code comments on these functions.