### PR TITLE
feat: enhance kubectl output with print columns for Astarte and ADI CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added `Operator Version`, `Astarte Version`, `Health`, `Base API URL` and `Broker URL` columns as print columns to the Astarte CRD.
+- Added `API IP` and `Broker IP` columns as print columns to the ADI CRD.
 
 ## [26.5.1] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [26.7.0] - unreleased
 
+### Added
+- Added `Operator Version`, `Astarte Version`, `Health`, `Base API URL` and `Broker URL` columns as print columns to the Astarte CRD.
+
 ## [26.5.1] - 2026-05-03
 
 ### Fixed

--- a/api/api/v2alpha1/astarte_types.go
+++ b/api/api/v2alpha1/astarte_types.go
@@ -97,6 +97,11 @@ type AstarteStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Operator Version",type=string,JSONPath=`.status.operatorVersion`
+// +kubebuilder:printcolumn:name="Astarte Version",type=string,JSONPath=`.status.astarteVersion`
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.health`
+// +kubebuilder:printcolumn:name="Base API URL",type=string,JSONPath=`.status.baseAPIURL`,priority=1
+// +kubebuilder:printcolumn:name="Broker URL",type=string,JSONPath=`.status.brokerURL`,priority=1
 // Astarte is the Schema for the astartes API
 //
 // **Custom Astarte annotations**

--- a/api/ingress/v2alpha1/astartedefaultingress_types.go
+++ b/api/ingress/v2alpha1/astartedefaultingress_types.go
@@ -90,6 +90,8 @@ type AstarteDefaultIngressStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=adi
+// +kubebuilder:printcolumn:name="API IP",type=string,JSONPath=`.status.api.loadBalancer.ingress[0].ip`,priority=0
+// +kubebuilder:printcolumn:name="Broker IP",type=string,JSONPath=`.status.broker.loadBalancer.ingress[0].ip`,priority=0
 // AstarteDefaultIngress is the Schema for the astartedefaultingresses API
 //
 // **Custom ADI annotations**

--- a/charts/astarte-operator/templates/crds/astartedefaultingresses.ingress.astarte-platform.org.yaml
+++ b/charts/astarte-operator/templates/crds/astartedefaultingresses.ingress.astarte-platform.org.yaml
@@ -28,7 +28,14 @@ spec:
     singular: astartedefaultingress
   scope: Namespaced
   versions:
-    - name: v2alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .status.api.loadBalancer.ingress[0].ip
+          name: API IP
+          type: string
+        - jsonPath: .status.broker.loadBalancer.ingress[0].ip
+          name: Broker IP
+          type: string
+      name: v2alpha1
       schema:
         openAPIV3Schema:
           properties:

--- a/charts/astarte-operator/templates/crds/astartes.api.astarte-platform.org.yaml
+++ b/charts/astarte-operator/templates/crds/astartes.api.astarte-platform.org.yaml
@@ -16,7 +16,25 @@ spec:
     singular: astarte
   scope: Namespaced
   versions:
-    - name: v2alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .status.operatorVersion
+          name: Operator Version
+          type: string
+        - jsonPath: .status.astarteVersion
+          name: Astarte Version
+          type: string
+        - jsonPath: .status.health
+          name: Status
+          type: string
+        - jsonPath: .status.baseAPIURL
+          name: Base API URL
+          priority: 1
+          type: string
+        - jsonPath: .status.brokerURL
+          name: Broker URL
+          priority: 1
+          type: string
+      name: v2alpha1
       schema:
         openAPIV3Schema:
           properties:

--- a/config/crd/bases/api.astarte-platform.org_astartes.yaml
+++ b/config/crd/bases/api.astarte-platform.org_astartes.yaml
@@ -14,7 +14,25 @@ spec:
     singular: astarte
   scope: Namespaced
   versions:
-  - name: v2alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.operatorVersion
+      name: Operator Version
+      type: string
+    - jsonPath: .status.astarteVersion
+      name: Astarte Version
+      type: string
+    - jsonPath: .status.health
+      name: Status
+      type: string
+    - jsonPath: .status.baseAPIURL
+      name: Base API URL
+      priority: 1
+      type: string
+    - jsonPath: .status.brokerURL
+      name: Broker URL
+      priority: 1
+      type: string
+    name: v2alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/config/crd/bases/ingress.astarte-platform.org_astartedefaultingresses.yaml
+++ b/config/crd/bases/ingress.astarte-platform.org_astartedefaultingresses.yaml
@@ -16,7 +16,14 @@ spec:
     singular: astartedefaultingress
   scope: Namespaced
   versions:
-  - name: v2alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.api.loadBalancer.ingress[0].ip
+      name: API IP
+      type: string
+    - jsonPath: .status.broker.loadBalancer.ingress[0].ip
+      name: Broker IP
+      type: string
+    name: v2alpha1
     schema:
       openAPIV3Schema:
         properties:


### PR DESCRIPTION
This PR improves the kubectl CLI experience when interacting with Astarte and ADI CRs. By adding kubebuilder printcolumn markers, key status fields and connection URLs are now exposed directly in the `kubectl get` output, reducing the need to output to YAML/JSON to find basic cluster information.

Example:
```sh
> kubectl get astarte -n astarte astarte -o wide
NAME      OPERATOR VERSION   ASTARTE VERSION   STATUS   BASE API URL                                  BROKER URL
astarte   26.5.0             1.3.0             green    https://api.astarte.192.168.49.210.sslip.io   mqtts://broker.astarte.192.168.49.200.sslip.io:1883

> kubectl get astartedefaultingresses.ingress.astarte-platform.org -n astarte adi -o wide
NAME   API IP           BROKER IP
adi    192.168.49.210   192.168.49.200
```