### PR TITLE
chore(helm): align operator image tag and bump chart version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixed
+- Changed the default image tag from "snapshot" to "26.5.0" in the Helm chart. This fix is released in 26.5.1 version of the Helm chart.
+
 ## [26.5.0] - 2026-05-07
 ### Added
 - When the `manualMaintenanceMode` field is set to `true` in the Astarte CR, the reconciliation of AstarteDefaultIngress resources is skipped.

--- a/charts/astarte-operator/Chart.yaml
+++ b/charts/astarte-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: astarte-operator
 description: The Astarte Kubernetes Operator Helm Chart.
 type: application
 
-version: "26.5.0"
+version: "26.5.1"
 appVersion: "26.5.0"
 kubeVersion: ">= 1.19.0-0"
 

--- a/charts/astarte-operator/values.yaml
+++ b/charts/astarte-operator/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: astarte/astarte-kubernetes-operator
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "snapshot"
+  tag: "26.5.0"
 
 # -- Resources to assign to each Astarte Operator instance.
 resources:


### PR DESCRIPTION
This updates the Helm chart to use the correct release image instead of the development snapshot for the 26.5 cycle. 

Changes:
- Update default image tag in values.yaml from 'snapshot' to '26.5.0'
- Bump chart version in Chart.yaml from 26.5.0 to 26.5.1