### PR TITLE
feat: add configurable metrics endpoint to Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `Operator Version`, `Astarte Version`, `Health`, `Base API URL` and `Broker URL` columns as print columns to the Astarte CRD.
 - Add `API IP` and `Broker IP` columns as print columns to the ADI CRD.
 - Add `AstarteFDOIngress` (v1alpha1) resource in the `ingress.astarte-platform.org` group to handle the ingress dedicated to Astarte FDO pairing requests.
+- Add configurable metrics endpoint in the Helm chart. Metrics are disabled by default (`metrics.enable: false`). When enabled (`metrics.enable: true`), metrics are served on the configured port (`metrics.port`, default `8443`) over HTTPS by default (`metrics.secure: true`). Set `metrics.secure: false` to use HTTP instead.
 
 ## [26.5.1] - 2026-05-03
 

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,19 @@ manifests: controller-gen yq kustomize ## Generate WebhookConfiguration, Cluster
 	# and inject helm templates for setting values
 	@sed -i "s/replicas:.*/replicas: {{ .Values.replicaCount }}/g" charts/astarte-operator/templates/manager.yaml
 	@sed -i "s/image:.*/image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'/g" charts/astarte-operator/templates/manager.yaml
+	# inject metrics helm templates
+	@sed -i 's/--metrics-bind-address=:8443/--metrics-bind-address={{ .Values.metrics.enable | ternary (printf ":%v" .Values.metrics.port) "0" }}/g' charts/astarte-operator/templates/manager.yaml
+	@sed -i 's/--metrics-secure=true/--metrics-secure={{ .Values.metrics.secure }}/g' charts/astarte-operator/templates/manager.yaml
+	@sed -i '/- containerPort: 8443/,/protocol: TCP/{/- containerPort: 8443/ s/.*/        {{- if .Values.metrics.enable }}\n&/;/protocol: TCP/ s/.*/&\n        {{- end }}/}' charts/astarte-operator/templates/manager.yaml
+	@sed -i 's/containerPort: 8443/containerPort: {{ .Values.metrics.port }}/g' charts/astarte-operator/templates/manager.yaml
+	# Wrap metrics service in conditional
+	@sed -i '1 i\{{- if .Values.metrics.enable }}' charts/astarte-operator/templates/manager.yaml
+	@sed -i '0,/^---$$/{s/^---$$/{{- end }}\n---/}' charts/astarte-operator/templates/manager.yaml
+	# Inject helm templates for service port values
+	@sed -i 's/    port: 8443/    port: {{ .Values.metrics.port }}/' charts/astarte-operator/templates/manager.yaml
+	@sed -i 's/    targetPort: 8443/    targetPort: {{ .Values.metrics.port }}/' charts/astarte-operator/templates/manager.yaml
+	# Inject helm template for dynamic port name based on metrics.secure
+	@sed -i 's/  - name: https/  - name: {{ .Values.metrics.secure | ternary "https" "http" }}/' charts/astarte-operator/templates/manager.yaml
 	$(KUSTOMIZE) build config/helm-webhook > charts/astarte-operator/templates/webhook.yaml
 
 .PHONY: generate

--- a/charts/astarte-operator/templates/manager.yaml
+++ b/charts/astarte-operator/templates/manager.yaml
@@ -1,3 +1,23 @@
+{{- if .Values.metrics.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: astarte-kubernetes-operator
+    control-plane: controller-manager
+  name: '{{ .Release.Name }}-controller-manager-metrics-service'
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  ports:
+  - name: {{ .Values.metrics.secure | ternary "https" "http" }}
+    port: {{ .Values.metrics.port }}
+    protocol: TCP
+    targetPort: {{ .Values.metrics.port }}
+  selector:
+    control-plane: controller-manager
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,6 +43,8 @@ spec:
       - args:
         - --leader-elect
         - --health-probe-bind-address=:8081
+        - --metrics-bind-address={{ .Values.metrics.enable | ternary (printf ":%v" .Values.metrics.port) "0" }}
+        - --metrics-secure={{ .Values.metrics.secure }}
         command:
         - /manager
         image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
@@ -38,6 +60,11 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        {{- if .Values.metrics.enable }}
+        - containerPort: {{ .Values.metrics.port }}
+          name: metrics
+          protocol: TCP
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /readyz

--- a/charts/astarte-operator/values.yaml
+++ b/charts/astarte-operator/values.yaml
@@ -22,3 +22,13 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+
+# -- Metrics configuration.
+# Metrics are exposed on the configured port. When enabled, they use HTTPS by default.
+metrics:
+  # -- Whether to enable the metrics endpoint.
+  enable: false
+  # -- The port to expose metrics on.
+  port: 8443
+  # -- Whether to serve metrics over HTTPS. Set to false to use HTTP.
+  secure: true

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,4 +1,21 @@
-# This patch adds the args to allow exposing the metrics endpoint using HTTPS
+# This patch disables the metrics endpoint by default (metrics-bind-address=0).
+# When enabling metrics, HTTPS is used by default. Set --metrics-secure=false for HTTP.
+
 - op: add
-  path: /spec/template/spec/containers/0/args/0
-  value: --metrics-bind-address=:8443
+  path: /spec/template/spec/containers/0/args/-
+  value: --metrics-bind-address=0
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --metrics-secure=true
+
+# To expose the metrics, replace the disabled bind address and uncomment the port:
+# - op: replace
+#   path: /spec/template/spec/containers/0/args/2
+#   value: --metrics-bind-address=:8443
+# - op: add
+#   path: /spec/template/spec/containers/0/ports/-
+#   value:
+#     containerPort: 8443
+#     name: metrics
+#     protocol: TCP

--- a/config/helm-manager/kustomization.yaml
+++ b/config/helm-manager/kustomization.yaml
@@ -16,7 +16,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../manager
+- manager_metrics_service.yaml
 patches:
 - path: manager_helm_values.yaml
 - path: manager_webhook_patch.yaml
 - path: manager_service_account_patch.yaml
+
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: controller-manager
+  path: manager_metrics_patch.yaml

--- a/config/helm-manager/manager_metrics_patch.yaml
+++ b/config/helm-manager/manager_metrics_patch.yaml
@@ -1,0 +1,14 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --metrics-bind-address=:8443
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --metrics-secure=true
+
+- op: add
+  path: /spec/template/spec/containers/0/ports/-
+  value:
+    containerPort: 8443
+    name: metrics
+    protocol: TCP

--- a/config/helm-manager/manager_metrics_service.yaml
+++ b/config/helm-manager/manager_metrics_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: astarte-kubernetes-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager


### PR DESCRIPTION
This PR introduce Prometheus metrics support: metrics are disabled by default (metrics.enable: false). When enabled, metrics are served on the configured port (default 8443) over HTTPS by default (metrics.secure: true). Set metrics.secure: false to use HTTP.