### PR TITLE
fix: handle injection of `*-CLUSTERING_KUBERNETES_SELECTOR` env vars

### DIFF
--- a/internal/reconcile/astarte_generic_api.go
+++ b/internal/reconcile/astarte_generic_api.go
@@ -284,6 +284,21 @@ func getAstarteRealmManagementEnvVars(cr *apiv2alpha1.Astarte) []v1.EnvVar {
 	// AMQP Producer configuration is now mandatory
 	ret = appendAstarteEventsProducerEnvVars(ret, cr)
 
+	ret = append(ret, v1.EnvVar{
+		Name:  "DATA_UPDATER_PLANT_CLUSTERING_KUBERNETES_SELECTOR",
+		Value: fmt.Sprint("app=", cr.Name, "-data-updater-plant"),
+	})
+
+	ret = append(ret, v1.EnvVar{
+		Name:  "REALM_MANAGEMENT_CLUSTERING_KUBERNETES_SELECTOR",
+		Value: fmt.Sprint("app=", cr.Name, "-realm-management"),
+	})
+
+	ret = append(ret, v1.EnvVar{
+		Name:  "PAIRING_CLUSTERING_KUBERNETES_SELECTOR",
+		Value: fmt.Sprint("app=", cr.Name, "-pairing"),
+	})
+
 	return ret
 }
 
@@ -304,6 +319,12 @@ func getAstarteAppEngineAPIEnvVars(cr *apiv2alpha1.Astarte) []v1.EnvVar {
 		Name:  "CASSANDRA_NODES",
 		Value: getCassandraNodes(cr),
 	})
+
+	ret = append(ret,
+		v1.EnvVar{
+			Name:  "DATA_UPDATER_PLANT_CLUSTERING_KUBERNETES_SELECTOR",
+			Value: fmt.Sprint("app=", cr.Name, "-data-updater-plant"),
+		})
 
 	ret = append(ret,
 		v1.EnvVar{

--- a/internal/reconcile/astarte_generic_backend.go
+++ b/internal/reconcile/astarte_generic_backend.go
@@ -20,6 +20,7 @@ package reconcile
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"go.openly.dev/pointy"
@@ -271,6 +272,12 @@ func getAstarteDataUpdaterPlantBackendEnvVars(replicaIndex, replicas int, cr *ap
 			Name: "DATA_UPDATER_PLANT_AMQP_DATA_QUEUE_TOTAL_COUNT",
 			// This must always hold the total data queue count, not just the one this specific replica of DUP is using
 			Value: strconv.Itoa(getDataQueueCount(cr)),
+		})
+
+	ret = append(ret,
+		v1.EnvVar{
+			Name:  "DATA_UPDATER_PLANT_CLUSTERING_KUBERNETES_SELECTOR",
+			Value: fmt.Sprint("app=", cr.Name, "-data-updater-plant"),
 		})
 
 	if cr.Spec.RabbitMQ.DataQueuesPrefix != "" {

--- a/internal/reconcile/utils.go
+++ b/internal/reconcile/utils.go
@@ -369,15 +369,10 @@ func getAstarteCommonEnvVars(deploymentName string, cr *apiv2alpha1.Astarte, com
 
 		// If Astarte version is bigger than 1.2.0, we need to set clustering environment variables.
 		if cr.Spec.Version != "" && semver.MustParse(cr.Spec.Version).GreaterThan(semver.MustParse("1.2.0")) {
-			ret = append(ret, v1.EnvVar{
-				Name:  "CLUSTERING_STRATEGY",
-				Value: "kubernetes",
-			})
-
 			ret = append(ret,
 				v1.EnvVar{
-					Name:  "DATA_UPDATER_PLANT_CLUSTERING_KUBERNETES_SELECTOR",
-					Value: fmt.Sprint("app=", cr.Name, "-data-updater-plant"),
+					Name:  "CLUSTERING_STRATEGY",
+					Value: "kubernetes",
 				})
 
 			ret = append(ret,


### PR DESCRIPTION
Based on: https://github.com/astarte-platform/astarte-kubernetes-operator/issues/522

Astarte Realm Management has now gained:
- `REALM_MANAGEMENT_CLUSTERING_KUBERNETES_SELECTOR`: The Endpoint label to query to get other realm management instances
- `PAIRING_CLUSTERING_KUBERNETES_SELECTOR`: The Endpoint label to query to get pairing instances

The env var `DATA_UPDATER_PLANT_CLUSTERING_KUBERNETES_SELECTOR` was being set on AppEngineAPI, DataUpdaterPlant, RealmManagement and Pairing but Pairing does not really need it. We proceed to remove it from Pairing.