### PR TITLE
fix: remove obsolete PVC deletion from Astarte finalizer

### DIFF
--- a/internal/controllerutils/astarte_finalizer.go
+++ b/internal/controllerutils/astarte_finalizer.go
@@ -49,9 +49,6 @@ func FinalizeAstarte(c client.Client, name, namespace string, reqLogger logr.Log
 	// different measures.
 	erasePVCPrefixes := []string{
 		name + "-vernemq-data",
-		name + "-rabbitmq-data",
-		name + "-cfssl-data",
-		name + "-cassandra-data",
 	}
 
 	pvcs := &v1.PersistentVolumeClaimList{}


### PR DESCRIPTION
Removed rabbitmq-data, cfssl-data, and cassandra-data from the list of PVC prefixes to be erased during finalization. These components are no longer created, making their deletion in the cleanup logic unnecessary.