### PR TITLE
fix(misc): improve resource scaling precision for CPU and memory

### DIFF
--- a/internal/misc/utils.go
+++ b/internal/misc/utils.go
@@ -194,10 +194,10 @@ func GetResourcesForAstarteComponent(cr *apiv2alpha1.Astarte, requestedResources
 		return v1.ResourceRequirements{}
 	}
 
-	cpuLimits := getAllocationScaledQuantity(cr.Spec.Components.Resources.Limits.Cpu(), resource.Milli, a.CPUCoefficient)
-	cpuRequests := getAllocationScaledQuantity(cr.Spec.Components.Resources.Requests.Cpu(), resource.Milli, a.CPUCoefficient)
-	memoryLimits := getAllocationScaledQuantity(cr.Spec.Components.Resources.Limits.Memory(), resource.Mega, a.MemoryCoefficient)
-	memoryRequests := getAllocationScaledQuantity(cr.Spec.Components.Resources.Requests.Memory(), resource.Mega, a.MemoryCoefficient)
+	cpuLimits := getCpuScaledQuantity(cr.Spec.Components.Resources.Limits.Cpu(), a.CPUCoefficient)
+	cpuRequests := getCpuScaledQuantity(cr.Spec.Components.Resources.Requests.Cpu(), a.CPUCoefficient)
+	memoryLimits := getMemoryScaledQuantity(cr.Spec.Components.Resources.Limits.Memory(), a.MemoryCoefficient)
+	memoryRequests := getMemoryScaledQuantity(cr.Spec.Components.Resources.Requests.Memory(), a.MemoryCoefficient)
 
 	realRequests := v1.ResourceList{}
 
@@ -237,8 +237,22 @@ func GetResourcesForAstarteComponent(cr *apiv2alpha1.Astarte, requestedResources
 	}
 }
 
-func getAllocationScaledQuantity(qty *resource.Quantity, scale resource.Scale, coefficient float64) *resource.Quantity {
-	return resource.NewScaledQuantity(int64(float64(qty.ScaledValue(scale))*coefficient), scale)
+// getCpuScaledQuantity scales a resource quantity by a coefficient.
+// It works directly with the canonical milli representation to avoid precision loss
+// from unit conversions.
+// The returned quantity will be in milli format
+func getCpuScaledQuantity(qty *resource.Quantity, coefficient float64) *resource.Quantity {
+	scaledValue := int64(float64(qty.MilliValue()) * coefficient)
+	return resource.NewMilliQuantity(scaledValue, qty.Format)
+}
+
+// getMemoryScaledQuantity scales a resource quantity by a coefficient.
+// It works directly with the canonical byte/bibyte representations to avoid precision loss
+// from unit conversions.
+// The returned quantity will be in bytes format
+func getMemoryScaledQuantity(qty *resource.Quantity, coefficient float64) *resource.Quantity {
+	scaledValue := int64(float64(qty.Value()) * coefficient)
+	return resource.NewQuantity(scaledValue, qty.Format)
 }
 
 func getNumberOfDeployedAstarteComponentsAsFloat(cr *apiv2alpha1.Astarte) float64 {


### PR DESCRIPTION
Replace `getAllocationScaledQuantity` function with specialized `getCpuScaledQuantity` and `getMemoryScaledQuantity` functions to eliminate precision loss in resource allocation calculations.

The old function caused precision loss when scaling memory resources specified in binary units (Mi, Gi) by converting through decimal units (M, G), resulting in allocation errors per component that compounded across all Astarte components.

Key improvements:
- getCpuScaledQuantity: Uses MilliValue() and NewMilliQuantity() to work directly with millicores, avoiding allocation errors
- getMemoryScaledQuantity: Uses Value() (bytes) and NewQuantity() to work directly with canonical byte representation, eliminating unit conversion precision loss
- Add comprehensive unit tests covering CPU/memory scaling with various input formats (millicores, cores, bytes, Mi, Gi, M, G)
- Add integration tests verifying exact byte-level allocations

This ensures accurate proportional distribution of resources across Astarte components without accumulating rounding errors.