### PR TITLE
fix: make RabbitMQ and Cassandra Connection fields required

### DIFF
--- a/api/api/v2alpha1/astarte_types.go
+++ b/api/api/v2alpha1/astarte_types.go
@@ -351,7 +351,7 @@ type AstarteRabbitMQConnectionSpec struct {
 }
 
 type AstarteRabbitMQSpec struct {
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	Connection *AstarteRabbitMQConnectionSpec `json:"connection,omitempty"`
 	// Configures the data queues prefix on RabbitMQ. You should change this setting only
 	// in custom RabbitMQ installations.
@@ -375,7 +375,7 @@ type AstarteCassandraConnectionSpec struct {
 }
 
 type AstarteCassandraSpec struct {
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	Connection *AstarteCassandraConnectionSpec `json:"connection,omitempty"`
 	// +kubebuilder:validation:Optional
 	AstarteSystemKeyspace AstarteSystemKeyspaceSpec `json:"astarteSystemKeyspace,omitempty"`

--- a/internal/misc/utils.go
+++ b/internal/misc/utils.go
@@ -339,10 +339,6 @@ func IsAstarteComponentDeployed(cr *apiv2alpha1.Astarte, component apiv2alpha1.A
 
 // GetRabbitMQHostnameAndPort returns the Cluster-accessible Hostname and AMQP port for RabbitMQ
 func GetRabbitMQHostnameAndPort(cr *apiv2alpha1.Astarte) (string, int32) {
-	if cr == nil || cr.Spec.RabbitMQ.Connection == nil {
-		return "", 5672
-	}
-
 	return cr.Spec.RabbitMQ.Connection.Host, pointy.Int32Value(cr.Spec.RabbitMQ.Connection.Port, 5672)
 }
 
@@ -350,7 +346,7 @@ func GetRabbitMQHostnameAndPort(cr *apiv2alpha1.Astarte) (string, int32) {
 func GetRabbitMQUserCredentialsSecret(cr *apiv2alpha1.Astarte) (string, string, string) {
 	// TODO: allow `connectionStringSecret` to be used too
 
-	if cr.Spec.RabbitMQ.Connection != nil && cr.Spec.RabbitMQ.Connection.CredentialsSecret != nil {
+	if cr.Spec.RabbitMQ.Connection.CredentialsSecret != nil {
 		return cr.Spec.RabbitMQ.Connection.CredentialsSecret.Name, cr.Spec.RabbitMQ.Connection.CredentialsSecret.UsernameKey, cr.Spec.RabbitMQ.Connection.CredentialsSecret.PasswordKey
 	}
 	return cr.Name + "-rabbitmq-user-credentials", RabbitMQDefaultUserCredentialsUsernameKey, RabbitMQDefaultUserCredentialsPasswordKey
@@ -375,7 +371,7 @@ func GetRabbitMQCredentialsFor(cr *apiv2alpha1.Astarte, c client.Client) (string
 // GetCassandraUserCredentialsSecret gets the secret holding Cassandra credentials in the form <secret name>, <username key>, <password key>
 func GetCassandraUserCredentialsSecret(cr *apiv2alpha1.Astarte) (string, string, string) {
 	// TODO: allow `connectionStringSecret` to be used too
-	if cr.Spec.Cassandra.Connection != nil && cr.Spec.Cassandra.Connection.CredentialsSecret != nil {
+	if cr.Spec.Cassandra.Connection.CredentialsSecret != nil {
 		return cr.Spec.Cassandra.Connection.CredentialsSecret.Name, cr.Spec.Cassandra.Connection.CredentialsSecret.UsernameKey, cr.Spec.Cassandra.Connection.CredentialsSecret.PasswordKey
 	}
 	return cr.Name + "-cassandra-user-credentials", CassandraDefaultUserCredentialsUsernameKey, CassandraDefaultUserCredentialsPasswordKey

--- a/internal/misc/utils_test.go
+++ b/internal/misc/utils_test.go
@@ -794,10 +794,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 	// Test GetRabbitMQHostnameAndPort
 	Describe("GetRabbitMQHostnameAndPort", func() {
 		BeforeEach(func() {
-			// Initialize RabbitMQ.Connection if it's nil
-			if cr.Spec.RabbitMQ.Connection == nil {
-				cr.Spec.RabbitMQ.Connection = &v2alpha1.AstarteRabbitMQConnectionSpec{}
-			}
+			cr.Spec.RabbitMQ.Connection = &v2alpha1.AstarteRabbitMQConnectionSpec{}
 			cr.Spec.RabbitMQ.Connection.Host = CustomRabbitMQHost
 			cr.Spec.RabbitMQ.Connection.Port = pointy.Int32(CustomRabbitMQPort)
 		})

--- a/internal/reconcile/utils.go
+++ b/internal/reconcile/utils.go
@@ -617,30 +617,26 @@ func getAstarteCommonVolumes(cr *apiv2alpha1.Astarte) []v1.Volume {
 		},
 	}
 
-	if cr.Spec.RabbitMQ.Connection != nil {
-		if cr.Spec.RabbitMQ.Connection.SSLConfiguration.CustomCASecret.Name != "" {
-			// Mount the secret!
-			ret = append(ret, v1.Volume{
-				Name: "rabbitmq-ssl-ca",
-				VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{
-					SecretName: cr.Spec.RabbitMQ.Connection.SSLConfiguration.CustomCASecret.Name,
-					Items:      []v1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}},
-				}},
-			})
-		}
+	if cr.Spec.RabbitMQ.Connection.SSLConfiguration.CustomCASecret.Name != "" {
+		// Mount the secret!
+		ret = append(ret, v1.Volume{
+			Name: "rabbitmq-ssl-ca",
+			VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{
+				SecretName: cr.Spec.RabbitMQ.Connection.SSLConfiguration.CustomCASecret.Name,
+				Items:      []v1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}},
+			}},
+		})
 	}
 
-	if cr.Spec.Cassandra.Connection != nil {
-		if cr.Spec.Cassandra.Connection.SSLConfiguration.CustomCASecret.Name != "" {
-			// Mount the secret!
-			ret = append(ret, v1.Volume{
-				Name: "cassandra-ssl-ca",
-				VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{
-					SecretName: cr.Spec.Cassandra.Connection.SSLConfiguration.CustomCASecret.Name,
-					Items:      []v1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}},
-				}},
-			})
-		}
+	if cr.Spec.Cassandra.Connection.SSLConfiguration.CustomCASecret.Name != "" {
+		// Mount the secret!
+		ret = append(ret, v1.Volume{
+			Name: "cassandra-ssl-ca",
+			VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{
+				SecretName: cr.Spec.Cassandra.Connection.SSLConfiguration.CustomCASecret.Name,
+				Items:      []v1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}},
+			}},
+		})
 	}
 
 	return ret
