### PR TITLE
feat: Add `SECRET_KEY_BASE` env var to Astarte components

### DIFF
--- a/internal/controllerutils/astarte_controller.go
+++ b/internal/controllerutils/astarte_controller.go
@@ -258,6 +258,12 @@ func (r *ReconcileHelper) ReconcileAstarteResources(instance *apiv2alpha1.Astart
 	if err := recon.EnsureHousekeepingKey(instance, r.Client, r.Scheme); err != nil {
 		return err
 	}
+
+	// Ensure Secret Key Base
+	if err := recon.EnsureSecretKeyBase(instance, r.Client, r.Scheme); err != nil {
+		return err
+	}
+
 	// Then, make sure we have an up to date Erlang Configuration for our Pods
 	if err := recon.EnsureGenericErlangConfiguration(instance, r.Client, r.Scheme); err != nil {
 		return err

--- a/internal/reconcile/common_test.go
+++ b/internal/reconcile/common_test.go
@@ -83,6 +83,21 @@ var _ = Describe("Common reconcile testing", Ordered, func() {
 			Expect(secretPublic.Data).To(HaveKey("public-key"))
 		})
 
+		It("Should create a valid Secret Key Base", func() {
+			// Ensure the housekeeping key is created
+			Expect(EnsureSecretKeyBase(cr, k8sClient, scheme.Scheme)).To(Succeed())
+
+			// Check that the housekeeping keypair secrets are present
+			secret := &v1.Secret{}
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{
+					Name:      CustomAstarteName + "-secret-key-base",
+					Namespace: CustomAstarteNamespace,
+				}, secret)
+			}, Timeout, Interval).Should(Succeed())
+			Expect(secret.Data).To(HaveKey("key"))
+		})
+
 		Describe("Test EnsureGenericErlangConfiguration", func() {
 			It("should create the Generic Erlang Configuration ConfigMap", func() {
 				Expect(EnsureGenericErlangConfiguration(cr, k8sClient, scheme.Scheme)).To(Succeed())

--- a/internal/reconcile/utils.go
+++ b/internal/reconcile/utils.go
@@ -358,6 +358,13 @@ func getAstarteCommonEnvVars(deploymentName string, cr *apiv2alpha1.Astarte, com
 			Name:  "RELEASE_NAME",
 			Value: component.DockerImageName(),
 		},
+		{
+			Name: "SECRET_KEY_BASE",
+			ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{Name: fmt.Sprintf("%s-secret-key-base", cr.Name)},
+				Key:                  "key",
+			}},
+		},
 	}
 
 	// We need extra care for Erlang cookie, as some services share the same one


### PR DESCRIPTION
This commit implements the automatic generation and management of the  `SECRET_KEY_BASE` environment variable, which is required for `Phoenix.Tokens`  signing and the FDO TO2 protocol.

Key changes:
- Added `EnsureSecretKeyBase` reconciliation logic: Checks for the existence  of a secret named `<name>-secret-key-base`. If missing, it generates a  random 48-byte sequence, Base64 encodes it (resulting in a 64-character  string), and stores it in the secret.
- Updated the controller loop to execute `EnsureSecretKeyBase` before  configuring Erlang settings.
- Injected the `SECRET_KEY_BASE` environment variable into Astarte component  containers, populating it from the generated Kubernetes Secret.
- Added tests

Closes: https://github.com/astarte-platform/astarte-kubernetes-operator/issues/524