### PR TITLE
fix(validatePriorityClassesValues): enforce non-equal PriorityClassValues

### DIFF
--- a/api/api/v2alpha1/astarte_webhook.go
+++ b/api/api/v2alpha1/astarte_webhook.go
@@ -291,7 +291,8 @@ func (r *Astarte) validatePriorityClassesValues() *field.Error {
 	highPriorityValue := *r.Spec.Features.AstartePodPriorities.AstarteHighPriority
 	midPriorityValue := *r.Spec.Features.AstartePodPriorities.AstarteMidPriority
 	lowPriorityValue := *r.Spec.Features.AstartePodPriorities.AstarteLowPriority
-	if midPriorityValue > highPriorityValue || lowPriorityValue > midPriorityValue {
+
+	if midPriorityValue >= highPriorityValue || lowPriorityValue >= midPriorityValue {
 		err := errors.New("Astarte PriorityClass values are incoherent")
 		astartelog.Info(err.Error())
 		fldPath := field.NewPath("spec").Child("features").Child("astarte{Low|Medium|High}Priority")

--- a/api/api/v2alpha1/astarte_webhook_test.go
+++ b/api/api/v2alpha1/astarte_webhook_test.go
@@ -498,7 +498,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 			Expect(err.Field).To(Equal("spec.features.astarte{Low|Medium|High}Priority"))
 		})
 
-		It("should not return an error when priorities are equal", func() {
+		It("should return an error when priorities are equal", func() {
 			cr.Spec.Features.AstartePodPriorities = &AstartePodPrioritiesSpec{
 				Enable:              true,
 				AstarteHighPriority: pointy.Int(500),
@@ -507,7 +507,30 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 			}
 
 			err := cr.validatePriorityClassesValues()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(BeNil())
+			Expect(err.Field).To(Equal("spec.features.astarte{Low|Medium|High}Priority"))
+
+			cr.Spec.Features.AstartePodPriorities = &AstartePodPrioritiesSpec{
+				Enable:              true,
+				AstarteHighPriority: pointy.Int(100),
+				AstarteMidPriority:  pointy.Int(500),
+				AstarteLowPriority:  pointy.Int(500),
+			}
+
+			err = cr.validatePriorityClassesValues()
+			Expect(err).ToNot(BeNil())
+			Expect(err.Field).To(Equal("spec.features.astarte{Low|Medium|High}Priority"))
+
+			cr.Spec.Features.AstartePodPriorities = &AstartePodPrioritiesSpec{
+				Enable:              true,
+				AstarteHighPriority: pointy.Int(500),
+				AstarteMidPriority:  pointy.Int(100),
+				AstarteLowPriority:  pointy.Int(500),
+			}
+
+			err = cr.validatePriorityClassesValues()
+			Expect(err).ToNot(BeNil())
+			Expect(err.Field).To(Equal("spec.features.astarte{Low|Medium|High}Priority"))
 		})
 	})
 


### PR DESCRIPTION
- Updated `validatePriorityClassesValues` in `astarte_webhook.go` to require unique values for high, mid, and low PriorityClasses.
- Added validation error and logging for non-unique PriorityClass values.
- Updated tests in `astarte_webhook_test.go` to cover new validation logic.