### PR TITLE
fix: `DATA_UPDATER_PLANT_AMQP_EVENTS_EXCHANGE_NAME` should not be empty

### DIFF
--- a/internal/reconcile/utils.go
+++ b/internal/reconcile/utils.go
@@ -518,11 +518,15 @@ func appendAstarteEventsProducerEnvVars(ret []v1.EnvVar, cr *apiv2alpha1.Astarte
 			Name:  "ASTARTE_EVENTS_PRODUCER_AMQP_DATA_QUEUE_TOTAL_COUNT",
 			Value: "128",
 		},
-		v1.EnvVar{
-			Name:  "ASTARTE_EVENTS_PRODUCER_AMQP_EVENTS_EXCHANGE_NAME",
-			Value: cr.Spec.RabbitMQ.EventsExchangeName,
-		},
 	)
+
+	if cr.Spec.RabbitMQ.EventsExchangeName != "" {
+		ret = append(ret,
+			v1.EnvVar{
+				Name:  "ASTARTE_EVENTS_PRODUCER_AMQP_EVENTS_EXCHANGE_NAME",
+				Value: cr.Spec.RabbitMQ.EventsExchangeName,
+			})
+	}
 
 	return ret
 }


### PR DESCRIPTION
The `ASTARTE_EVENTS_PRODUCER_AMQP_EVENTS_EXCHANGE_NAME` env var should not be injected if `eventsExchangeName` is an empty string.

This PR fixes bug introduced in https://github.com/astarte-platform/astarte-kubernetes-operator/pull/515