### PR TITLE
feat: skip ADI reconciliation when Astarte is in manual maintenance mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [26.5.0-alpha.1] - Unreleased
+### Added
+- When the `manualMaintenanceMode` field is set to `true` in the Astarte CR, the reconciliation of AstarteDefaultIngress resources is skipped.
 
 ### Changed
 - Moved FDO configuration from the `spec.features` field to a dedicated `spec.fdo` field in the Astarte CR.

--- a/internal/controller/ingress/astartedefaultingress_controller.go
+++ b/internal/controller/ingress/astartedefaultingress_controller.go
@@ -88,6 +88,36 @@ func (r *AstarteDefaultIngressReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
+	reconciler := controllerutils.ReconcileHelper{
+		Client: r.Client,
+		Scheme: r.Scheme,
+	}
+
+	// Check if Astarte is in manual maintenance mode
+	if astarte.Spec.ManualMaintenanceMode {
+		// If that is so, compute the status and quit.
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			instance = &ingressv2alpha1.AstarteDefaultIngress{}
+			if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
+				return err
+			}
+
+			instance.Status = reconciler.ComputeADIStatusResource(reqLogger, instance)
+
+			if err := r.Client.Status().Update(ctx, instance); err != nil {
+				reqLogger.Error(err, "Failed to update AstarteDefaultIngress status.")
+				return err
+			}
+			return nil
+		}); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// Notify and return
+		reqLogger.Info("AstarteDefaultIngress Reconciliation skipped due to Manual Maintenance Mode set true in Astarte CR. Hope you know what you're doing!")
+		return ctrl.Result{}, nil
+	}
+
 	// Reconcile the API Ingress
 	if err := defaultingress.EnsureAPIIngress(instance, astarte, r.Client, r.Scheme, reqLogger); err != nil {
 		return ctrl.Result{}, err
@@ -95,11 +125,6 @@ func (r *AstarteDefaultIngressReconciler) Reconcile(ctx context.Context, req ctr
 	// Reconcile the Broker Ingress
 	if err := defaultingress.EnsureBrokerIngress(instance, astarte, r.Client, r.Scheme, reqLogger); err != nil {
 		return ctrl.Result{}, err
-	}
-
-	reconciler := controllerutils.ReconcileHelper{
-		Client: r.Client,
-		Scheme: r.Scheme,
 	}
 
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {


### PR DESCRIPTION
We want to propagate the behavior of Astarte manual maintenance mode to ADI as well. 

When the manualMaintenanceMode field is set to true in the Astarte custom resource, the controller now skips the reconciliation of AstarteDefaultIngress resources. It still updates the resource status before exiting the reconciliation loop.