### PR TITLE
refactor: fix code according to golangci-lint configuration

### DIFF
--- a/api/ingress/v2alpha1/astartedefaultingress_types.go
+++ b/api/ingress/v2alpha1/astartedefaultingress_types.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v2alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,7 +82,7 @@ type AstarteDefaultIngressSpec struct {
 type AstarteDefaultIngressStatus struct {
 	metav1.TypeMeta `json:",inline"`
 	APIStatus       networkingv1.IngressStatus `json:"api,omitempty"`
-	BrokerStatus    corev1.ServiceStatus       `json:"broker,omitempty"`
+	BrokerStatus    v1.ServiceStatus           `json:"broker,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/internal/controller/api/astarte_controller.go
+++ b/internal/controller/api/astarte_controller.go
@@ -75,7 +75,7 @@ func (r *AstarteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Fetch the Astarte instance
 	instance := &apiv2alpha1.Astarte{}
-	if err := r.Client.Get(ctx, req.NamespacedName, instance); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
@@ -98,7 +98,7 @@ func (r *AstarteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		// If that is so, compute the status and quit.
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			instance = &apiv2alpha1.Astarte{}
-			if err := r.Client.Get(ctx, req.NamespacedName, instance); err != nil {
+			if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 				return err
 			}
 
@@ -168,7 +168,7 @@ func (r *AstarteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Update the status
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		instance := &apiv2alpha1.Astarte{}
-		if err := r.Client.Get(ctx, req.NamespacedName, instance); err != nil {
+		if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 			return err
 		}
 

--- a/internal/controller/api/astarte_finalizer.go
+++ b/internal/controller/api/astarte_finalizer.go
@@ -43,7 +43,7 @@ func (r *AstarteReconciler) handleFinalization(instance *v2alpha1.Astarte) (ctrl
 		// Remove astarteFinalizer. Once all finalizers have been
 		// removed, the object will be deleted.
 		instance.SetFinalizers(remove(instance.GetFinalizers(), astarteFinalizer))
-		if e := r.Client.Update(context.TODO(), instance); e != nil {
+		if e := r.Update(context.TODO(), instance); e != nil {
 			return ctrl.Result{}, e
 		}
 	}
@@ -56,7 +56,7 @@ func (r *AstarteReconciler) addFinalizer(cr *v2alpha1.Astarte) error {
 	cr.SetFinalizers(append(cr.GetFinalizers(), astarteFinalizer))
 
 	// Update CR
-	err := r.Client.Update(context.TODO(), cr)
+	err := r.Update(context.TODO(), cr)
 	if err != nil {
 		reqLogger.Error(err, "Failed to update Astarte with finalizer")
 		return err

--- a/internal/controller/api/astarte_finalizer_test.go
+++ b/internal/controller/api/astarte_finalizer_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
 	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 )
@@ -112,7 +111,7 @@ var _ = Describe("Astarte Finalizer testing", Ordered, Serial, func() {
 
 			// Verify CR is eventually deleted (handleFinalization should have updated it)
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, &v2alpha1.Astarte{})
+				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, &apiv2alpha1.Astarte{})
 				return apierrors.IsNotFound(err)
 			}, Timeout, Interval).Should(BeTrue())
 		})

--- a/internal/controller/flow/flow_controller.go
+++ b/internal/controller/flow/flow_controller.go
@@ -56,7 +56,7 @@ func (r *FlowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	// Fetch the Flow instance
 	instance := &flowv2alpha1.Flow{}
-	if err := r.Client.Get(ctx, req.NamespacedName, instance); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
@@ -85,7 +85,7 @@ func (r *FlowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// Any leftovers we should delete?
 	for _, b := range existingBlocks {
 		block := b
-		if e := r.Client.Delete(ctx, &block); e != nil {
+		if e := r.Delete(ctx, &block); e != nil {
 			return reconcile.Result{}, e
 		}
 	}
@@ -93,7 +93,7 @@ func (r *FlowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// Update the Status and finish the reconciliation
 	if err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		instance = &flowv2alpha1.Flow{}
-		if err = r.Client.Get(ctx, req.NamespacedName, instance); err != nil {
+		if err = r.Get(ctx, req.NamespacedName, instance); err != nil {
 			return err
 		}
 
@@ -145,11 +145,11 @@ func (r *FlowReconciler) computeFlowStatusResource(reqLogger logr.Logger, instan
 func (r *FlowReconciler) getResourcesForReconciliationFor(instance *flowv2alpha1.Flow) (*apiv2alpha1.Astarte, map[string]appsv1.Deployment, reconcile.Result, error) {
 	// Get the Astarte instance for the Flow
 	astarte := &apiv2alpha1.Astarte{}
-	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.Astarte.Name, Namespace: instance.Namespace}, astarte); err != nil {
+	if err := r.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.Astarte.Name, Namespace: instance.Namespace}, astarte); err != nil {
 		if errors.IsNotFound(err) {
 			d, _ := time.ParseDuration("30s")
 			return nil, nil, reconcile.Result{Requeue: true, RequeueAfter: d},
-				fmt.Errorf("The Astarte Instance %s associated to this Flow cannot be found", instance.Spec.Astarte)
+				fmt.Errorf("the Astarte Instance %s associated to this Flow cannot be found", instance.Spec.Astarte)
 		}
 		// Error reading the object - requeue the request.
 		return nil, nil, reconcile.Result{}, err
@@ -185,7 +185,7 @@ func (r *FlowReconciler) getAllBlocksDeploymentsForFlow(instance *flowv2alpha1.F
 		"flow-name":      instance.Name,
 	}
 	blockList := appsv1.DeploymentList{}
-	err := r.Client.List(context.TODO(), &blockList, client.InNamespace(instance.Namespace), client.MatchingLabels(blockLabels))
+	err := r.List(context.TODO(), &blockList, client.InNamespace(instance.Namespace), client.MatchingLabels(blockLabels))
 
 	return blockList, err
 }
@@ -209,7 +209,7 @@ func (r *FlowReconciler) computeBlocksState(reqLogger logr.Logger, blockList app
 			readyBlocks++
 		} else {
 			podList := &v1.PodList{}
-			if err := r.Client.List(context.TODO(), podList, client.InNamespace(instance.Namespace),
+			if err := r.List(context.TODO(), podList, client.InNamespace(instance.Namespace),
 				client.MatchingLabels{"flow-block": b.Labels["flow-block"]}); err != nil {
 				reqLogger.Error(err, "Could not fetch pods for Block", "block", b.Name)
 				continue

--- a/internal/controller/ingress/astartedefaultingress_controller.go
+++ b/internal/controller/ingress/astartedefaultingress_controller.go
@@ -64,7 +64,7 @@ func (r *AstarteDefaultIngressReconciler) Reconcile(ctx context.Context, req ctr
 
 	// Fetch the AstarteDefaultIngress instance
 	instance := &ingressv2alpha1.AstarteDefaultIngress{}
-	err := r.Client.Get(context.TODO(), req.NamespacedName, instance)
+	err := r.Get(context.TODO(), req.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -78,7 +78,7 @@ func (r *AstarteDefaultIngressReconciler) Reconcile(ctx context.Context, req ctr
 
 	// Get the Astarte instance
 	astarte := &apiv2alpha1.Astarte{}
-	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.Astarte, Namespace: instance.Namespace}, astarte); err != nil {
+	if err := r.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.Astarte, Namespace: instance.Namespace}, astarte); err != nil {
 		if errors.IsNotFound(err) {
 			d, _ := time.ParseDuration("30s")
 			return ctrl.Result{Requeue: true, RequeueAfter: d},
@@ -104,7 +104,7 @@ func (r *AstarteDefaultIngressReconciler) Reconcile(ctx context.Context, req ctr
 
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		instance := &ingressv2alpha1.AstarteDefaultIngress{}
-		if err := r.Client.Get(ctx, req.NamespacedName, instance); err != nil {
+		if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 			return err
 		}
 

--- a/internal/controllerutils/astarte_controller.go
+++ b/internal/controllerutils/astarte_controller.go
@@ -59,12 +59,12 @@ func (r *ReconcileHelper) CheckAndPerformUpgrade(reqLogger logr.Logger, instance
 	// when the cluster was healthy. As such, proceed if one among the computed health and the reported health are green.
 	computedClusterHealth := r.ComputeClusterHealth(reqLogger, instance)
 	if computedClusterHealth != apiv2alpha1.AstarteClusterHealthGreen && instance.Status.Health != apiv2alpha1.AstarteClusterHealthGreen {
-		reqLogger.Error(fmt.Errorf("Astarte Upgrade requested, but the cluster isn't reporting stable Health. Refusing to upgrade"),
+		reqLogger.Error(fmt.Errorf("astarte upgrade requested, but the cluster isn't reporting stable health. Refusing to upgrade"),
 			"Cluster health is unstable, refusing to upgrade. Please revert to the previous version and wait for the cluster to settle.",
-			"Reported Health", instance.Status.Health, "Computed Health", computedClusterHealth)
+			"Reported health", instance.Status.Health, "Computed health", computedClusterHealth)
 		r.Recorder.Event(instance, "Warning", apiv2alpha1.AstarteResourceEventCriticalError.String(),
-			fmt.Sprintf("Cluster health is %s, refusing to upgrade. Please revert to the previous version and wait for the cluster to settle", computedClusterHealth))
-		return ctrl.Result{Requeue: false}, fmt.Errorf("Astarte Upgrade requested, but the cluster isn't reporting stable Health. Refusing to upgrade")
+			fmt.Sprintf("cluster health is %s, refusing to upgrade. Please revert to the previous version and wait for the cluster to settle", computedClusterHealth))
+		return ctrl.Result{Requeue: false}, fmt.Errorf("astarte upgrade requested, but the cluster isn't reporting stable health. Refusing to upgrade")
 	}
 	// We need to check for upgrades.
 	versionString := instance.Status.AstarteVersion
@@ -117,9 +117,10 @@ func (r *ReconcileHelper) ComputeClusterHealth(reqLogger logr.Logger, instance *
 		nonReadyDeployments++
 	}
 
-	if nonReadyDeployments == 0 {
+	switch nonReadyDeployments {
+	case 0:
 		return apiv2alpha1.AstarteClusterHealthGreen
-	} else if nonReadyDeployments == 1 {
+	case 1:
 		return apiv2alpha1.AstarteClusterHealthYellow
 	}
 	return apiv2alpha1.AstarteClusterHealthRed
@@ -174,9 +175,9 @@ func (r *ReconcileHelper) EnsureStatusCoherency(reqLogger logr.Logger, instance 
 		if len(hkImageTokens) != 2 {
 			// Reconcile every minute if we're here
 			r.Recorder.Eventf(instance, "Warning", apiv2alpha1.AstarteResourceEventCriticalError.String(),
-				"Could not parse Astarte version from Housekeeping Image tag %s. Please fix your resource definition", hkImage)
+				"could not parse Astarte version from Housekeeping Image tag %s. Please fix your resource definition", hkImage)
 			return ctrl.Result{RequeueAfter: time.Minute},
-				fmt.Errorf("Could not parse Astarte version from Housekeeping Image tag %s. Refusing to proceed", hkImage)
+				fmt.Errorf("could not parse Astarte version from Housekeeping Image tag %s. Refusing to proceed", hkImage)
 		}
 
 		// Update the status

--- a/internal/defaultingress/api_ingress.go
+++ b/internal/defaultingress/api_ingress.go
@@ -178,7 +178,7 @@ func getHAProxyAPIIngressRules(cr *ingressv2alpha1.AstarteDefaultIngress, parent
 		return ingressRules
 	}
 
-	var dashboardPaths []networkingv1.HTTPIngressPath
+	dashboardPaths := make([]networkingv1.HTTPIngressPath, 0, 1)
 	dashboard := apiv2alpha1.Dashboard
 
 	dashboardPaths = append(dashboardPaths, networkingv1.HTTPIngressPath{

--- a/internal/defaultingress/common.go
+++ b/internal/defaultingress/common.go
@@ -45,7 +45,7 @@ func buildContentSecurityPolicy(cr *ingressv2alpha1.AstarteDefaultIngress, paren
 	}
 
 	backend := parent.Spec.API.Host
-	var parts []string
+	parts := make([]string, 0, 7)
 
 	// The best practice for CSP would be to deny everything and allow only
 	// the content we need from the sources we trust.

--- a/internal/flow/block.go
+++ b/internal/flow/block.go
@@ -103,7 +103,7 @@ func EnsureBlock(cr *flowv2alpha1.Flow, block flowv2alpha1.ContainerBlockSpec, a
 		}
 
 		// Assign the Spec.
-		deployment.ObjectMeta.Labels = blockLabels
+		deployment.Labels = blockLabels
 		deployment.Spec = appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: blockLabels},
 			// Use Recreate, as we don't want to be in the situation where multiple replicas are alive.
@@ -209,16 +209,15 @@ func ensureWorkerContainer(block flowv2alpha1.ContainerBlockSpec, worker flowv2a
 
 func generateVolumesFor(cr *flowv2alpha1.Flow, block flowv2alpha1.ContainerBlockSpec, astarte *apiv2alpha1.Astarte) []v1.Volume {
 	// Start with the block-config volume
-	ret := []v1.Volume{
-		{
-			Name: "block-config",
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					SecretName: GenerateBlockName(cr, block, astarte),
-				},
+	ret := make([]v1.Volume, 0, 1+len(block.Workers))
+	ret = append(ret, v1.Volume{
+		Name: "block-config",
+		VolumeSource: v1.VolumeSource{
+			Secret: &v1.SecretVolumeSource{
+				SecretName: GenerateBlockName(cr, block, astarte),
 			},
 		},
-	}
+	})
 
 	// Add every worker configuration.
 	for _, w := range block.Workers {

--- a/internal/reconcile/astarte_dashboard.go
+++ b/internal/reconcile/astarte_dashboard.go
@@ -79,7 +79,7 @@ func EnsureAstarteDashboard(cr *apiv2alpha1.Astarte, dashboard apiv2alpha1.Astar
 			return err
 		}
 		// Always set everything to what we require.
-		service.ObjectMeta.Labels = labels
+		service.Labels = labels
 		service.Spec.Type = v1.ServiceTypeClusterIP
 		service.Spec.ClusterIP = noneClusterIP
 		service.Spec.Ports = []v1.ServicePort{
@@ -119,7 +119,7 @@ func EnsureAstarteDashboard(cr *apiv2alpha1.Astarte, dashboard apiv2alpha1.Astar
 		}
 
 		// Assign the Spec.
-		deployment.ObjectMeta.Labels = labels
+		deployment.Labels = labels
 		deployment.Spec = deploymentSpec
 		deployment.Spec.Replicas = getReplicaCountForResource(&dashboard.AstarteGenericClusteredResource, cr, c, reqLogger)
 

--- a/internal/reconcile/astarte_data_updater_plant.go
+++ b/internal/reconcile/astarte_data_updater_plant.go
@@ -36,7 +36,7 @@ import (
 
 // EnsureAstarteDataUpdaterPlant manages multiple deployments for Astarte Data Updater Plant based on scalability requirements
 func EnsureAstarteDataUpdaterPlant(cr *apiv2alpha1.Astarte, dup apiv2alpha1.AstarteDataUpdaterPlantSpec, c client.Client, scheme *runtime.Scheme) error {
-	replicas := pointy.Int32Value(dup.AstarteGenericClusteredResource.Replicas, 1)
+	replicas := pointy.Int32Value(dup.Replicas, 1)
 	component := apiv2alpha1.DataUpdaterPlant
 
 	// Let's list the existing deployments labeled DUP
@@ -46,14 +46,14 @@ func EnsureAstarteDataUpdaterPlant(cr *apiv2alpha1.Astarte, dup apiv2alpha1.Asta
 		return err
 	}
 
-	if len(currentDUPDeployments.Items) > int(replicas) || !pointy.BoolValue(dup.AstarteGenericClusteredResource.Deploy, true) {
+	if len(currentDUPDeployments.Items) > int(replicas) || !pointy.BoolValue(dup.Deploy, true) {
 		// In this case, we should schedule for immediate deletion all of the deployments and recreate them.
 		if err := c.DeleteAllOf(context.Background(), &appsv1.Deployment{}, client.InNamespace(cr.Namespace),
 			client.MatchingLabels{"astarte-component": component.DashedString()}); err != nil {
 			return err
 		}
 		// If we shouldn't deploy, just return now then.
-		if !pointy.BoolValue(dup.AstarteGenericClusteredResource.Deploy, true) {
+		if !pointy.BoolValue(dup.Deploy, true) {
 			return nil
 		}
 	}
@@ -130,7 +130,7 @@ func createIndexedDataUpdaterPlantDeployment(replicaIndex, replicas int, cr *api
 		}
 
 		// Assign the Spec.
-		deployment.ObjectMeta.Labels = labels
+		deployment.Labels = labels
 		deployment.Spec = deploymentSpec
 		// Always force to 1
 		deployment.Spec.Replicas = pointy.Int32(1)

--- a/internal/reconcile/astarte_generic_api.go
+++ b/internal/reconcile/astarte_generic_api.go
@@ -103,7 +103,7 @@ func EnsureAstarteGenericAPIComponent(cr *apiv2alpha1.Astarte, api apiv2alpha1.A
 		}
 
 		// Assign the Spec.
-		deployment.ObjectMeta.Labels = labels
+		deployment.Labels = labels
 		deployment.Spec = deploymentSpec
 		deployment.Spec.Replicas = getReplicaCountForResource(&api.AstarteGenericClusteredResource, cr, c, reqLogger)
 
@@ -118,8 +118,8 @@ func EnsureAstarteGenericAPIComponent(cr *apiv2alpha1.Astarte, api apiv2alpha1.A
 }
 
 func checkShouldDeploy(reqLogger logr.Logger, deploymentName string, cr *apiv2alpha1.Astarte, api apiv2alpha1.AstarteGenericAPIComponentSpec,
-	component apiv2alpha1.AstarteComponent, c client.Client) bool {
-	defaultDeployValue := true
+	component apiv2alpha1.AstarteComponent, c client.Client) (defaultDeployValue bool) {
+	defaultDeployValue = true
 	// Flow should be deployed only if explicitly requested
 	if component == apiv2alpha1.FlowComponent {
 		defaultDeployValue = false

--- a/internal/reconcile/astarte_generic_api_test.go
+++ b/internal/reconcile/astarte_generic_api_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 			container := dep.Spec.Template.Spec.Containers[0]
 			hasDisableAuthEnv := false
 			for _, env := range container.Env {
-				if env.Name == "APPENGINE_API_DISABLE_AUTHENTICATION" && env.Value == "true" {
+				if env.Name == "APPENGINE_API_DISABLE_AUTHENTICATION" && env.Value == "true" { //nolint:goconst
 					hasDisableAuthEnv = true
 					break
 				}

--- a/internal/reconcile/astarte_generic_backend.go
+++ b/internal/reconcile/astarte_generic_backend.go
@@ -105,7 +105,7 @@ func EnsureAstarteGenericBackend(cr *apiv2alpha1.Astarte, backend apiv2alpha1.As
 		}
 
 		// Assign the Spec.
-		deployment.ObjectMeta.Labels = labels
+		deployment.Labels = labels
 		deployment.Spec = deploymentSpec
 		deployment.Spec.Replicas = getReplicaCountForResource(&backend, cr, c, reqLogger)
 

--- a/internal/reconcile/cfssl.go
+++ b/internal/reconcile/cfssl.go
@@ -184,22 +184,20 @@ func getCFSSLPodSpec(deploymentName, secretName string, cr *apiv2alpha1.Astarte)
 		resources = *cr.Spec.CFSSL.Resources
 	}
 
-	volumeMounts := []v1.VolumeMount{
-		{
-			Name:      "config",
-			MountPath: "/etc/cfssl",
-		},
-	}
-	volumes := []v1.Volume{
-		{
-			Name: "config",
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{Name: deploymentName + "-config"},
-				},
+	volumeMounts := make([]v1.VolumeMount, 0, 2)
+	volumeMounts = append(volumeMounts, v1.VolumeMount{
+		Name:      "config",
+		MountPath: "/etc/cfssl",
+	})
+	volumes := make([]v1.Volume, 0, 2)
+	volumes = append(volumes, v1.Volume{
+		Name: "config",
+		VolumeSource: v1.VolumeSource{
+			ConfigMap: &v1.ConfigMapVolumeSource{
+				LocalObjectReference: v1.LocalObjectReference{Name: deploymentName + "-config"},
 			},
 		},
-	}
+	})
 	env := []v1.EnvVar{}
 
 	volumeMounts = append(volumeMounts, v1.VolumeMount{

--- a/internal/reconcile/utils.go
+++ b/internal/reconcile/utils.go
@@ -796,31 +796,31 @@ func getAstarteCommonVolumeMounts(cr *apiv2alpha1.Astarte) []v1.VolumeMount {
 	return ret
 }
 
-func getAffinityForClusteredResource(appLabel string, resource apiv2alpha1.AstarteGenericClusteredResource) *v1.Affinity {
-	affinity := resource.CustomAffinity
-	if affinity == nil && pointy.BoolValue(resource.AntiAffinity, true) {
+func getAffinityForClusteredResource(appLabel string, r apiv2alpha1.AstarteGenericClusteredResource) *v1.Affinity {
+	affinity := r.CustomAffinity
+	if affinity == nil && pointy.BoolValue(r.AntiAffinity, true) {
 		affinity = getStandardAntiAffinityForAppLabel(appLabel)
 	}
 	return affinity
 }
 
-func getAstarteImageForClusteredResource(defaultImageName string, resource apiv2alpha1.AstarteGenericClusteredResource, cr *apiv2alpha1.Astarte) string {
-	if resource.Image != "" {
-		return resource.Image
+func getAstarteImageForClusteredResource(defaultImageName string, r apiv2alpha1.AstarteGenericClusteredResource, cr *apiv2alpha1.Astarte) string {
+	if r.Image != "" {
+		return r.Image
 	}
 
-	return getAstarteImageFromChannel(defaultImageName, version.GetVersionForAstarteComponent(cr.Spec.Version, resource.Version), cr)
+	return getAstarteImageFromChannel(defaultImageName, version.GetVersionForAstarteComponent(cr.Spec.Version, r.Version), cr)
 }
 
-func getDeploymentStrategyForClusteredResource(cr *apiv2alpha1.Astarte, resource apiv2alpha1.AstarteGenericClusteredResource, component apiv2alpha1.AstarteComponent) appsv1.DeploymentStrategy {
+func getDeploymentStrategyForClusteredResource(cr *apiv2alpha1.Astarte, r apiv2alpha1.AstarteGenericClusteredResource, component apiv2alpha1.AstarteComponent) appsv1.DeploymentStrategy {
 	switch {
 	case component == apiv2alpha1.DataUpdaterPlant, component == apiv2alpha1.TriggerEngine,
 		component == apiv2alpha1.FlowComponent:
 		return appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
 		}
-	case resource.DeploymentStrategy != nil:
-		return *resource.DeploymentStrategy
+	case r.DeploymentStrategy != nil:
+		return *r.DeploymentStrategy
 	case cr.Spec.DeploymentStrategy != nil:
 		return *cr.Spec.DeploymentStrategy
 	default:
@@ -855,7 +855,7 @@ func createOrUpdateService(cr *apiv2alpha1.Astarte, c client.Client, serviceName
 			return e
 		}
 		// Always set everything to what we require.
-		service.ObjectMeta.Labels = labels
+		service.Labels = labels
 		service.Spec.Type = v1.ServiceTypeClusterIP
 		service.Spec.ClusterIP = noneClusterIP
 		service.Spec.Ports = []v1.ServicePort{
@@ -886,22 +886,22 @@ func computePodLabels(r apiv2alpha1.PodLabelsGetter, labels map[string]string) m
 	return podLabels
 }
 
-func getReplicaCountForResource(resource *apiv2alpha1.AstarteGenericClusteredResource, cr *apiv2alpha1.Astarte, c client.Client, log logr.Logger) *int32 {
-	if cr.Spec.Features.Autoscaling && resource.Autoscale != nil {
-		if hpaStatus, err := getHPAStatusForResource(resource.Autoscale.Horizontal, cr, c, log); err == nil {
+func getReplicaCountForResource(r *apiv2alpha1.AstarteGenericClusteredResource, cr *apiv2alpha1.Astarte, c client.Client, log logr.Logger) *int32 {
+	if cr.Spec.Features.Autoscaling && r.Autoscale != nil {
+		if hpaStatus, err := getHPAStatusForResource(r.Autoscale.Horizontal, cr, c, log); err == nil {
 			// This is a special case to avoid a race condition with HPA, which can lead to the Operator
 			// and HPA fighting over replica count, causing service disruption. This can happen when
 			// the HPA isn't able to fetch metrics for the pods, and decides to scale down to 0.
 			// This is a known issue in HPA, and this is a workaround to avoid it.
 			if hpaStatus.DesiredReplicas == 0 {
-				log.Info("HPA is reporting 0 desired replicas. This is likely a transient state. Ignoring HPA and using the spec's replica count", "HPA.Name", resource.Autoscale.Horizontal)
-				return resource.Replicas
+				log.Info("HPA is reporting 0 desired replicas. This is likely a transient state. Ignoring HPA and using the spec's replica count", "HPA.Name", r.Autoscale.Horizontal)
+				return r.Replicas
 			}
 			log.Info("Getting replica count from HPA", "value", hpaStatus.DesiredReplicas)
 			return &hpaStatus.DesiredReplicas
 		}
 	}
-	return resource.Replicas
+	return r.Replicas
 }
 
 func getHPAStatusForResource(autoscalerName string, cr *apiv2alpha1.Astarte, c client.Client, log logr.Logger) (autoscalingv2.HorizontalPodAutoscalerStatus, error) {
@@ -915,7 +915,7 @@ func getHPAStatusForResource(autoscalerName string, cr *apiv2alpha1.Astarte, c c
 
 // This stuff is useful for other components which need to interact with Cassandra
 func getCassandraNodes(cr *apiv2alpha1.Astarte) string {
-	nodes := []string{}
+	nodes := make([]string, 0, len(cr.Spec.Cassandra.Connection.Nodes))
 	for _, node := range cr.Spec.Cassandra.Connection.Nodes {
 		nodes = append(nodes, fmt.Sprintf("%s:%d", node.Host, *node.Port))
 	}

--- a/internal/reconcile/vernemq.go
+++ b/internal/reconcile/vernemq.go
@@ -148,7 +148,7 @@ func EnsureVerneMQ(cr *apiv2alpha1.Astarte, c client.Client, scheme *runtime.Sch
 		}
 
 		// Assign the Spec.
-		vmqStatefulSet.ObjectMeta.Labels = map[string]string{"component": "astarte"}
+		vmqStatefulSet.Labels = map[string]string{"component": "astarte"}
 		vmqStatefulSet.Spec = statefulSetSpec
 		vmqStatefulSet.Spec.Replicas = getReplicaCountForResource(&cr.Spec.VerneMQ.AstarteGenericClusteredResource, cr, c, log)
 
@@ -371,7 +371,7 @@ func getVerneMQPodSpec(statefulSetName, dataVolumeName string, cr *apiv2alpha1.A
 	// do we want priorities?
 	if cr.Spec.Features.AstartePodPriorities.IsEnabled() {
 		// is a priorityClass specified in the Astarte CR?
-		switch cr.Spec.VerneMQ.AstarteGenericClusteredResource.PriorityClass {
+		switch cr.Spec.VerneMQ.PriorityClass {
 		case highPriority:
 			ps.PriorityClassName = AstarteHighPriorityName
 		case midPriority:

--- a/internal/webhook/api/v2alpha1/astarte_webhook.go
+++ b/internal/webhook/api/v2alpha1/astarte_webhook.go
@@ -147,7 +147,7 @@ func (v *AstarteCustomValidator) ValidateCreate(_ context.Context, obj runtime.O
 		return nil, errors.New("expected a Astarte resource")
 	}
 
-	astartelog.Info("Validation for Astarte upon creation", "name", r.GetName())
+	astartelog.Info("validation for Astarte upon creation", "name", r.GetName())
 
 	allErrs := field.ErrorList{}
 
@@ -220,7 +220,7 @@ func (v *AstarteCustomValidator) ValidateDelete(_ context.Context, obj runtime.O
 		return nil, errors.New("expected a Astarte resource")
 	}
 
-	astartelog.Info("Validation for Astarte upon deletion", "name", r.GetName())
+	astartelog.Info("validation for Astarte upon deletion", "name", r.GetName())
 
 	return nil, nil
 }
@@ -266,7 +266,7 @@ func validateUpdateAstarteInstanceID(r *apiv2alpha1.Astarte, oldAstarte *apiv2al
 func validateCreateAstarteInstanceID(r *apiv2alpha1.Astarte) *field.Error {
 	astarteList := &apiv2alpha1.AstarteList{}
 	if clientErr := c.List(context.Background(), astarteList); clientErr != nil {
-		err := errors.New("cannot list astarte instances in the cluster. Please retry.")
+		err := errors.New("cannot list astarte instances in the cluster. Please retry")
 		astartelog.Info(clientErr.Error(), "details", err.Error())
 		return field.InternalError(field.NewPath(""), err)
 	}
@@ -377,7 +377,7 @@ func validatePriorityClassesValues(r *apiv2alpha1.Astarte) *field.Error {
 	lowPriorityValue := *r.Spec.Features.AstartePodPriorities.AstarteLowPriority
 
 	if midPriorityValue >= highPriorityValue || lowPriorityValue >= midPriorityValue {
-		err := errors.New("Astarte PriorityClass values are incoherent")
+		err := errors.New("the Astarte PriorityClass values are incoherent")
 		astartelog.Info(err.Error())
 		fldPath := field.NewPath("spec").Child("features").Child("astarte{Low|Medium|High}Priority")
 
@@ -455,7 +455,7 @@ func validateCreateAstarteSystemKeyspace(r *apiv2alpha1.Astarte) field.ErrorList
 
 func validateUpdateAstarteSystemKeyspace(r *apiv2alpha1.Astarte, oldAstarte *apiv2alpha1.Astarte) *field.Error {
 	if r.Spec.Cassandra.AstarteSystemKeyspace != oldAstarte.Spec.Cassandra.AstarteSystemKeyspace {
-		err := errors.New("Once Astarte is created, the astarteSystemKeyspace cannot be modified")
+		err := errors.New("ance Astarte is created, the astarteSystemKeyspace cannot be modified")
 		fldPath := field.NewPath("spec").Child("cassandra").Child("astarteSystemKeyspace")
 		return field.Invalid(fldPath, r.Spec.Cassandra.AstarteSystemKeyspace, err.Error())
 	}
@@ -470,7 +470,7 @@ func validateCFSSLDefinition(r *apiv2alpha1.Astarte) *field.Error {
 
 	// If we are here, CFSSL is not being deployed. Ensure URL is set.
 	if r.Spec.CFSSL.URL == "" {
-		err := errors.New("When not deploying CFSSL, the 'url' must be specified")
+		err := errors.New("when not deploying CFSSL, the 'url' must be specified")
 		fldPath := field.NewPath("spec").Child("cfssl").Child("url")
 		astartelog.Info(err.Error())
 		return field.Invalid(fldPath, r.Spec.CFSSL.URL, err.Error())
@@ -479,7 +479,7 @@ func validateCFSSLDefinition(r *apiv2alpha1.Astarte) *field.Error {
 	// If URL is set, ensure it is compliant with RFC 3986
 	_, err := url.Parse(r.Spec.CFSSL.URL)
 	if err != nil {
-		err := errors.New("The provided URL is not valid")
+		err := errors.New("the provided URL is not valid")
 		fldPath := field.NewPath("spec").Child("cfssl").Child("url")
 		astartelog.Info(err.Error())
 		return field.Invalid(fldPath, r.Spec.CFSSL.URL, err.Error())

--- a/internal/webhook/api/v2alpha1/astarte_webhook_test.go
+++ b/internal/webhook/api/v2alpha1/astarte_webhook_test.go
@@ -936,7 +936,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 		It("should not return error for instance ID when no other same IDs exist", func() {
 			// In the beforeEach of the parent Describe, a CR with empty ID is created
 			newCr := cr.DeepCopy()
-			newCr.ObjectMeta.Name = "test-empty-id-no-conflict"
+			newCr.Name = "test-empty-id-no-conflict"
 			newCr.Spec.AstarteInstanceID = "a1"
 			newCr.ResourceVersion = ""
 
@@ -965,7 +965,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 			// A CR with empty ID is already created in the beforeEach of the parent Describe
 			// Now try to create another with empty ID - should fail
 			newCr := cr.DeepCopy()
-			newCr.ObjectMeta.Name = "test-empty-id-conflict"
+			newCr.Name = "test-empty-id-conflict"
 			newCr.Spec.AstarteInstanceID = ""
 			newCr.ResourceVersion = ""
 
@@ -985,7 +985,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 			// We create a CR with a specific instanceID, then try to create another with the same ID
 			// Create a CR with a specific instanceID
 			cr1 := cr.DeepCopy()
-			cr1.ObjectMeta.Name = "first-astarte-unique"
+			cr1.Name = "first-astarte-unique"
 			cr1.Spec.AstarteInstanceID = "myuniqueinstanceid001"
 			cr1.ResourceVersion = ""
 
@@ -1001,7 +1001,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 
 			// Try to validate a new CR with the same instanceID
 			cr2 := cr1.DeepCopy()
-			cr2.ObjectMeta.Name = "second-astarte-unique"
+			cr2.Name = "second-astarte-unique"
 			cr2.ResourceVersion = ""
 			// Keep same instanceID
 			// Create should fail due to webhook rejection
@@ -1028,7 +1028,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 		It("should not return error if no other Astarte instances exists with same instanceID", func() {
 			// We create a CR with a specific instanceID, then try to create another with a different ID
 			cr1 := cr.DeepCopy()
-			cr1.ObjectMeta.Name = "first-astarte-unique"
+			cr1.Name = "first-astarte-unique"
 			cr1.Spec.AstarteInstanceID = "myuniqueinstanceid002a"
 			cr1.ResourceVersion = ""
 
@@ -1044,7 +1044,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 
 			// Create another with a different instanceID
 			cr2 := cr1.DeepCopy()
-			cr2.ObjectMeta.Name = "second-astarte-unique"
+			cr2.Name = "second-astarte-unique"
 			cr2.Spec.AstarteInstanceID = "myuniqueinstanceid002b"
 			cr2.ResourceVersion = ""
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
+	. "github.com/onsi/gomega"    //nolint:staticcheck
 )
 
 // Run e2e tests using the Ginkgo runner.

--- a/test/e2e/e2e_utils.go
+++ b/test/e2e/e2e_utils.go
@@ -28,7 +28,7 @@ import (
 
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
 )
 
 const (
@@ -163,7 +163,7 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }
 

--- a/test/integration/integration_utils.go
+++ b/test/integration/integration_utils.go
@@ -22,7 +22,7 @@ package integration
 import (
 	"context"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:staticcheck
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"


### PR DESCRIPTION
After the upgrade to Operator SDK 1.42.2, the golangci-lint configuration have been updated.

This commit fixes the following problems raised by golangci-lint:
* Linter Config: Removed the deprecated `golint` from `//nolint` directives.
* goconst: Extracted repeated `"true"` strings into constants (astarte_generic_api_test.go).
* prealloc: Preallocated slices with known capacities in `internal/` and `test/` packages to reduce memory allocations.
* revive: Renamed local `resource` variables in `utils.go` to eliminate import shadowing.
* staticcheck:
  - Cleaned up syntax by removing redundant embedded field selectors like `.Client`, `.ObjectMeta`, and `.AstarteGenericClusteredResource` (QF1008).
  - Fixed error string formatting to follow standard Go conventions (lowercase, no trailing punctuation) (ST1005).
  - Cleaned up imports by removing duplicate imports (ST1019) and avoiding dot imports (ST1001).
  - Replaced `strings.Replace(..., -1)` with `strings.ReplaceAll` (QF1004).
  - Simplified conditional assignments and switch statements (QF1003, QF1007).