### PR TITLE
chore: prepare for v24.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [24.5.2] - 2026-03-25
+
 ## [24.5.2-rc.0] - 2025-09-24
 ### Added
 - AppEngine, DUP, VerneMQ have `get` and `list` permissions on

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 24.5.2-rc.0
+VERSION ?= 24.5.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/charts/astarte-operator/Chart.yaml
+++ b/charts/astarte-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: astarte-operator
 description: The Astarte Kubernetes Operator Helm Chart.
 type: application
 
-version: "24.5.2-rc.0"
-appVersion: "24.5.2-rc.0"
+version: "24.5.2"
+appVersion: "24.5.2"
 kubeVersion: ">= 1.19.0-0"
 
 home: https://github.com/astarte-platform/astarte-kubernetes-operator

--- a/charts/astarte-operator/values.yaml
+++ b/charts/astarte-operator/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: astarte/astarte-kubernetes-operator
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "24.5.2-rc.0"
+  tag: "24.5.2"
 
 # -- Resources to assign to each Astarte Operator instance.
 resources:

--- a/docs/documentation/mix.exs
+++ b/docs/documentation/mix.exs
@@ -8,7 +8,7 @@ defmodule Doc.MixProject do
   def project do
     [
       app: :doc,
-      version: "24.5.2-rc.0",
+      version: "24.5.2",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/version/version.go
+++ b/version/version.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// Version is the Operator's version
-	Version = "24.5.2-rc.0"
+	Version = "24.5.2"
 
 	// AstarteVersionConstraintString represents the range of supported Astarte versions for this Operator.
 	// If the Astarte version falls out of this range, reconciliation will be immediately aborted.


### PR DESCRIPTION
Edit documentation to prepare for tag and release of a stable `24.5.2` version