### PR TITLE
test: assert NotFound for deleted resources (replace `ShouldNot(Succeed())`)

### DIFF
--- a/api/api/v2alpha1/astarte_webhook_test.go
+++ b/api/api/v2alpha1/astarte_webhook_test.go
@@ -141,9 +141,10 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 			// Cleanup the secret
 			Expect(k8sClient.Delete(context.Background(), secret)).To(Succeed())
 
-			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: secretName, Namespace: CustomAstarteNamespace}, &v1.Secret{})
-			}, Timeout, Interval).ShouldNot(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: secretName, Namespace: CustomAstarteNamespace}, &v1.Secret{})
+				return apierrors.IsNotFound(err)
+			}, Timeout, Interval).Should(BeTrue())
 		})
 	})
 
@@ -941,9 +942,10 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 				return k8sClient.Delete(context.Background(), newCr)
 			}, Timeout, Interval).Should(Succeed())
 
-			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: newCr.Name, Namespace: CustomAstarteNamespace}, &Astarte{})
-			}, Timeout, Interval).ShouldNot(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: newCr.Name, Namespace: CustomAstarteNamespace}, &Astarte{})
+				return apierrors.IsNotFound(err)
+			}, Timeout, Interval).Should(BeTrue())
 		})
 
 		It("should return error for empty instance ID when another empty ID exists", func() {
@@ -1004,9 +1006,10 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 
 			// Cleanup
 			Expect(k8sClient.Delete(context.Background(), cr1)).To(Succeed())
-			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: CustomAstarteNamespace}, &Astarte{})
-			}, Timeout, Interval).ShouldNot(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: CustomAstarteNamespace}, &Astarte{})
+				return apierrors.IsNotFound(err)
+			}, Timeout, Interval).Should(BeTrue())
 		})
 
 		It("should not return error if no other Astarte instances exists with same instanceID", func() {
@@ -1044,14 +1047,16 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 
 			// Cleanup
 			Expect(k8sClient.Delete(context.Background(), cr1)).To(Succeed())
-			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: CustomAstarteNamespace}, &Astarte{})
-			}, Timeout, Interval).ShouldNot(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: CustomAstarteNamespace}, &Astarte{})
+				return apierrors.IsNotFound(err)
+			}, Timeout, Interval).Should(BeTrue())
 
 			Expect(k8sClient.Delete(context.Background(), cr2)).To(Succeed())
-			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr2.Name, Namespace: CustomAstarteNamespace}, &Astarte{})
-			}, Timeout, Interval).ShouldNot(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr2.Name, Namespace: CustomAstarteNamespace}, &Astarte{})
+				return apierrors.IsNotFound(err)
+			}, Timeout, Interval).Should(BeTrue())
 		})
 	})
 })

--- a/internal/controller/api/astarte_finalizer_test.go
+++ b/internal/controller/api/astarte_finalizer_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -110,9 +111,10 @@ var _ = Describe("Astarte Finalizer testing", Ordered, Serial, func() {
 			Expect(cr.GetFinalizers()).ToNot(ContainElement(astarteFinalizer))
 
 			// Verify CR is eventually deleted (handleFinalization should have updated it)
-			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, &v2alpha1.Astarte{})
-			}, Timeout, Interval).ShouldNot(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, &v2alpha1.Astarte{})
+				return apierrors.IsNotFound(err)
+			}, Timeout, Interval).Should(BeTrue())
 		})
 	})
 

--- a/internal/reconcile/astarte_data_updater_plant_test.go
+++ b/internal/reconcile/astarte_data_updater_plant_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -126,9 +127,10 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 
 			// Cleanup
 			Expect(k8sClient.Delete(context.Background(), cr1)).To(Succeed())
-			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: cr1.Namespace}, &apiv2alpha1.Astarte{})
-			}, Timeout, Interval).ShouldNot(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: cr1.Namespace}, &apiv2alpha1.Astarte{})
+				return apierrors.IsNotFound(err)
+			}, Timeout, Interval).Should(BeTrue())
 		})
 	})
 

--- a/internal/reconcile/astarte_priorityclass_test.go
+++ b/internal/reconcile/astarte_priorityclass_test.go
@@ -29,6 +29,7 @@ import (
 	"go.openly.dev/pointy"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -74,9 +75,10 @@ var _ = Describe("Astarte PriorityClass reconcile tests", Ordered, Serial, func(
 			// Objects should not exist
 			for _, name := range []string{AstarteHighPriorityName, AstarteMidPriorityName, AstarteLowPriorityName} {
 				pc := &schedulingv1.PriorityClass{}
-				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{Name: name}, pc)
-				}, Timeout, Interval).ShouldNot(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(context.Background(), types.NamespacedName{Name: name}, pc)
+					return apierrors.IsNotFound(err)
+				}, Timeout, Interval).Should(BeTrue())
 			}
 
 			// Explicitly disable
@@ -88,9 +90,10 @@ var _ = Describe("Astarte PriorityClass reconcile tests", Ordered, Serial, func(
 			Expect(EnsureAstartePriorityClasses(cr, k8sClient, scheme.Scheme)).To(Succeed())
 			for _, name := range []string{AstarteHighPriorityName, AstarteMidPriorityName, AstarteLowPriorityName} {
 				pc := &schedulingv1.PriorityClass{}
-				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{Name: name}, pc)
-				}, Timeout, Interval).ShouldNot(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(context.Background(), types.NamespacedName{Name: name}, pc)
+					return apierrors.IsNotFound(err)
+				}, Timeout, Interval).Should(BeTrue())
 			}
 		})
 


### PR DESCRIPTION
Replace generic Eventually(...).ShouldNot(Succeed()) checks with explicit Eventual checks that assert apierrors.IsNotFound(err). This makes tests verify the expected absence of resources (NotFound) instead of any generic error, reducing false positives from unrelated failures. Also added the required import of k8s.io/apimachinery/pkg/api/errors where needed.