@@ -655,26 +651,22 @@ func getAstarteCommonVolumeMounts(cr *apiv2alpha1.Astarte) []v1.VolumeMount {
 		},
 	}
 
-	if cr.Spec.RabbitMQ.Connection != nil {
-		if cr.Spec.RabbitMQ.Connection.SSLConfiguration.CustomCASecret.Name != "" {
-			// Mount the secret!
-			ret = append(ret, v1.VolumeMount{
-				Name:      "rabbitmq-ssl-ca",
-				MountPath: "/rabbitmq-ssl",
-				ReadOnly:  true,
-			})
-		}
+	if cr.Spec.RabbitMQ.Connection.SSLConfiguration.CustomCASecret.Name != "" {
+		// Mount the secret!
+		ret = append(ret, v1.VolumeMount{
+			Name:      "rabbitmq-ssl-ca",
+			MountPath: "/rabbitmq-ssl",
+			ReadOnly:  true,
+		})
 	}
 
-	if cr.Spec.Cassandra.Connection != nil {
-		if cr.Spec.Cassandra.Connection.SSLConfiguration.CustomCASecret.Name != "" {
-			// Mount the secret!
-			ret = append(ret, v1.VolumeMount{
-				Name:      "cassandra-ssl-ca",
-				MountPath: "/cassandra-ssl",
-				ReadOnly:  true,
-			})
-		}
+	if cr.Spec.Cassandra.Connection.SSLConfiguration.CustomCASecret.Name != "" {
+		// Mount the secret!
+		ret = append(ret, v1.VolumeMount{
+			Name:      "cassandra-ssl-ca",
+			MountPath: "/cassandra-ssl",
+			ReadOnly:  true,
+		})
 	}
 
 	return ret
@@ -799,10 +791,6 @@ func getHPAStatusForResource(autoscalerName string, cr *apiv2alpha1.Astarte, c c
 
 // This stuff is useful for other components which need to interact with Cassandra
 func getCassandraNodes(cr *apiv2alpha1.Astarte) string {
-	if cr.Spec.Cassandra.Connection == nil {
-		return ""
-	}
-
 	nodes := []string{}
 	for _, node := range cr.Spec.Cassandra.Connection.Nodes {
 		nodes = append(nodes, fmt.Sprintf("%s:%d", node.Host, *node.Port))
@@ -812,11 +800,6 @@ func getCassandraNodes(cr *apiv2alpha1.Astarte) string {
 }
 
 func appendAstarteKeyspaceEnvVars(cr *apiv2alpha1.Astarte) []v1.EnvVar {
-	// Return empty slice if Cassandra is not configured
-	if cr.Spec.Cassandra.Connection == nil {
-		return []v1.EnvVar{}
-	}
-
 	ask := cr.Spec.Cassandra.AstarteSystemKeyspace
 
 	ret := []v1.EnvVar{

--- a/internal/reconcile/utils_test.go
+++ b/internal/reconcile/utils_test.go
@@ -669,14 +669,6 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 			Expect(result).To(Equal(expected))
 		})
 
-		It("should return empty string when no cassandra connection", func() {
-			crWithoutCassandra := cr.DeepCopy()
-			crWithoutCassandra.Spec.Cassandra.Connection = nil
-
-			result := getCassandraNodes(crWithoutCassandra)
-			Expect(result).To(Equal(""))
-		})
-
 		It("should handle multiple cassandra nodes", func() {
 			cr.Spec.Cassandra.Connection.Nodes = append(cr.Spec.Cassandra.Connection.Nodes,
 				apiv2alpha1.HostAndPort{


### PR DESCRIPTION
- Mark Connection field as required in AstarteRabbitMQSpec and AstarteCassandraSpec
- Remove nil checks for Connection fields across codebase
- Update validation tags from Optional to Required in API types
- Simplify utility functions by removing unnecessary nil guards
- Clean up test cases that tested nil connection scenarios