### PR TITLE
fix: expose mqtt-ssl port in vernemq service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [unreleased]
 ### Fixed
 - Changed the default image tag from "snapshot" to "26.5.0" in the Helm chart. This fix is released in 26.5.1 version of the Helm chart.
+- Service `astarte-vernemq` now expose `mqtt-ssl` (8883) port
 
 ## [26.5.0] - 2026-05-07
 ### Added

--- a/internal/reconcile/vernemq.go
+++ b/internal/reconcile/vernemq.go
@@ -89,6 +89,12 @@ func EnsureVerneMQ(cr *apiv2alpha1.Astarte, c client.Client, scheme *runtime.Sch
 				Protocol:   v1.ProtocolTCP,
 			},
 			{
+				Name:       "mqtt-ssl",
+				Port:       8883,
+				TargetPort: intstr.FromString("mqtt-ssl"),
+				Protocol:   v1.ProtocolTCP,
+			},
+			{
 				Name:       "mqtt-reverse",
 				Port:       1885,
 				TargetPort: intstr.FromString("mqtt-reverse"),


### PR DESCRIPTION
Add the missing mqtt-ssl (8883) port to the astarte-vernemq service definition and update the changelog.