### PR TITLE
test: consolidate suite setup and improve test patterns

### DIFF
--- a/api/api/v2alpha1/astarte_types_test.go
+++ b/api/api/v2alpha1/astarte_types_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package v2alpha1
 
 import (
-	"context"
-
 	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -62,7 +60,7 @@ var _ = Describe("Astarte types testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test AstartePodPriorities.IsEnabled()", func() {

--- a/api/api/v2alpha1/suite_test.go
+++ b/api/api/v2alpha1/suite_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v2alpha1
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,76 +32,44 @@ import (
 	// +kubebuilder:scaffold:imports
 
 	"k8s.io/client-go/kubernetes/scheme"
-
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+const Timeout = "30s"
+const Interval = "1s"
 
 var cfg *rest.Config
 var k8sClient client.Client
+var ctx context.Context
+var cancel context.CancelFunc
 var testEnv *envtest.Environment
 var baseCr *Astarte
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
-
-	RunSpecs(t, "Webhook Suite")
-}
-
-// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
-// ENVTEST-based tests depend on specific binaries, usually located in paths set by
-// controller-runtime. When running tests directly (e.g., via an IDE) without using
-// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
-//
-// This function streamlines the process by finding the required binaries, similar to
-// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
-// properly set up, run 'make setup-envtest' beforehand.
-func getFirstFoundEnvTestBinaryDir() string {
-	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
-	entries, err := os.ReadDir(basePath)
-	if err != nil {
-		logf.Log.Error(err, "Failed to read directory", "path", basePath)
-		return ""
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
-		}
-	}
-	return ""
+	RunSpecs(t, "APIs Suite")
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = integrationutils.SetupTestSuite()
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
-
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: getFirstFoundEnvTestBinaryDir(),
-	}
+	testEnv = integrationutils.DefaultEnvTestConfig(
+		filepath.Join("..", "..", "..", "config", "crd", "bases"),
+		filepath.Join("..", "..", "..", "bin", "k8s"),
+	)
 
 	var err error
-	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
 	err = AddToScheme(scheme.Scheme)
 	Expect(err).ToNot(HaveOccurred())
-
 	err = admissionv1.AddToScheme(scheme.Scheme)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -117,11 +86,8 @@ var _ = BeforeSuite(func() {
 	baseCr = &Astarte{}
 	err = yaml.Unmarshal(manifestBytes, baseCr)
 	Expect(err).ToNot(HaveOccurred())
-
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	integrationutils.StopEnvTest(testEnv, cancel)
 })

--- a/internal/controller/api/astarte_controller_test.go
+++ b/internal/controller/api/astarte_controller_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package controller
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -43,18 +42,15 @@ const (
 var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 	BeforeAll(func() {
 		integrationutils.CreateNamespace(k8sClient, CustomAstarteNamespace)
-	})
-
-	AfterAll(func() {
-		// Do not delete the namespace here to avoid 'NamespaceTerminating' flakiness in subsequent specs
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		DeferCleanup(func() {
+			integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
+		})
 	})
 
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-resource"
 		var controllerReconciler *AstarteReconciler
 		var cr *apiv2alpha1.Astarte
-		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
@@ -76,10 +72,9 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 			cr.SetNamespace(CustomAstarteNamespace)
 			cr.SetResourceVersion("")
 			integrationutils.DeployAstarte(k8sClient, cr)
-		})
-
-		AfterEach(func() {
-			integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
+			DeferCleanup(func() {
+				integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
+			})
 		})
 
 		It("should successfully reconcile the resource", func() {
@@ -105,7 +100,6 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 			})
 
 			Expect(err).To(HaveOccurred())
-			// Check that we're requeuing after a minute due to version error
 			Expect(result.RequeueAfter).To(Equal(time.Minute))
 		})
 
@@ -142,7 +136,6 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 		const finalizerTestName = "test-finalizer"
 		var controllerReconciler *AstarteReconciler
 		var cr *apiv2alpha1.Astarte
-		ctx := context.Background()
 
 		BeforeEach(func() {
 			controllerReconciler = &AstarteReconciler{
@@ -152,7 +145,6 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 				Recorder: record.NewFakeRecorder(1024),
 			}
 
-			// Create the resource with finalizer and deletion timestamp
 			cr = baseCr.DeepCopy()
 			cr.SetName(finalizerTestName)
 			cr.SetNamespace(CustomAstarteNamespace)
@@ -161,10 +153,9 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 			cr.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
+			DeferCleanup(func() {
+				integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
+			})
 		})
 
 		It("should handle finalization", func() {
@@ -185,7 +176,6 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 		const addFinalizerTestName = "test-add-finalizer"
 		var controllerReconciler *AstarteReconciler
 		var cr *apiv2alpha1.Astarte
-		ctx := context.Background()
 
 		BeforeEach(func() {
 			controllerReconciler = &AstarteReconciler{
@@ -200,10 +190,9 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 			cr.SetNamespace(CustomAstarteNamespace)
 			cr.SetResourceVersion("")
 			integrationutils.DeployAstarte(k8sClient, cr)
-		})
-
-		AfterEach(func() {
-			integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
+			DeferCleanup(func() {
+				integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
+			})
 		})
 
 		It("should add a finalizer to an Astarte resource", func() {
@@ -230,11 +219,9 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 			updatedList := remove(list, "a")
 			Expect(updatedList).To(Equal([]string{"b", "c", "d"}))
 
-			// Test removing an element not in the list
 			updatedList = remove(list, "x")
 			Expect(updatedList).To(Equal(list))
 
-			// Test removing from an empty list
 			emptyList := []string{}
 			updatedList = remove(emptyList, "a")
 			Expect(updatedList).To(BeEmpty())
@@ -245,34 +232,30 @@ var _ = Describe("Astarte Controller", Ordered, Serial, func() {
 var _ = Describe("Standalone Tests", func() {
 	Context("Testing with k8sClient directly", func() {
 		It("should handle non-existent resources", func() {
-			ctx := context.Background()
-
-			// Ensure the test namespace exists and isn't terminating
 			Eventually(func() error {
 				ns := &v1.Namespace{}
 				if err := k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteNamespace}, ns); err != nil {
-					// Try to create if it's missing
 					cErr := k8sClient.Create(ctx, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: CustomAstarteNamespace}})
 					if apierrors.IsAlreadyExists(cErr) {
 						return nil
 					}
 					return cErr
 				}
-				// If it's terminating, return an error to retry
 				if ns.Status.Phase == v1.NamespaceTerminating {
 					return fmt.Errorf("namespace terminating")
 				}
 				return nil
-			}, "20s", Interval).Should(Succeed())
+			}).Should(Succeed())
 
-			// Create a test resource
 			cr := baseCr.DeepCopy()
 			cr.SetName("test-direct-reconcile")
 			cr.SetNamespace(CustomAstarteNamespace)
 			cr.SetResourceVersion("")
 			integrationutils.DeployAstarte(k8sClient, cr)
+			DeferCleanup(func() {
+				integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
+			})
 
-			// Create the reconciler with the test client
 			reconciler := &AstarteReconciler{
 				Client:   k8sClient,
 				Scheme:   k8sClient.Scheme(),
@@ -280,7 +263,6 @@ var _ = Describe("Standalone Tests", func() {
 				Recorder: record.NewFakeRecorder(1024),
 			}
 
-			// Test reconciling a non-existent resource
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "non-existent",
@@ -290,8 +272,6 @@ var _ = Describe("Standalone Tests", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
-
-			// Cleanup is handled by the test framework
 		})
 	})
 })

--- a/internal/controller/api/astarte_finalizer_test.go
+++ b/internal/controller/api/astarte_finalizer_test.go
@@ -19,8 +19,7 @@ limitations under the License.
 package controller
 
 import (
-	"context"
-
+	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,7 +27,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
-	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 )
 
 var _ = Describe("Astarte Finalizer testing", Ordered, Serial, func() {
@@ -42,10 +40,9 @@ var _ = Describe("Astarte Finalizer testing", Ordered, Serial, func() {
 
 	BeforeAll(func() {
 		integrationutils.CreateNamespace(k8sClient, CustomAstarteNamespace)
-	})
-
-	AfterAll(func() {
-		integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
+		DeferCleanup(func() {
+			integrationutils.DeleteNamespace(k8sClient, CustomAstarteNamespace)
+		})
 	})
 
 	BeforeEach(func() {
@@ -58,96 +55,83 @@ var _ = Describe("Astarte Finalizer testing", Ordered, Serial, func() {
 		cr.SetNamespace(CustomAstarteNamespace)
 		cr.SetResourceVersion("")
 		integrationutils.DeployAstarte(k8sClient, cr)
-	})
-
-	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		DeferCleanup(func() {
+			integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
+		})
 	})
 
 	Describe("Test HandleFinalization", func() {
 		It("should successfully finalize Astarte instance with finalizer", func() {
-			// First get the existing CR to update it with finalizer
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
-			}, Timeout, Interval).Should(Succeed())
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+			}).Should(Succeed())
 
-			// Add finalizer to the CR
 			cr.SetFinalizers([]string{astarteFinalizer})
 
 			Eventually(func() error {
-				return k8sClient.Update(context.Background(), cr)
-			}, Timeout, Interval).Should(Succeed())
+				return k8sClient.Update(ctx, cr)
+			}).Should(Succeed())
 
-			// Verify CR was created with finalizer
 			Eventually(func() []string {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 				if err != nil {
 					return nil
 				}
 				return cr.GetFinalizers()
-			}, Timeout, Interval).Should(ContainElement(astarteFinalizer))
+			}).Should(ContainElement(astarteFinalizer))
 
-			// Mark the CR for deletion
 			Eventually(func() error {
-				return k8sClient.Delete(context.Background(), cr)
-			}, Timeout, Interval).Should(Succeed())
+				return k8sClient.Delete(ctx, cr)
+			}).Should(Succeed())
 
-			// Get a copy with deletion timestamp
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 				if err != nil {
 					return false
 				}
 				return cr.GetDeletionTimestamp() != nil
-			}, Timeout, Interval).Should(BeTrue())
+			}).Should(BeTrue())
 
-			// Call handleFinalization
 			result, err := reconciler.handleFinalization(cr)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(ctrl.Result{}))
 
-			// Verify finalizer was removed from the object
 			Expect(cr.GetFinalizers()).ToNot(ContainElement(astarteFinalizer))
 
-			// Verify CR is eventually deleted (handleFinalization should have updated it)
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, &apiv2alpha1.Astarte{})
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, &apiv2alpha1.Astarte{})
 				return apierrors.IsNotFound(err)
-			}, Timeout, Interval).Should(BeTrue())
+			}).Should(BeTrue())
 		})
 	})
 
 	Describe("Test AddFinalizer", func() {
 		It("should successfully add finalizer to CR", func() {
-			// Createa new CR without finalizers
 			crNew := cr.DeepCopy()
 			crNew.Name = "test-astarte-finalizer-add"
 			crNew.SetFinalizers([]string{})
 			crNew.ResourceVersion = ""
 
-			Expect(k8sClient.Create(context.Background(), crNew)).To(Succeed())
+			Expect(k8sClient.Create(ctx, crNew)).To(Succeed())
 
-			// Verify CR was created without finalizer
 			Eventually(func() []string {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: crNew.Name, Namespace: crNew.Namespace}, crNew)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: crNew.Name, Namespace: crNew.Namespace}, crNew)
 				if err != nil {
 					return nil
 				}
 				return crNew.GetFinalizers()
-			}, Timeout, Interval).ShouldNot(ContainElement(astarteFinalizer))
+			}).ShouldNot(ContainElement(astarteFinalizer))
 
-			// Add finalizer
 			err := reconciler.addFinalizer(crNew)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify finalizer was added
 			Eventually(func() []string {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: crNew.Name, Namespace: crNew.Namespace}, crNew)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: crNew.Name, Namespace: crNew.Namespace}, crNew)
 				if err != nil {
 					return nil
 				}
 				return crNew.GetFinalizers()
-			}, Timeout, Interval).Should(ContainElement(astarteFinalizer))
+			}).Should(ContainElement(astarteFinalizer))
 		})
 	})
 })

--- a/internal/controller/api/suite_test.go
+++ b/internal/controller/api/suite_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,63 +32,37 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
+	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	// +kubebuilder:scaffold:imports
 )
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var baseCr *apiv2alpha1.Astarte
 
 const Timeout = "30s"
 const Interval = "1s"
 
+var cfg *rest.Config
+var k8sClient client.Client
+var ctx context.Context
+var cancel context.CancelFunc
+var testEnv *envtest.Environment
+var baseCr *apiv2alpha1.Astarte
+
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
-
 	RunSpecs(t, "Controller Suite")
 }
 
-func getFirstFoundEnvTestBinaryDir() string {
-	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
-	entries, err := os.ReadDir(basePath)
-	if err != nil {
-		logf.Log.Error(err, "Failed to read directory", "path", basePath)
-		return ""
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
-		}
-	}
-	return ""
-}
-
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = integrationutils.SetupTestSuite()
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
-
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: getFirstFoundEnvTestBinaryDir(),
-	}
+	testEnv = integrationutils.DefaultEnvTestConfig(
+		filepath.Join("..", "..", "..", "config", "crd", "bases"),
+		filepath.Join("..", "..", "..", "bin", "k8s"),
+	)
 
 	var err error
-	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
@@ -101,6 +76,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
+	// Tests call Reconcile() directly and inspect return values, so we
+	// don't register the controller with a manager here.
+
+	By("loading the base Astarte manifest")
 	manifestPath := filepath.Join("..", "..", "..", "test", "manifests", "api_v2alpha1_astarte_1.3.yaml")
 	manifestBytes, err := os.ReadFile(manifestPath)
 	Expect(err).ToNot(HaveOccurred())
@@ -108,11 +87,8 @@ var _ = BeforeSuite(func() {
 	baseCr = &apiv2alpha1.Astarte{}
 	err = yaml.Unmarshal(manifestBytes, baseCr)
 	Expect(err).ToNot(HaveOccurred())
-
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	integrationutils.StopEnvTest(testEnv, cancel)
 })

--- a/internal/controller/flow/flow_controller_test.go
+++ b/internal/controller/flow/flow_controller_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package flow
 
 import (
-	context "context"
-
 	. "github.com/onsi/ginkgo/v2"
 
 	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
@@ -33,23 +31,10 @@ const (
 var _ = Describe("Flow Controller", Ordered, Serial, func() {
 	BeforeAll(func() {
 		integrationutils.CreateNamespace(k8sClient, CustomFlowNamespace)
+		DeferCleanup(func() {
+			integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomFlowNamespace)
+		})
 	})
 
-	AfterAll(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomFlowNamespace)
-	})
-
-	Context("Test Reconcile function", func() {
-		// To be implemented
-	})
-
-	Context("Test computeFlowStatusResource function", func() {
-		// To be implemented
-	})
-
-	Context("Test getResourcesForReconciliationFor function", func() {
-		// To be implemented
-	})
-
-	// Add more tests here
+	PIt("reconciles Flow resources", func() {})
 })

--- a/internal/controller/flow/suite_test.go
+++ b/internal/controller/flow/suite_test.go
@@ -19,7 +19,7 @@ limitations under the License.
 package flow
 
 import (
-	"os"
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -30,59 +30,33 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	flowv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/flow/v2alpha1"
+	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
 var cfg *rest.Config
 var k8sClient client.Client
+var ctx context.Context
+var cancel context.CancelFunc
 var testEnv *envtest.Environment
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
-
-	RunSpecs(t, "Controller Suite")
-}
-
-func getFirstFoundEnvTestBinaryDir() string {
-	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
-	entries, err := os.ReadDir(basePath)
-	if err != nil {
-		logf.Log.Error(err, "Failed to read directory", "path", basePath)
-		return ""
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
-		}
-	}
-	return ""
+	RunSpecs(t, "Flow Controller Suite")
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = integrationutils.SetupTestSuite()
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
-
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: getFirstFoundEnvTestBinaryDir(),
-	}
+	testEnv = integrationutils.DefaultEnvTestConfig(
+		filepath.Join("..", "..", "..", "config", "crd", "bases"),
+		filepath.Join("..", "..", "..", "bin", "k8s"),
+	)
 
 	var err error
-	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
@@ -95,11 +69,8 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	integrationutils.StopEnvTest(testEnv, cancel)
 })

--- a/internal/controller/ingress/astartedefaultingress_controller_test.go
+++ b/internal/controller/ingress/astartedefaultingress_controller_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package ingress
 
 import (
-	context "context"
-
 	. "github.com/onsi/ginkgo/v2"
 
 	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
@@ -33,27 +31,10 @@ const (
 var _ = Describe("AstarteDefaultIngress Controller", Ordered, Serial, func() {
 	BeforeAll(func() {
 		integrationutils.CreateNamespace(k8sClient, CustomIngressNamespace)
+		DeferCleanup(func() {
+			integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomIngressNamespace)
+		})
 	})
 
-	AfterAll(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomIngressNamespace)
-	})
-
-	Context("Test Reconcile function", func() {
-		// To be implemented
-	})
-
-	Context("Test EnsureAPIIngress function", func() {
-		// To be implemented
-	})
-
-	Context("Test EnsureBrokerIngress function", func() {
-		// To be implemented
-	})
-
-	Context("Test EnsureMetricsIngress function", func() {
-		// To be implemented
-	})
-
-	// Add more tests here
+	PIt("reconciles Ingress resources", func() {})
 })

--- a/internal/controller/ingress/suite_test.go
+++ b/internal/controller/ingress/suite_test.go
@@ -19,7 +19,7 @@ limitations under the License.
 package ingress
 
 import (
-	"os"
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -30,59 +30,33 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	ingressv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/ingress/v2alpha1"
+	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
 var cfg *rest.Config
 var k8sClient client.Client
+var ctx context.Context
+var cancel context.CancelFunc
 var testEnv *envtest.Environment
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
-
-	RunSpecs(t, "Controller Suite")
-}
-
-func getFirstFoundEnvTestBinaryDir() string {
-	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
-	entries, err := os.ReadDir(basePath)
-	if err != nil {
-		logf.Log.Error(err, "Failed to read directory", "path", basePath)
-		return ""
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
-		}
-	}
-	return ""
+	RunSpecs(t, "Ingress Controller Suite")
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = integrationutils.SetupTestSuite()
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
-
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: getFirstFoundEnvTestBinaryDir(),
-	}
+	testEnv = integrationutils.DefaultEnvTestConfig(
+		filepath.Join("..", "..", "..", "config", "crd", "bases"),
+		filepath.Join("..", "..", "..", "bin", "k8s"),
+	)
 
 	var err error
-	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
@@ -95,11 +69,8 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	integrationutils.StopEnvTest(testEnv, cancel)
 })

--- a/internal/controllerutils/astarte_controller_test.go
+++ b/internal/controllerutils/astarte_controller_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package controllerutils
 
 import (
-	"context"
-
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
 	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	. "github.com/onsi/ginkgo/v2"
@@ -51,9 +49,10 @@ var _ = Describe("controllerutils tests", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
-	Describe("TestFunction", func() {
+	Describe("controllerutils reconciliation tests", func() {
+		PIt("reconciles with ReconcileHelper", func() {})
 	})
 })

--- a/internal/controllerutils/astarte_finalizer_test.go
+++ b/internal/controllerutils/astarte_finalizer_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package controllerutils
 
 import (
-	"context"
-
 	"github.com/astarte-platform/astarte-kubernetes-operator/internal/reconcile"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -47,11 +45,11 @@ var _ = Describe("finalizePriorityClasses", Ordered, Serial, func() {
 
 	AfterEach(func() {
 		// Ensure we don't leak the unrelated class between tests
-		_ = k8sClient.Delete(context.Background(), &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "unrelated-priority"}})
+		_ = k8sClient.Delete(ctx, &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "unrelated-priority"}})
 		// Also try to remove Astarte* classes in case a test failed midway
-		_ = k8sClient.Delete(context.Background(), &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteHighPriorityName}})
-		_ = k8sClient.Delete(context.Background(), &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteMidPriorityName}})
-		_ = k8sClient.Delete(context.Background(), &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteLowPriorityName}})
+		_ = k8sClient.Delete(ctx, &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteHighPriorityName}})
+		_ = k8sClient.Delete(ctx, &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteMidPriorityName}})
+		_ = k8sClient.Delete(ctx, &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteLowPriorityName}})
 	})
 
 	It("deletes Astarte PriorityClasses and leaves others", func() {
@@ -62,14 +60,14 @@ var _ = Describe("finalizePriorityClasses", Ordered, Serial, func() {
 		low := &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteLowPriorityName}, Value: 100000, GlobalDefault: false, PreemptionPolicy: &preempt}
 		other := &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "unrelated-priority"}, Value: 1, GlobalDefault: false, PreemptionPolicy: &preempt}
 
-		Expect(k8sClient.Create(context.Background(), high)).To(Succeed())
-		Expect(k8sClient.Create(context.Background(), mid)).To(Succeed())
-		Expect(k8sClient.Create(context.Background(), low)).To(Succeed())
-		Expect(k8sClient.Create(context.Background(), other)).To(Succeed())
+		Expect(k8sClient.Create(ctx, high)).To(Succeed())
+		Expect(k8sClient.Create(ctx, mid)).To(Succeed())
+		Expect(k8sClient.Create(ctx, low)).To(Succeed())
+		Expect(k8sClient.Create(ctx, other)).To(Succeed())
 
 		// Sanity check they exist
 		pcList := &scheduling.PriorityClassList{}
-		Expect(k8sClient.List(context.Background(), pcList)).To(Succeed())
+		Expect(k8sClient.List(ctx, pcList)).To(Succeed())
 		found := map[string]bool{}
 		for _, pc := range pcList.Items {
 			found[pc.Name] = true
@@ -84,19 +82,19 @@ var _ = Describe("finalizePriorityClasses", Ordered, Serial, func() {
 
 		// Astarte classes should be gone
 		exists := &scheduling.PriorityClass{}
-		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: reconcile.AstarteHighPriorityName}, exists)).NotTo(Succeed())
-		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: reconcile.AstarteMidPriorityName}, exists)).NotTo(Succeed())
-		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: reconcile.AstarteLowPriorityName}, exists)).NotTo(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: reconcile.AstarteHighPriorityName}, exists)).NotTo(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: reconcile.AstarteMidPriorityName}, exists)).NotTo(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: reconcile.AstarteLowPriorityName}, exists)).NotTo(Succeed())
 
 		// Other should still exist
-		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "unrelated-priority"}, &scheduling.PriorityClass{})).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "unrelated-priority"}, &scheduling.PriorityClass{})).To(Succeed())
 	})
 
 	It("is a no-op when no Astarte PriorityClasses exist", func() {
 		// Ensure none exist
-		_ = k8sClient.Delete(context.Background(), &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteHighPriorityName}})
-		_ = k8sClient.Delete(context.Background(), &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteMidPriorityName}})
-		_ = k8sClient.Delete(context.Background(), &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteLowPriorityName}})
+		_ = k8sClient.Delete(ctx, &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteHighPriorityName}})
+		_ = k8sClient.Delete(ctx, &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteMidPriorityName}})
+		_ = k8sClient.Delete(ctx, &scheduling.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: reconcile.AstarteLowPriorityName}})
 
 		Expect(finalizePriorityClasses(k8sClient, logger)).To(Succeed())
 	})

--- a/internal/controllerutils/suite_test.go
+++ b/internal/controllerutils/suite_test.go
@@ -33,18 +33,14 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
+	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	// +kubebuilder:scaffold:imports
 )
 
 const Timeout = "30s"
 const Interval = "1s"
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var cfg *rest.Config
 var k8sClient client.Client
@@ -55,37 +51,26 @@ var baseCr *apiv2alpha1.Astarte
 
 func TestControllerUtils(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "TestControllerUtils Suite")
+	RunSpecs(t, "ControllerUtils Suite")
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
+	ctx, cancel = integrationutils.SetupTestSuite()
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
-
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: getFirstFoundEnvTestBinaryDir(),
-	}
+	testEnv = integrationutils.DefaultEnvTestConfig(
+		filepath.Join("..", "..", "config", "crd", "bases"),
+		filepath.Join("..", "..", "bin", "k8s"),
+	)
 
 	var err error
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
-
 	Expect(cfg).NotTo(BeNil())
 
 	err = apiv2alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Also register Scheduling v1 (PriorityClass) to the scheme, used by finalizePriorityClasses tests
 	err = schedulingv1.AddToScheme(scheme.Scheme)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -105,31 +90,5 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	cancel()
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	integrationutils.StopEnvTest(testEnv, cancel)
 })
-
-// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
-// ENVTEST-based tests depend on specific binaries, usually located in paths set by
-// controller-runtime. When running tests directly (e.g., via an IDE) without using
-// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
-//
-// This function streamlines the process by finding the required binaries, similar to
-// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
-// properly set up, run 'make setup-envtest' beforehand.
-func getFirstFoundEnvTestBinaryDir() string {
-	basePath := filepath.Join("..", "..", "bin", "k8s")
-	entries, err := os.ReadDir(basePath)
-	if err != nil {
-		logf.Log.Error(err, "Failed to read directory", "path", basePath)
-		return ""
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
-		}
-	}
-	return ""
-}

--- a/internal/deps/dependencies_versions_test.go
+++ b/internal/deps/dependencies_versions_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package deps
 
 import (
-	"context"
-
 	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,7 +34,7 @@ var _ = Describe("Deps", Ordered, Serial, func() {
 	})
 
 	AfterAll(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	Context("Testing the GetDefaultVersionForCFSSL function", func() {

--- a/internal/deps/suite_test.go
+++ b/internal/deps/suite_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package deps
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,76 +27,41 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/yaml"
-
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
+	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	// +kubebuilder:scaffold:imports
 )
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var baseCr *apiv2alpha1.Astarte
 
 const Timeout = "30s"
 const Interval = "1s"
 
+var cfg *rest.Config
+var k8sClient client.Client
+var ctx context.Context
+var cancel context.CancelFunc
+var testEnv *envtest.Environment
+var baseCr *apiv2alpha1.Astarte
+
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
-
-	RunSpecs(t, "Controller Suite")
-}
-
-// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
-// ENVTEST-based tests depend on specific binaries, usually located in paths set by
-// controller-runtime. When running tests directly (e.g., via an IDE) without using
-// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
-//
-// This function streamlines the process by finding the required binaries, similar to
-// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
-// properly set up, run 'make setup-envtest' beforehand.
-func getFirstFoundEnvTestBinaryDir() string {
-	basePath := filepath.Join("..", "..", "bin", "k8s")
-	entries, err := os.ReadDir(basePath)
-	if err != nil {
-		logf.Log.Error(err, "Failed to read directory", "path", basePath)
-		return ""
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
-		}
-	}
-	return ""
+	RunSpecs(t, "Deps Suite")
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = integrationutils.SetupTestSuite()
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
-
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: getFirstFoundEnvTestBinaryDir(),
-	}
+	testEnv = integrationutils.DefaultEnvTestConfig(
+		filepath.Join("..", "..", "config", "crd", "bases"),
+		filepath.Join("..", "..", "bin", "k8s"),
+	)
 
 	var err error
-	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
@@ -119,7 +85,5 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	integrationutils.StopEnvTest(testEnv, cancel)
 })

--- a/internal/misc/suite_test.go
+++ b/internal/misc/suite_test.go
@@ -26,21 +26,19 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
+	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+const Timeout = "30s"
+const Interval = "1s"
 
 var cfg *rest.Config
 var k8sClient client.Client
@@ -49,55 +47,19 @@ var cancel context.CancelFunc
 var testEnv *envtest.Environment
 var baseCr *apiv2alpha1.Astarte
 
-const Timeout = "30s"
-const Interval = "1s"
-
 func TestMisc(t *testing.T) {
 	RegisterFailHandler(Fail)
-
 	RunSpecs(t, "Misc Suite")
 }
 
-// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
-// ENVTEST-based tests depend on specific binaries, usually located in paths set by
-// controller-runtime. When running tests directly (e.g., via an IDE) without using
-// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
-//
-// This function streamlines the process by finding the required binaries, similar to
-// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
-// properly set up, run 'make setup-envtest' beforehand.
-func getFirstFoundEnvTestBinaryDir() string {
-	basePath := filepath.Join("..", "..", "bin", "k8s")
-	entries, err := os.ReadDir(basePath)
-	if err != nil {
-		logf.Log.Error(err, "Failed to read directory", "path", basePath)
-		return ""
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
-		}
-	}
-	return ""
-}
-
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
+	ctx, cancel = integrationutils.SetupTestSuite()
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
-
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: getFirstFoundEnvTestBinaryDir(),
-	}
+	testEnv = integrationutils.DefaultEnvTestConfig(
+		filepath.Join("..", "..", "config", "crd", "bases"),
+		filepath.Join("..", "..", "bin", "k8s"),
+	)
 
 	var err error
 	cfg, err = testEnv.Start()
@@ -110,7 +72,6 @@ var _ = BeforeSuite(func() {
 	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
@@ -124,8 +85,5 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	cancel()
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	integrationutils.StopEnvTest(testEnv, cancel)
 })

--- a/internal/misc/utils_test.go
+++ b/internal/misc/utils_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package misc
 
 import (
-	"context"
 	"strconv"
 
 	"github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
@@ -71,7 +70,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("ReconcileConfigMap", func() {
@@ -89,9 +88,9 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 
 		AfterEach(func() {
 			cm := &v1.ConfigMap{}
-			err := k8sClient.Get(context.Background(), types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, cm)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, cm)
 			if err == nil {
-				Expect(k8sClient.Delete(context.Background(), cm)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, cm)).To(Succeed())
 			}
 		})
 
@@ -100,7 +99,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			createdCm := &v1.ConfigMap{}
-			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, createdCm)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, createdCm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(createdCm.Data).To(Equal(cmData))
 		})
@@ -116,7 +115,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			cm := &v1.ConfigMap{}
-			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, cm)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, cm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cm.Data).To(Equal(updated))
 		})
@@ -135,9 +134,9 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 
 		AfterEach(func() {
 			createdSecret := &v1.Secret{}
-			err := k8sClient.Get(context.Background(), types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, createdSecret)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, createdSecret)
 			if err == nil {
-				Expect(k8sClient.Delete(context.Background(), createdSecret)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, createdSecret)).To(Succeed())
 			}
 		})
 
@@ -147,7 +146,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 
 			createdSecret := &v1.Secret{}
 
-			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, createdSecret)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, createdSecret)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(createdSecret.Type).To(Equal(v1.SecretTypeTLS))
 			Expect(string(createdSecret.Data[v1.TLSCertKey])).To(Equal(cert))
@@ -164,7 +163,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			s := &v1.Secret{}
-			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, s)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, s)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(s.Data[v1.TLSCertKey])).To(Equal(newCert))
 			Expect(string(s.Data[v1.TLSPrivateKeyKey])).To(Equal(newKey))
@@ -186,9 +185,9 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 
 		AfterEach(func() {
 			createdSecret := &v1.Secret{}
-			err := k8sClient.Get(context.Background(), types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, createdSecret)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, createdSecret)
 			if err == nil {
-				Expect(k8sClient.Delete(context.Background(), createdSecret)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, createdSecret)).To(Succeed())
 			}
 		})
 
@@ -198,7 +197,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 
 			createdSecret := &v1.Secret{}
 
-			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, createdSecret)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, createdSecret)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(createdSecret.Data).To(Equal(secretData))
 		})
@@ -212,7 +211,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			s := &v1.Secret{}
-			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, s)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: objName, Namespace: CustomAstarteNamespace}, s)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(s.Data).To(Equal(updated))
 		})
@@ -227,14 +226,14 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			s := &v1.Secret{}
-			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: name, Namespace: CustomAstarteNamespace}, s)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: CustomAstarteNamespace}, s)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(s.Type).To(Equal(v1.SecretTypeOpaque))
 			Expect(string(s.Data["a"])).To(Equal("1"))
 			Expect(string(s.Data["b"])).To(Equal("2"))
 
 			// cleanup
-			Expect(k8sClient.Delete(context.Background(), s)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, s)).To(Succeed())
 		})
 	})
 
@@ -248,13 +247,13 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			s := &v1.Secret{}
-			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: name, Namespace: CustomAstarteNamespace}, s)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: CustomAstarteNamespace}, s)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(s.Labels).To(HaveKeyWithValue("foo", "bar"))
 			Expect(string(s.Data["x"])).To(Equal("y"))
 
 			// cleanup
-			Expect(k8sClient.Delete(context.Background(), s)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, s)).To(Succeed())
 		})
 	})
 
@@ -1063,8 +1062,8 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 							RabbitMQDefaultUserCredentialsPasswordKey: []byte("pass"),
 						},
 					}
-					Expect(k8sClient.Create(context.Background(), sec)).To(Succeed())
-					defer func() { _ = k8sClient.Delete(context.Background(), sec) }()
+					Expect(k8sClient.Create(ctx, sec)).To(Succeed())
+					defer func() { _ = k8sClient.Delete(ctx, sec) }()
 
 					host, port, user, pass, err := GetRabbitMQCredentialsFor(cr, k8sClient)
 					Expect(err).ToNot(HaveOccurred())

--- a/internal/reconcile/astarte_dashboard_test.go
+++ b/internal/reconcile/astarte_dashboard_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package reconcile
 
 import (
-	"context"
 	"encoding/json"
 
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
@@ -58,36 +57,36 @@ var _ = Describe("Astarte Dashboard reconcile tests", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test EnsureAstarteDashboard", func() {
 		It("should not create a deployment when disabled", func() {
 			cr.Spec.Components.Dashboard.Deploy = pointy.Bool(false)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteDashboard(cr, cr.Spec.Components.Dashboard, k8sClient, scheme.Scheme)).To(Succeed())
 
 			// Deployment should not exist
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, dep)).ToNot(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, dep)).ToNot(Succeed())
 		})
 
 		It("should create deployment, service and configmap with defaults", func() {
 			cr.Spec.Components.Dashboard.Deploy = pointy.Bool(true)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteDashboard(cr, cr.Spec.Components.Dashboard, k8sClient, scheme.Scheme)).To(Succeed())
 
 			// Deployment
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, dep)).To(Succeed())
 			Expect(dep.Labels).To(Not(BeNil()))
 			Expect(dep.Labels["app"]).To(Equal(cr.Name + "-dashboard"))
 			Expect(dep.Labels["component"]).To(Equal("astarte"))
@@ -95,13 +94,13 @@ var _ = Describe("Astarte Dashboard reconcile tests", Ordered, Serial, func() {
 
 			// Service
 			svc := &v1.Service{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, svc)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, svc)).To(Succeed())
 			Expect(svc.Spec.Ports).To(HaveLen(1))
 			Expect(svc.Spec.Ports[0].Port).To(Equal(int32(80)))
 
 			// ConfigMap
 			cm := &v1.ConfigMap{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name + "-dashboard-config", Namespace: cr.Namespace}, cm)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name + "-dashboard-config", Namespace: cr.Namespace}, cm)).To(Succeed())
 			cfgStr, ok := cm.Data["config.json"]
 			Expect(ok).To(BeTrue())
 
@@ -130,24 +129,24 @@ var _ = Describe("Astarte Dashboard reconcile tests", Ordered, Serial, func() {
 		It("should delete existing deployment when disabling", func() {
 			// Enable first
 			cr.Spec.Components.Dashboard.Deploy = pointy.Bool(true)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 			Expect(EnsureAstarteDashboard(cr, cr.Spec.Components.Dashboard, k8sClient, scheme.Scheme)).To(Succeed())
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, dep)).To(Succeed())
 
 			// Now disable
 			cr.Spec.Components.Dashboard.Deploy = pointy.Bool(false)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 			Expect(EnsureAstarteDashboard(cr, cr.Spec.Components.Dashboard, k8sClient, scheme.Scheme)).To(Succeed())
 
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, &appsv1.Deployment{})
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, &appsv1.Deployment{})
 				return err != nil
 			}, Timeout, Interval).Should(BeTrue())
 		})
@@ -156,15 +155,15 @@ var _ = Describe("Astarte Dashboard reconcile tests", Ordered, Serial, func() {
 			// Mark Flow component as deployed in CR
 			cr.Spec.Components.Flow = apiv2alpha1.AstarteGenericAPIComponentSpec{AstarteGenericClusteredResource: apiv2alpha1.AstarteGenericClusteredResource{Deploy: pointy.Bool(true)}}
 			cr.Spec.Components.Dashboard.Deploy = pointy.Bool(true)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteDashboard(cr, cr.Spec.Components.Dashboard, k8sClient, scheme.Scheme)).To(Succeed())
 
 			cm := &v1.ConfigMap{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name + "-dashboard-config", Namespace: cr.Namespace}, cm)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name + "-dashboard-config", Namespace: cr.Namespace}, cm)).To(Succeed())
 			cfgStr := cm.Data["config.json"]
 			var cfg map[string]interface{}
 			Expect(json.Unmarshal([]byte(cfgStr), &cfg)).To(Succeed())
@@ -190,22 +189,22 @@ var _ = Describe("Astarte Dashboard reconcile tests", Ordered, Serial, func() {
 
 			// Update CR's spec for consistency with helper functions
 			cr.Spec.Components.Dashboard = dashboardSpec
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteDashboard(cr, dashboardSpec, k8sClient, scheme.Scheme)).To(Succeed())
 
 			// Deployment should reflect replica count
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, dep)).To(Succeed())
 			Expect(dep.Spec.Replicas).ToNot(BeNil())
 			Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
 
 			// ConfigMap should contain optional fields
 			cm := &v1.ConfigMap{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name + "-dashboard-config", Namespace: cr.Namespace}, cm)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name + "-dashboard-config", Namespace: cr.Namespace}, cm)).To(Succeed())
 			cfgStr := cm.Data["config.json"]
 			var cfg map[string]interface{}
 			Expect(json.Unmarshal([]byte(cfgStr), &cfg)).To(Succeed())
@@ -225,15 +224,15 @@ var _ = Describe("Astarte Dashboard reconcile tests", Ordered, Serial, func() {
 					Value: "custom_value",
 				},
 			}
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteDashboard(cr, cr.Spec.Components.Dashboard, k8sClient, scheme.Scheme)).To(Succeed())
 
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name + "-dashboard", Namespace: cr.Namespace}, dep)).To(Succeed())
 
 			envs := dep.Spec.Template.Spec.Containers[0].Env
 			found := false

--- a/internal/reconcile/astarte_data_updater_plant_test.go
+++ b/internal/reconcile/astarte_data_updater_plant_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package reconcile
 
 import (
-	"context"
 	"strconv"
 
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
@@ -62,7 +61,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 	Describe("Test EnsureAstarteDataUpdaterPlant", func() {
 		It("should return error if it is not possible to list current DUP Deployments", func() {
@@ -101,34 +100,34 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 			dups := &appsv1.DeploymentList{}
 
 			// We should have 2 deployments now
-			Expect(k8sClient.Create(context.Background(), cr1)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cr1)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: cr1.Namespace}, cr1)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr1.Name, Namespace: cr1.Namespace}, cr1)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteDataUpdaterPlant(cr1, cr1.Spec.Components.DataUpdaterPlant, k8sClient, scheme.Scheme)).To(Succeed())
-			Expect(k8sClient.List(context.Background(), dups, client.InNamespace(cr1.Namespace),
+			Expect(k8sClient.List(ctx, dups, client.InNamespace(cr1.Namespace),
 				client.MatchingLabels{"astarte-component": "data-updater-plant"})).To(Succeed())
 			Expect(dups.Items).To(HaveLen(2))
 
 			// Update the CR to have only 1 DUP replica
 			cr1.Spec.Components.DataUpdaterPlant.Replicas = pointy.Int32(1)
-			Expect(k8sClient.Update(context.Background(), cr1)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr1)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: cr1.Namespace}, cr1)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr1.Name, Namespace: cr1.Namespace}, cr1)
 			}, Timeout, Interval).Should(Succeed())
 
 			// We should have only 1 deployment now
 			Expect(EnsureAstarteDataUpdaterPlant(cr1, cr1.Spec.Components.DataUpdaterPlant, k8sClient, scheme.Scheme)).To(Succeed())
 
-			Expect(k8sClient.List(context.Background(), dups, client.InNamespace(cr1.Namespace),
+			Expect(k8sClient.List(ctx, dups, client.InNamespace(cr1.Namespace),
 				client.MatchingLabels{"astarte-component": "data-updater-plant"})).To(Succeed())
 			Expect(dups.Items).To(HaveLen(1))
 
 			// Cleanup
-			Expect(k8sClient.Delete(context.Background(), cr1)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, cr1)).To(Succeed())
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: cr1.Namespace}, &apiv2alpha1.Astarte{})
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: cr1.Name, Namespace: cr1.Namespace}, &apiv2alpha1.Astarte{})
 				return apierrors.IsNotFound(err)
 			}, Timeout, Interval).Should(BeTrue())
 		})
@@ -139,9 +138,9 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 			cr.Spec.Components.DataUpdaterPlant.Deploy = pointy.Bool(true)
 			cr.Spec.Components.DataUpdaterPlant.Replicas = pointy.Int32(3)
 
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(createIndexedDataUpdaterPlantDeployment(0, 3, cr, cr.Spec.Components.DataUpdaterPlant, k8sClient, scheme.Scheme)).To(Succeed())
@@ -149,7 +148,7 @@ var _ = Describe("Misc utils testing", Ordered, Serial, func() {
 			Expect(createIndexedDataUpdaterPlantDeployment(2, 3, cr, cr.Spec.Components.DataUpdaterPlant, k8sClient, scheme.Scheme)).To(Succeed())
 
 			dups := &appsv1.DeploymentList{}
-			Expect(k8sClient.List(context.Background(), dups, client.InNamespace(cr.Namespace),
+			Expect(k8sClient.List(ctx, dups, client.InNamespace(cr.Namespace),
 				client.MatchingLabels{"astarte-component": "data-updater-plant"})).To(Succeed())
 
 			Expect(dups.Items).To((HaveLen(3)))

--- a/internal/reconcile/astarte_generic_api_test.go
+++ b/internal/reconcile/astarte_generic_api_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package reconcile
 
 import (
-	"context"
-
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
 	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 
@@ -62,7 +60,7 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test EnsureAstarteGenericAPIComponent", func() {
@@ -88,9 +86,9 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 					apiSpec = cr.Spec.Components.Flow
 				}
 
-				Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+				Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+					return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 				}, Timeout, Interval).Should(Succeed())
 
 				Expect(EnsureAstarteGenericAPIComponent(cr, apiSpec, component, k8sClient, scheme.Scheme)).To(Succeed())
@@ -98,7 +96,7 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 				// Deployment should exist
 				deploymentName := cr.Name + "-" + component.DashedString()
 				dep := &appsv1.Deployment{}
-				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
 				Expect(dep.Labels).ToNot(BeNil())
 				Expect(dep.Labels["app"]).To(Equal(deploymentName))
 				Expect(dep.Labels["component"]).To(Equal("astarte"))
@@ -107,14 +105,14 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 				// Service should exist
 				serviceName := cr.Name + "-" + component.ServiceName()
 				svc := &v1.Service{}
-				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: serviceName, Namespace: cr.Namespace}, svc)).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: cr.Namespace}, svc)).To(Succeed())
 				Expect(svc.Spec.Ports).To(HaveLen(1))
 				Expect(svc.Spec.Ports[0].Port).To(Equal(astarteServicesPort))
 
 				// Cookie secret should exist
 				cookieSecret := &v1.Secret{}
 				cookieSecretName := deploymentName + "-cookie"
-				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: cookieSecretName, Namespace: cr.Namespace}, cookieSecret)).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cookieSecretName, Namespace: cr.Namespace}, cookieSecret)).To(Succeed())
 
 				// Verify container configuration
 				Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(1))
@@ -147,9 +145,9 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 		It("should not create deployment when component is disabled", func() {
 			component := apiv2alpha1.AppEngineAPI
 			cr.Spec.Components.AppengineAPI.Deploy = pointy.Bool(false)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteGenericAPIComponent(cr, cr.Spec.Components.AppengineAPI.AstarteGenericAPIComponentSpec, component, k8sClient, scheme.Scheme)).To(Succeed())
@@ -157,7 +155,7 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 			// Deployment should not exist
 			deploymentName := cr.Name + "-" + component.DashedString()
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).ToNot(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).ToNot(Succeed())
 		})
 
 		It("should delete existing deployment when disabling component", func() {
@@ -166,29 +164,29 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 
 			// Enable first
 			cr.Spec.Components.AppengineAPI.Deploy = pointy.Bool(true)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteGenericAPIComponent(cr, cr.Spec.Components.AppengineAPI.AstarteGenericAPIComponentSpec, component, k8sClient, scheme.Scheme)).To(Succeed())
 
 			// Verify deployment exists
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
 
 			// Now disable
 			cr.Spec.Components.AppengineAPI.Deploy = pointy.Bool(false)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteGenericAPIComponent(cr, cr.Spec.Components.AppengineAPI.AstarteGenericAPIComponentSpec, component, k8sClient, scheme.Scheme)).To(Succeed())
 
 			// Deployment should be deleted
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)
 				return apierrors.IsNotFound(err)
 			}, Timeout, Interval).Should(BeTrue())
 		})
@@ -206,16 +204,16 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 					v1.ResourceMemory: resource.MustParse("512Mi"),
 				},
 			}
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteGenericAPIComponent(cr, cr.Spec.Components.AppengineAPI.AstarteGenericAPIComponentSpec, component, k8sClient, scheme.Scheme)).To(Succeed())
 
 			deploymentName := cr.Name + "-" + component.DashedString()
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
 
 			container := dep.Spec.Template.Spec.Containers[0]
 			Expect(container.Resources.Requests.Cpu().String()).To(Equal("100m"))
@@ -228,16 +226,16 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 			component := apiv2alpha1.AppEngineAPI
 			cr.Spec.Components.AppengineAPI.Deploy = pointy.Bool(true)
 			cr.Spec.Components.AppengineAPI.Replicas = pointy.Int32(3)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteGenericAPIComponent(cr, cr.Spec.Components.AppengineAPI.AstarteGenericAPIComponentSpec, component, k8sClient, scheme.Scheme)).To(Succeed())
 
 			deploymentName := cr.Name + "-" + component.DashedString()
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
 
 			Expect(*dep.Spec.Replicas).To(Equal(int32(3)))
 		})
@@ -246,16 +244,16 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 			component := apiv2alpha1.AppEngineAPI
 			cr.Spec.Components.AppengineAPI.Deploy = pointy.Bool(true)
 			cr.Spec.Components.AppengineAPI.DisableAuthentication = pointy.Bool(true)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteGenericAPIComponent(cr, cr.Spec.Components.AppengineAPI.AstarteGenericAPIComponentSpec, component, k8sClient, scheme.Scheme)).To(Succeed())
 
 			deploymentName := cr.Name + "-" + component.DashedString()
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
 
 			container := dep.Spec.Template.Spec.Containers[0]
 			hasDisableAuthEnv := false
@@ -274,9 +272,9 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 		It("should create ServiceAccount for AppEngineAPI", func() {
 			component := apiv2alpha1.AppEngineAPI
 			cr.Spec.Components.AppengineAPI.Deploy = pointy.Bool(true)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteGenericAPIComponent(cr, cr.Spec.Components.AppengineAPI.AstarteGenericAPIComponentSpec, component, k8sClient, scheme.Scheme)).To(Succeed())
@@ -285,28 +283,28 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 
 			// ServiceAccount should exist
 			sa := &v1.ServiceAccount{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, sa)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, sa)).To(Succeed())
 
 			// Role should exist
 			role := &rbacv1.Role{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, role)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, role)).To(Succeed())
 
 			// RoleBinding should exist
 			roleBinding := &rbacv1.RoleBinding{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, roleBinding)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, roleBinding)).To(Succeed())
 
 			// Deployment should reference the ServiceAccount
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
 			Expect(dep.Spec.Template.Spec.ServiceAccountName).To(Equal(deploymentName))
 		})
 
 		It("should create ServiceAccount for RealmManagement", func() {
 			component := apiv2alpha1.RealmManagement
 			cr.Spec.Components.RealmManagement.Deploy = pointy.Bool(true)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteGenericAPIComponent(cr, cr.Spec.Components.RealmManagement, component, k8sClient, scheme.Scheme)).To(Succeed())
@@ -315,28 +313,28 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 
 			// ServiceAccount should exist
 			sa := &v1.ServiceAccount{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, sa)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, sa)).To(Succeed())
 
 			// Role should exist
 			role := &rbacv1.Role{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, role)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, role)).To(Succeed())
 
 			// RoleBinding should exist
 			roleBinding := &rbacv1.RoleBinding{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, roleBinding)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, roleBinding)).To(Succeed())
 
 			// Deployment should reference the ServiceAccount
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
 			Expect(dep.Spec.Template.Spec.ServiceAccountName).To(Equal(deploymentName))
 		})
 
 		It("should create ServiceAccount for Pairing", func() {
 			component := apiv2alpha1.Pairing
 			cr.Spec.Components.Pairing.Deploy = pointy.Bool(true)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteGenericAPIComponent(cr, cr.Spec.Components.Pairing, component, k8sClient, scheme.Scheme)).To(Succeed())
@@ -345,19 +343,19 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 
 			// ServiceAccount should exist
 			sa := &v1.ServiceAccount{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, sa)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, sa)).To(Succeed())
 
 			// Role should exist
 			role := &rbacv1.Role{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, role)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, role)).To(Succeed())
 
 			// RoleBinding should exist
 			roleBinding := &rbacv1.RoleBinding{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, roleBinding)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, roleBinding)).To(Succeed())
 
 			// Deployment should reference the ServiceAccount
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
 			Expect(dep.Spec.Template.Spec.ServiceAccountName).To(Equal(deploymentName))
 		})
 
@@ -371,9 +369,9 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 				AstarteMidPriority:  pointy.Int(500),
 				AstarteLowPriority:  pointy.Int(100),
 			}
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			// Create PriorityClasses first
@@ -383,7 +381,7 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 
 			deploymentName := cr.Name + "-" + component.DashedString()
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
 
 			Expect(dep.Spec.Template.Spec.PriorityClassName).To(Equal(AstarteHighPriorityName))
 		})
@@ -432,16 +430,16 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 			component := apiv2alpha1.Housekeeping
 			cr.Spec.Components.Housekeeping.Deploy = pointy.Bool(true)
 			cr.Spec.Features.RealmDeletion = true
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteGenericAPIComponent(cr, cr.Spec.Components.Housekeeping, component, k8sClient, scheme.Scheme)).To(Succeed())
 
 			deploymentName := cr.Name + "-" + component.DashedString()
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
 
 			container := dep.Spec.Template.Spec.Containers[0]
 
@@ -463,16 +461,16 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 		It("should add proper environment variables for Pairing", func() {
 			component := apiv2alpha1.Pairing
 			cr.Spec.Components.Pairing.Deploy = pointy.Bool(true)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteGenericAPIComponent(cr, cr.Spec.Components.Pairing, component, k8sClient, scheme.Scheme)).To(Succeed())
 
 			deploymentName := cr.Name + "-" + component.DashedString()
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
 
 			container := dep.Spec.Template.Spec.Containers[0]
 
@@ -501,16 +499,16 @@ var _ = Describe("Astarte Generic API reconcile tests", Ordered, Serial, func() 
 			component := apiv2alpha1.AppEngineAPI
 			cr.Spec.Components.AppengineAPI.Deploy = pointy.Bool(true)
 			cr.Spec.AstarteInstanceID = CustomAstarteInstanceID
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstarteGenericAPIComponent(cr, cr.Spec.Components.AppengineAPI.AstarteGenericAPIComponentSpec, component, k8sClient, scheme.Scheme)).To(Succeed())
 
 			deploymentName := cr.Name + "-" + component.DashedString()
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: cr.Namespace}, dep)).To(Succeed())
 
 			container := dep.Spec.Template.Spec.Containers[0]
 			hasInstanceID := false

--- a/internal/reconcile/astarte_generic_backend_test.go
+++ b/internal/reconcile/astarte_generic_backend_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package reconcile
 
 import (
-	"context"
-
 	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	"go.openly.dev/pointy"
 
@@ -63,7 +61,7 @@ var _ = Describe("Astarte Generic Backend testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test EnsureAstarteGenericBackend", func() {
@@ -81,7 +79,7 @@ var _ = Describe("Astarte Generic Backend testing", Ordered, Serial, func() {
 				deployment := &appsv1.Deployment{}
 				deploymentName := cr.Name + "-" + component.DashedString()
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{
+					return k8sClient.Get(ctx, types.NamespacedName{
 						Name:      deploymentName,
 						Namespace: CustomAstarteNamespace,
 					}, deployment)
@@ -103,7 +101,7 @@ var _ = Describe("Astarte Generic Backend testing", Ordered, Serial, func() {
 				service := &v1.Service{}
 				serviceName := cr.Name + "-" + component.ServiceName()
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{
+					return k8sClient.Get(ctx, types.NamespacedName{
 						Name:      serviceName,
 						Namespace: CustomAstarteNamespace,
 					}, service)
@@ -130,7 +128,7 @@ var _ = Describe("Astarte Generic Backend testing", Ordered, Serial, func() {
 				deployment := &appsv1.Deployment{}
 				deploymentName := cr.Name + "-" + component.DashedString()
 				Eventually(func() bool {
-					err := k8sClient.Get(context.Background(), types.NamespacedName{
+					err := k8sClient.Get(ctx, types.NamespacedName{
 						Name:      deploymentName,
 						Namespace: CustomAstarteNamespace,
 					}, deployment)
@@ -151,7 +149,7 @@ var _ = Describe("Astarte Generic Backend testing", Ordered, Serial, func() {
 				deployment := &appsv1.Deployment{}
 				deploymentName := cr.Name + "-" + component.DashedString()
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{
+					return k8sClient.Get(ctx, types.NamespacedName{
 						Name:      deploymentName,
 						Namespace: CustomAstarteNamespace,
 					}, deployment)
@@ -163,7 +161,7 @@ var _ = Describe("Astarte Generic Backend testing", Ordered, Serial, func() {
 
 				// Verify deployment was deleted
 				Eventually(func() bool {
-					err := k8sClient.Get(context.Background(), types.NamespacedName{
+					err := k8sClient.Get(ctx, types.NamespacedName{
 						Name:      deploymentName,
 						Namespace: CustomAstarteNamespace,
 					}, deployment)
@@ -195,7 +193,7 @@ var _ = Describe("Astarte Generic Backend testing", Ordered, Serial, func() {
 				deployment := &appsv1.Deployment{}
 				deploymentName := cr.Name + "-" + component.DashedString()
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{
+					return k8sClient.Get(ctx, types.NamespacedName{
 						Name:      deploymentName,
 						Namespace: CustomAstarteNamespace,
 					}, deployment)
@@ -232,7 +230,7 @@ var _ = Describe("Astarte Generic Backend testing", Ordered, Serial, func() {
 				deployment := &appsv1.Deployment{}
 				deploymentName := cr.Name + "-" + component.DashedString()
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{
+					return k8sClient.Get(ctx, types.NamespacedName{
 						Name:      deploymentName,
 						Namespace: CustomAstarteNamespace,
 					}, deployment)
@@ -273,7 +271,7 @@ var _ = Describe("Astarte Generic Backend testing", Ordered, Serial, func() {
 				deployment := &appsv1.Deployment{}
 				deploymentName := cr.Name + "-" + component.DashedString()
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{
+					return k8sClient.Get(ctx, types.NamespacedName{
 						Name:      deploymentName,
 						Namespace: CustomAstarteNamespace,
 					}, deployment)

--- a/internal/reconcile/astarte_priorityclass_test.go
+++ b/internal/reconcile/astarte_priorityclass_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package reconcile
 
 import (
-	"context"
-
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
 	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 
@@ -59,16 +57,16 @@ var _ = Describe("Astarte PriorityClass reconcile tests", Ordered, Serial, func(
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("EnsureAstartePriorityClasses", func() {
 		It("should not create PriorityClasses when feature disabled or nil", func() {
 			// Feature nil
 			cr.Spec.Features.AstartePodPriorities = nil
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 			Expect(EnsureAstartePriorityClasses(cr, k8sClient, scheme.Scheme)).To(Succeed())
 
@@ -76,22 +74,22 @@ var _ = Describe("Astarte PriorityClass reconcile tests", Ordered, Serial, func(
 			for _, name := range []string{AstarteHighPriorityName, AstarteMidPriorityName, AstarteLowPriorityName} {
 				pc := &schedulingv1.PriorityClass{}
 				Eventually(func() bool {
-					err := k8sClient.Get(context.Background(), types.NamespacedName{Name: name}, pc)
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, pc)
 					return apierrors.IsNotFound(err)
 				}, Timeout, Interval).Should(BeTrue())
 			}
 
 			// Explicitly disable
 			cr.Spec.Features.AstartePodPriorities = &apiv2alpha1.AstartePodPrioritiesSpec{Enable: false}
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 			Expect(EnsureAstartePriorityClasses(cr, k8sClient, scheme.Scheme)).To(Succeed())
 			for _, name := range []string{AstarteHighPriorityName, AstarteMidPriorityName, AstarteLowPriorityName} {
 				pc := &schedulingv1.PriorityClass{}
 				Eventually(func() bool {
-					err := k8sClient.Get(context.Background(), types.NamespacedName{Name: name}, pc)
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, pc)
 					return apierrors.IsNotFound(err)
 				}, Timeout, Interval).Should(BeTrue())
 			}
@@ -104,9 +102,9 @@ var _ = Describe("Astarte PriorityClass reconcile tests", Ordered, Serial, func(
 				AstarteMidPriority:  pointy.Int(200),
 				AstarteLowPriority:  pointy.Int(20),
 			}
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstartePriorityClasses(cr, k8sClient, scheme.Scheme)).To(Succeed())
@@ -114,7 +112,7 @@ var _ = Describe("Astarte PriorityClass reconcile tests", Ordered, Serial, func(
 			// Check all PriorityClasses exist with expected values
 			testPriorityClass := func(name string, expected int32) {
 				pc := &schedulingv1.PriorityClass{}
-				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: name}, pc)).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name}, pc)).To(Succeed())
 				Expect(pc.Value).To(Equal(expected))
 				Expect(pc.GlobalDefault).To(BeFalse())
 				Expect(pc.PreemptionPolicy).ToNot(BeNil())
@@ -134,9 +132,9 @@ var _ = Describe("Astarte PriorityClass reconcile tests", Ordered, Serial, func(
 				AstarteMidPriority:  pointy.Int(150),
 				AstarteLowPriority:  pointy.Int(15),
 			}
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureAstartePriorityClasses(cr, k8sClient, scheme.Scheme)).To(Succeed())
@@ -144,7 +142,7 @@ var _ = Describe("Astarte PriorityClass reconcile tests", Ordered, Serial, func(
 			// Helper function to test priority class properties
 			testPriorityClassProperties := func(name string, expectedValue int32, expectedDescriptionSubstring string) {
 				pc := &schedulingv1.PriorityClass{}
-				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: name}, pc)).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name}, pc)).To(Succeed())
 				Expect(pc.Value).To(Equal(expectedValue))
 				Expect(pc.Description).To(ContainSubstring(expectedDescriptionSubstring))
 				Expect(pc.GlobalDefault).To(BeFalse())
@@ -168,18 +166,18 @@ var _ = Describe("Astarte PriorityClass reconcile tests", Ordered, Serial, func(
 				{AstarteLowPriorityName, int32(15), "Astarte low-priority pods"},
 			} {
 				pc := &schedulingv1.PriorityClass{}
-				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: testCase.name}, pc)).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testCase.name}, pc)).To(Succeed())
 
 				originalValue := pc.Value
 				originalDescription := pc.Description
 
 				// Modify mutable fields (e.g. Description
 				pc.Description = "modified description"
-				Expect(k8sClient.Update(context.Background(), pc)).To(Succeed())
+				Expect(k8sClient.Update(ctx, pc)).To(Succeed())
 
 				// Verify the changes were applied
 				modifiedPc := &schedulingv1.PriorityClass{}
-				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: testCase.name}, modifiedPc)).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testCase.name}, modifiedPc)).To(Succeed())
 				Expect(modifiedPc.Description).To(Equal("modified description"))
 
 				// Re-run reconciliation - should restore all fields to expected values
@@ -187,19 +185,19 @@ var _ = Describe("Astarte PriorityClass reconcile tests", Ordered, Serial, func(
 
 				// Verify reconciliation restored the correct values
 				restoredPc := &schedulingv1.PriorityClass{}
-				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: testCase.name}, restoredPc)).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testCase.name}, restoredPc)).To(Succeed())
 				Expect(restoredPc.Value).To(Equal(originalValue))
 				Expect(restoredPc.Description).To(Equal(originalDescription))
 				Expect(restoredPc.GlobalDefault).To(BeFalse())
 				Expect(*restoredPc.PreemptionPolicy).To(Equal(v1.PreemptNever))
 
 				// Try to change non-mutable field (Value) - should trigger an error on update
-				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: AstarteHighPriorityName}, pc)).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: AstarteHighPriorityName}, pc)).To(Succeed())
 				pc.Value = originalValue + 100
-				Expect(k8sClient.Update(context.Background(), pc)).ToNot(Succeed())
+				Expect(k8sClient.Update(ctx, pc)).ToNot(Succeed())
 				// Re-run ensure - should not change anything as Value cannot be changed
 				Expect(EnsureAstartePriorityClasses(cr, k8sClient, scheme.Scheme)).To(Succeed())
-				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: testCase.name}, pc)).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testCase.name}, pc)).To(Succeed())
 				Expect(pc.Value).To(Equal(originalValue)) // Value should remain unchanged
 			}
 		})

--- a/internal/reconcile/cfssl_test.go
+++ b/internal/reconcile/cfssl_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package reconcile
 
 import (
-	"context"
-
 	"go.openly.dev/pointy"
 
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
@@ -58,14 +56,14 @@ var _ = Describe("CFSSL testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test EnsureCFSSL", func() {
 		It("should create/update the CFSSL pod", func() {
 			deploymentName := CustomAstarteName + "-cfssl"
 			cr.Spec.CFSSL.Deploy = pointy.Bool(true)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 
 			// First reconciliation
 			Expect(EnsureCFSSL(cr, k8sClient, scheme.Scheme)).To(Succeed())
@@ -73,7 +71,7 @@ var _ = Describe("CFSSL testing", Ordered, Serial, func() {
 			// Check that the deployment is created
 			cfsslDeployment := &appsv1.Deployment{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: CustomAstarteNamespace}, cfsslDeployment)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: CustomAstarteNamespace}, cfsslDeployment)
 			}, Timeout, Interval).Should(Succeed())
 
 			// Store the checksum
@@ -82,14 +80,14 @@ var _ = Describe("CFSSL testing", Ordered, Serial, func() {
 
 			// Update the Astarte CR
 			cr.Spec.CFSSL.CaExpiry = "1h"
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 
 			// Second reconciliation
 			Expect(EnsureCFSSL(cr, k8sClient, scheme.Scheme)).To(Succeed())
 
 			// Check that the deployment is updated
 			Eventually(func() string {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: deploymentName, Namespace: CustomAstarteNamespace}, cfsslDeployment)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: CustomAstarteNamespace}, cfsslDeployment)
 				if err != nil {
 					return ""
 				}

--- a/internal/reconcile/common_test.go
+++ b/internal/reconcile/common_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package reconcile
 
 import (
-	"context"
-
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
 	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	. "github.com/onsi/ginkgo/v2"
@@ -55,7 +53,7 @@ var _ = Describe("Common reconcile testing", Ordered, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test EnsureHousekeepingKey", func() {
@@ -66,7 +64,7 @@ var _ = Describe("Common reconcile testing", Ordered, func() {
 			// Check that the housekeeping keypair secrets are present
 			secretPrivate := &v1.Secret{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      CustomAstarteName + "-housekeeping-private-key",
 					Namespace: CustomAstarteNamespace,
 				}, secretPrivate)
@@ -75,7 +73,7 @@ var _ = Describe("Common reconcile testing", Ordered, func() {
 
 			secretPublic := &v1.Secret{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      CustomAstarteName + "-housekeeping-public-key",
 					Namespace: CustomAstarteNamespace,
 				}, secretPublic)
@@ -90,7 +88,7 @@ var _ = Describe("Common reconcile testing", Ordered, func() {
 			// Check that the housekeeping keypair secrets are present
 			secret := &v1.Secret{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      CustomAstarteName + "-secret-key-base",
 					Namespace: CustomAstarteNamespace,
 				}, secret)
@@ -104,7 +102,7 @@ var _ = Describe("Common reconcile testing", Ordered, func() {
 
 				cm := &v1.ConfigMap{}
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{
+					return k8sClient.Get(ctx, types.NamespacedName{
 						Name:      CustomAstarteName + "-generic-erlang-configuration",
 						Namespace: CustomAstarteNamespace,
 					}, cm)
@@ -119,7 +117,7 @@ var _ = Describe("Common reconcile testing", Ordered, func() {
 
 				secret := &v1.Secret{}
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{
+					return k8sClient.Get(ctx, types.NamespacedName{
 						Name:      CustomAstarteName + "-erlang-clustering-cookie",
 						Namespace: CustomAstarteNamespace,
 					}, secret)

--- a/internal/reconcile/probes_test.go
+++ b/internal/reconcile/probes_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package reconcile
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -71,7 +69,7 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	// Default probes (no custom overrides)
@@ -150,9 +148,9 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 	Describe("Test probes injection on reconcile (Astarte Components)", func() {
 		DescribeTable("should inject default probes when no custom probes are set",
 			func(component apiv2alpha1.AstarteComponent) {
-				Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+				Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+					return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 				}, Timeout, Interval).Should(Succeed())
 
 				switch component {
@@ -174,7 +172,7 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 				deploymentName := cr.Name + "-" + component.DashedString()
 				dep := &appsv1.Deployment{}
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{
+					return k8sClient.Get(ctx, types.NamespacedName{
 						Name:      deploymentName,
 						Namespace: CustomAstarteNamespace,
 					}, dep)
@@ -242,9 +240,9 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 					cr.Spec.Components.TriggerEngine.StartupProbe = customProbe
 				}
 
-				Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+				Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+					return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 				}, Timeout, Interval).Should(Succeed())
 
 				switch component {
@@ -265,7 +263,7 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 				deploymentName := cr.Name + "-" + component.DashedString()
 				dep := &appsv1.Deployment{}
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), types.NamespacedName{
+					return k8sClient.Get(ctx, types.NamespacedName{
 						Name:      deploymentName,
 						Namespace: CustomAstarteNamespace,
 					}, dep)
@@ -496,9 +494,9 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 	// Test probes injection on reconcile for CFSSL and VerneMQ
 	Describe("Test probes injection on reconcile (CFSSL)", func() {
 		It("should inject default probes when no custom probes are set", func() {
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureCFSSL(cr, k8sClient, scheme.Scheme)).To(Succeed())
@@ -507,7 +505,7 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 			deploymentName := cr.Name + "-cfssl"
 			dep := &appsv1.Deployment{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      deploymentName,
 					Namespace: CustomAstarteNamespace,
 				}, dep)
@@ -539,9 +537,9 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 			cr.Spec.CFSSL.ReadinessProbe = customProbe
 			cr.Spec.CFSSL.StartupProbe = customProbe
 
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureCFSSL(cr, k8sClient, scheme.Scheme)).To(Succeed())
@@ -550,7 +548,7 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 			deploymentName := cr.Name + "-cfssl"
 			dep := &appsv1.Deployment{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      deploymentName,
 					Namespace: CustomAstarteNamespace,
 				}, dep)
@@ -595,9 +593,9 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 
 	Describe("Test probes injection on reconcile (VerneMQ)", func() {
 		It("should inject default probes when no custom probes are set", func() {
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureVerneMQ(cr, k8sClient, scheme.Scheme)).To(Succeed())
@@ -606,7 +604,7 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 			statefulSetName := cr.Name + "-vernemq"
 			sts := &appsv1.StatefulSet{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      statefulSetName,
 					Namespace: CustomAstarteNamespace,
 				}, sts)
@@ -638,9 +636,9 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 			cr.Spec.VerneMQ.ReadinessProbe = customProbe
 			cr.Spec.VerneMQ.StartupProbe = customProbe
 
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: CustomAstarteName, Namespace: CustomAstarteNamespace}, cr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Expect(EnsureVerneMQ(cr, k8sClient, scheme.Scheme)).To(Succeed())
@@ -649,7 +647,7 @@ var _ = Describe("Astarte Probes testing", Ordered, Serial, func() {
 			statefulSetName := cr.Name + "-vernemq"
 			sts := &appsv1.StatefulSet{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      statefulSetName,
 					Namespace: CustomAstarteNamespace,
 				}, sts)

--- a/internal/reconcile/suite_test.go
+++ b/internal/reconcile/suite_test.go
@@ -26,21 +26,19 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
+	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+const Timeout = "30s"
+const Interval = "1s"
 
 var cfg *rest.Config
 var k8sClient client.Client
@@ -49,55 +47,19 @@ var cancel context.CancelFunc
 var testEnv *envtest.Environment
 var baseCr *apiv2alpha1.Astarte
 
-const Timeout = "30s"
-const Interval = "1s"
-
 func TestReconcile(t *testing.T) {
 	RegisterFailHandler(Fail)
-
 	RunSpecs(t, "Reconcile Test Suite")
 }
 
-// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
-// ENVTEST-based tests depend on specific binaries, usually located in paths set by
-// controller-runtime. When running tests directly (e.g., via an IDE) without using
-// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
-//
-// This function streamlines the process by finding the required binaries, similar to
-// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
-// properly set up, run 'make setup-envtest' beforehand.
-func getFirstFoundEnvTestBinaryDir() string {
-	basePath := filepath.Join("..", "..", "bin", "k8s")
-	entries, err := os.ReadDir(basePath)
-	if err != nil {
-		logf.Log.Error(err, "Failed to read directory", "path", basePath)
-		return ""
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
-		}
-	}
-	return ""
-}
-
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
+	ctx, cancel = integrationutils.SetupTestSuite()
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
-
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: getFirstFoundEnvTestBinaryDir(),
-	}
+	testEnv = integrationutils.DefaultEnvTestConfig(
+		filepath.Join("..", "..", "config", "crd", "bases"),
+		filepath.Join("..", "..", "bin", "k8s"),
+	)
 
 	var err error
 	cfg, err = testEnv.Start()
@@ -110,7 +72,6 @@ var _ = BeforeSuite(func() {
 	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
@@ -124,8 +85,5 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	cancel()
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	integrationutils.StopEnvTest(testEnv, cancel)
 })

--- a/internal/reconcile/utils_test.go
+++ b/internal/reconcile/utils_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package reconcile
 
 import (
-	"context"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base32"
@@ -71,7 +70,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test getAstarteCommonEnvVars", func() {
@@ -148,7 +147,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 			// Verify secret was created
 			secret := &v1.Secret{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      secretName,
 					Namespace: CustomAstarteNamespace,
 				}, secret)
@@ -183,7 +182,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 			// Verify secret was created
 			secret := &v1.Secret{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      secretName,
 					Namespace: CustomAstarteNamespace,
 				}, secret)
@@ -223,7 +222,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 			// Verify ServiceAccount
 			sa := &v1.ServiceAccount{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      name,
 					Namespace: CustomAstarteNamespace,
 				}, sa)
@@ -232,7 +231,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 			// Verify Role
 			role := &rbacv1.Role{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      name,
 					Namespace: CustomAstarteNamespace,
 				}, role)
@@ -243,7 +242,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 			// Verify RoleBinding
 			rb := &rbacv1.RoleBinding{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      name,
 					Namespace: CustomAstarteNamespace,
 				}, rb)
@@ -272,7 +271,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 			// Verify secret was created
 			secret := &v1.Secret{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      secretName,
 					Namespace: CustomAstarteNamespace,
 				}, secret)
@@ -280,7 +279,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 
 			// Verify cookie content
 			Eventually(func() bool {
-				if err := k8sClient.Get(context.Background(), types.NamespacedName{
+				if err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      secretName,
 					Namespace: CustomAstarteNamespace,
 				}, secret); err != nil {
@@ -308,7 +307,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 			// Get the original cookie
 			secret := &v1.Secret{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      secretName,
 					Namespace: CustomAstarteNamespace,
 				}, secret)
@@ -321,7 +320,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 
 			// Verify cookie wasn't changed
 			Eventually(func() string {
-				if err := k8sClient.Get(context.Background(), types.NamespacedName{
+				if err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      secretName,
 					Namespace: CustomAstarteNamespace,
 				}, secret); err != nil {
@@ -604,7 +603,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 			// Verify service was created
 			service := &v1.Service{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      serviceName,
 					Namespace: CustomAstarteNamespace,
 				}, service)
@@ -634,7 +633,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 			// Wait for service creation to complete
 			service := &v1.Service{}
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
+				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      serviceName,
 					Namespace: CustomAstarteNamespace,
 				}, service)
@@ -647,7 +646,7 @@ var _ = Describe("Utils functions testing", Ordered, Serial, func() {
 
 			// Verify service was updated
 			Eventually(func() map[string]string {
-				if err := k8sClient.Get(context.Background(), types.NamespacedName{
+				if err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      serviceName,
 					Namespace: CustomAstarteNamespace,
 				}, service); err != nil {

--- a/internal/reconcile/vernemq_test.go
+++ b/internal/reconcile/vernemq_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package reconcile
 
 import (
-	"context"
-
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
 	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	"go.openly.dev/pointy"
@@ -73,7 +71,7 @@ var _ = Describe("VerneMQ testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("Test EnsureVerneMQ", func() {
@@ -84,16 +82,16 @@ var _ = Describe("VerneMQ testing", Ordered, Serial, func() {
 			statefulSetName := GetVerneMQStatefulSetName(cr)
 			Expect(statefulSetName).To(Equal(CustomAstarteName + "-vernemq"))
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: statefulSetName, Namespace: cr.Namespace}, &appsv1.StatefulSet{})
+				return k8sClient.Get(ctx, types.NamespacedName{Name: statefulSetName, Namespace: cr.Namespace}, &appsv1.StatefulSet{})
 			}, Timeout, Interval).Should(Succeed())
 
 			// Update the VerneMQ spec to use a different image
 			cr.Spec.VerneMQ.Image = "vernemq/vernemq:0.12.3"
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 
 			// update astarte cr.vernemq.deploy to true to force reconciliation
 			cr.Spec.VerneMQ.Deploy = pointy.Bool(true)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 
 			// Reconcile again
 			Expect(EnsureVerneMQ(cr, k8sClient, scheme.Scheme)).To(Succeed())
@@ -101,7 +99,7 @@ var _ = Describe("VerneMQ testing", Ordered, Serial, func() {
 			// Check that the VerneMQ statefulSet is updated
 			updatedStatefulSet := &appsv1.StatefulSet{}
 			Eventually(func() string {
-				if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: statefulSetName, Namespace: cr.Namespace}, updatedStatefulSet); err != nil {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: statefulSetName, Namespace: cr.Namespace}, updatedStatefulSet); err != nil {
 					return ""
 				}
 				if len(updatedStatefulSet.Spec.Template.Spec.Containers) == 0 {
@@ -112,10 +110,10 @@ var _ = Describe("VerneMQ testing", Ordered, Serial, func() {
 
 			// Now, set cr.spec.vernemq.deploy to false and ensure the statefulSet is deleted
 			cr.Spec.VerneMQ.Deploy = pointy.Bool(false)
-			Expect(k8sClient.Update(context.Background(), cr)).To(Succeed())
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 			Expect(EnsureVerneMQ(cr, k8sClient, scheme.Scheme)).To(Succeed())
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: statefulSetName, Namespace: cr.Namespace}, &appsv1.StatefulSet{})
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: statefulSetName, Namespace: cr.Namespace}, &appsv1.StatefulSet{})
 				return apierrors.IsNotFound(err)
 			}, Timeout, Interval).Should(BeTrue())
 		})

--- a/internal/webhook/api/v2alpha1/astarte_webhook_test.go
+++ b/internal/webhook/api/v2alpha1/astarte_webhook_test.go
@@ -20,8 +20,6 @@ limitations under the License.
 package v2alpha1
 
 import (
-	"context"
-
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
 	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	. "github.com/onsi/ginkgo/v2"
@@ -70,7 +68,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 	})
 
 	AfterEach(func() {
-		integrationutils.TeardownResourcesInNamespace(context.Background(), k8sClient, CustomAstarteNamespace)
+		integrationutils.TeardownResourcesInNamespace(ctx, k8sClient, CustomAstarteNamespace)
 	})
 
 	Describe("TestValidateSSLListener", func() {
@@ -129,11 +127,11 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 					"key":  []byte("my-key"),
 				},
 			}
-			Expect(k8sClient.Create(context.Background(), secret)).To(Succeed())
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
 			// Ensure the secret is created and available in the client cache
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: secretName, Namespace: CustomAstarteNamespace}, &v1.Secret{})
+				return k8sClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: CustomAstarteNamespace}, &v1.Secret{})
 			}, Timeout, Interval).Should(Succeed())
 
 			// Wait for the validation to pass - give more time for webhook client cache sync
@@ -143,10 +141,10 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 			}, Timeout, Interval).Should(BeTrue())
 
 			// Cleanup the secret
-			Expect(k8sClient.Delete(context.Background(), secret)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
 
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: secretName, Namespace: CustomAstarteNamespace}, &v1.Secret{})
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: CustomAstarteNamespace}, &v1.Secret{})
 				return apierrors.IsNotFound(err)
 			}, Timeout, Interval).Should(BeTrue())
 		})
@@ -855,7 +853,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 		It("should succeed when spec passes all validations", func() {
 			cr.Spec.AstarteInstanceID = "coverageid1"
 			validator := &AstarteCustomValidator{}
-			w, err := validator.ValidateCreate(context.Background(), cr)
+			w, err := validator.ValidateCreate(ctx, cr)
 			Expect(w).To(BeNil())
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -864,7 +862,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 			cr.Spec.AstarteInstanceID = "coverageid2"
 			cr.Spec.VerneMQ = apiv2alpha1.AstarteVerneMQSpec{SSLListener: pointy.Bool(true), SSLListenerCertSecretName: ""}
 			validator := &AstarteCustomValidator{}
-			w, err := validator.ValidateCreate(context.Background(), cr)
+			w, err := validator.ValidateCreate(ctx, cr)
 			Expect(w).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsInvalid(err)).To(BeTrue())
@@ -874,7 +872,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 			cr.Spec.AstarteInstanceID = "coverageid3"
 			cr.Spec.Cassandra.AstarteSystemKeyspace.ReplicationFactor = pointy.Int(2) // Even number - invalid
 			validator := &AstarteCustomValidator{}
-			w, err := validator.ValidateCreate(context.Background(), cr)
+			w, err := validator.ValidateCreate(ctx, cr)
 			Expect(w).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsInvalid(err)).To(BeTrue())
@@ -893,7 +891,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 			oldObj.Spec.AstarteInstanceID = "old"
 			cr.Spec.AstarteInstanceID = "new"
 			validator := &AstarteCustomValidator{}
-			w, err := validator.ValidateUpdate(context.Background(), cr, oldObj)
+			w, err := validator.ValidateUpdate(ctx, cr, oldObj)
 			Expect(w).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsInvalid(err)).To(BeTrue())
@@ -912,7 +910,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 				},
 			}
 			validator := &AstarteCustomValidator{}
-			w, err := validator.ValidateUpdate(context.Background(), cr, oldObj)
+			w, err := validator.ValidateUpdate(ctx, cr, oldObj)
 			Expect(w).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsInvalid(err)).To(BeTrue())
@@ -924,7 +922,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 			cr.Spec.AstarteInstanceID = "same"
 			cr.Spec.Cassandra = apiv2alpha1.AstarteCassandraSpec{AstarteSystemKeyspace: apiv2alpha1.AstarteSystemKeyspaceSpec{}}
 			validator := &AstarteCustomValidator{}
-			w, err := validator.ValidateUpdate(context.Background(), cr, oldObj)
+			w, err := validator.ValidateUpdate(ctx, cr, oldObj)
 			Expect(w).To(BeNil())
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -970,7 +968,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 		// The function is not implemented, expect nil, nil
 		It("should return nil, nil", func() {
 			validator := &AstarteCustomValidator{}
-			w, err := validator.ValidateDelete(context.Background(), cr)
+			w, err := validator.ValidateDelete(ctx, cr)
 			Expect(w).To(BeNil())
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -986,21 +984,21 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 
 			// Create should succeed
 			Eventually(func() error {
-				return k8sClient.Create(context.Background(), newCr)
+				return k8sClient.Create(ctx, newCr)
 			}, Timeout, Interval).Should(Succeed())
 
 			// Fetch to ensure it's created
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: newCr.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
+				return k8sClient.Get(ctx, types.NamespacedName{Name: newCr.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
 			}, Timeout, Interval).Should(Succeed())
 
 			// Cleanup
 			Eventually(func() error {
-				return k8sClient.Delete(context.Background(), newCr)
+				return k8sClient.Delete(ctx, newCr)
 			}, Timeout, Interval).Should(Succeed())
 
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: newCr.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: newCr.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
 				return apierrors.IsNotFound(err)
 			}, Timeout, Interval).Should(BeTrue())
 		})
@@ -1015,7 +1013,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 
 			// Create should fail due to webhook rejection
 			Eventually(func() error {
-				return k8sClient.Create(context.Background(), newCr)
+				return k8sClient.Create(ctx, newCr)
 			}, Timeout, Interval).ShouldNot(Succeed())
 
 			// Test the validator directly
@@ -1035,12 +1033,12 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 
 			// Create should succeed
 			Eventually(func() error {
-				return k8sClient.Create(context.Background(), cr1)
+				return k8sClient.Create(ctx, cr1)
 			}, Timeout, Interval).Should(Succeed())
 
 			// Fetch to ensure it's created
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr1.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
 			}, Timeout, Interval).Should(Succeed())
 
 			// Try to validate a new CR with the same instanceID
@@ -1052,7 +1050,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 
 			// Create should not succeed
 			Eventually(func() error {
-				return k8sClient.Create(context.Background(), cr2)
+				return k8sClient.Create(ctx, cr2)
 			}, Timeout, Interval).Should(Not(Succeed()))
 
 			// Test the validator directly
@@ -1062,9 +1060,9 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 			}, Timeout, Interval).Should(BeTrue())
 
 			// Cleanup
-			Expect(k8sClient.Delete(context.Background(), cr1)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, cr1)).To(Succeed())
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: cr1.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
 				return apierrors.IsNotFound(err)
 			}, Timeout, Interval).Should(BeTrue())
 		})
@@ -1078,12 +1076,12 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 
 			// Create should succeed
 			Eventually(func() error {
-				return k8sClient.Create(context.Background(), cr1)
+				return k8sClient.Create(ctx, cr1)
 			}, Timeout, Interval).Should(Succeed())
 
 			// Fetch to ensure it's created
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr1.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
 			}, Timeout, Interval).Should(Succeed())
 
 			// Create another with a different instanceID
@@ -1094,24 +1092,24 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 
 			// Create should succeed
 			Eventually(func() error {
-				return k8sClient.Create(context.Background(), cr2)
+				return k8sClient.Create(ctx, cr2)
 			}, Timeout, Interval).Should(Succeed())
 
 			// Fetch to ensure it's created
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: cr2.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
+				return k8sClient.Get(ctx, types.NamespacedName{Name: cr2.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
 			}, Timeout, Interval).Should(Succeed())
 
 			// Cleanup
-			Expect(k8sClient.Delete(context.Background(), cr1)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, cr1)).To(Succeed())
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr1.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: cr1.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
 				return apierrors.IsNotFound(err)
 			}, Timeout, Interval).Should(BeTrue())
 
-			Expect(k8sClient.Delete(context.Background(), cr2)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, cr2)).To(Succeed())
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cr2.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: cr2.Name, Namespace: CustomAstarteNamespace}, &apiv2alpha1.Astarte{})
 				return apierrors.IsNotFound(err)
 			}, Timeout, Interval).Should(BeTrue())
 		})

--- a/internal/webhook/api/v2alpha1/webhook_suite_test.go
+++ b/internal/webhook/api/v2alpha1/webhook_suite_test.go
@@ -1,5 +1,7 @@
 /*
-Copyright 2026 The Kubernetes authors.
+This file is part of Astarte.
+
+Copyright 2020-26 SECO Mind Srl.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,6 +30,7 @@ import (
 	"time"
 
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
+	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -37,15 +40,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	// +kubebuilder:scaffold:imports
 )
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 const Timeout = "30s"
 const Interval = "1s"
@@ -61,17 +59,21 @@ var (
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
+	RunSpecs(t, "Astarte Webhook Suite")
+}
 
-	RunSpecs(t, "Webhook Suite")
+func getRepoRoot() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "."
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", ".."))
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = integrationutils.SetupTestSuite()
 
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	var err error
-	err = apiv2alpha1.AddToScheme(scheme.Scheme)
+	err := apiv2alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
@@ -80,19 +82,16 @@ var _ = BeforeSuite(func() {
 	repoRoot := getRepoRoot()
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join(repoRoot, "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
-
+		ErrorIfCRDPathMissing: true,
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join(repoRoot, "config", "webhook")},
 		},
 	}
 
-	// Retrieve the first found binary directory to allow running tests from IDEs
-	if getFirstFoundEnvTestBinaryDir() != "" {
-		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	if binDir := integrationutils.GetFirstFoundEnvTestBinaryDir(filepath.Join(repoRoot, "bin", "k8s")); binDir != "" {
+		testEnv.BinaryAssetsDirectory = binDir
 	}
 
-	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
@@ -101,7 +100,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager.
+	By("starting webhook server")
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
@@ -116,8 +115,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = SetupAstarteWebhookWithManager(mgr)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
+	// +kubebuilder:scaffold:webhook
+
+	By("loading the base Astarte manifest")
 	manifestPath := filepath.Join(repoRoot, "test", "manifests", "api_v2alpha1_astarte_1.3.yaml")
 	manifestBytes, err := os.ReadFile(manifestPath)
 	Expect(err).ToNot(HaveOccurred())
@@ -126,15 +128,12 @@ var _ = BeforeSuite(func() {
 	err = yaml.Unmarshal(manifestBytes, baseCr)
 	Expect(err).ToNot(HaveOccurred())
 
-	// +kubebuilder:scaffold:webhook
-
 	go func() {
 		defer GinkgoRecover()
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -142,48 +141,10 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
-
 		return conn.Close()
 	}).Should(Succeed())
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	integrationutils.StopEnvTest(testEnv, cancel)
 })
-
-// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
-// ENVTEST-based tests depend on specific binaries, usually located in paths set by
-// controller-runtime. When running tests directly (e.g., via an IDE) without using
-// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
-//
-// This function streamlines the process by finding the required binaries, similar to
-// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
-// properly set up, run 'make setup-envtest' beforehand.
-func getFirstFoundEnvTestBinaryDir() string {
-	basePath := filepath.Join(getRepoRoot(), "bin", "k8s")
-	entries, err := os.ReadDir(basePath)
-	if err != nil {
-		logf.Log.Error(err, "Failed to read directory", "path", basePath)
-		return ""
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
-		}
-	}
-	return ""
-}
-
-func getRepoRoot() string {
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		logf.Log.Error(fmt.Errorf("cannot determine caller"), "Failed to compute repository root")
-		return "."
-	}
-
-	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", ".."))
-}

--- a/internal/webhook/flow/v2alpha1/webhook_suite_test.go
+++ b/internal/webhook/flow/v2alpha1/webhook_suite_test.go
@@ -1,5 +1,7 @@
 /*
-Copyright 2026 The Kubernetes authors.
+This file is part of Astarte.
+
+Copyright 2020-26 SECO Mind Srl.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,30 +23,28 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
+	flowv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/flow/v2alpha1"
+	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	flowv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/flow/v2alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+const Timeout = "30s"
+const Interval = "1s"
 
 var (
 	ctx       context.Context
@@ -56,17 +56,21 @@ var (
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
+	RunSpecs(t, "Flow Webhook Suite")
+}
 
-	RunSpecs(t, "Webhook Suite")
+func getRepoRoot() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "."
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", ".."))
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = integrationutils.SetupTestSuite()
 
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	var err error
-	err = flowv2alpha1.AddToScheme(scheme.Scheme)
+	err := flowv2alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
@@ -75,19 +79,16 @@ var _ = BeforeSuite(func() {
 	repoRoot := getRepoRoot()
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join(repoRoot, "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
-
+		ErrorIfCRDPathMissing: true,
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join(repoRoot, "config", "webhook")},
 		},
 	}
 
-	// Retrieve the first found binary directory to allow running tests from IDEs
-	if getFirstFoundEnvTestBinaryDir() != "" {
-		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	if binDir := integrationutils.GetFirstFoundEnvTestBinaryDir(filepath.Join(repoRoot, "bin", "k8s")); binDir != "" {
+		testEnv.BinaryAssetsDirectory = binDir
 	}
 
-	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
@@ -96,7 +97,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager.
+	By("starting webhook server")
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
@@ -121,7 +122,6 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -129,48 +129,10 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
-
 		return conn.Close()
 	}).Should(Succeed())
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	integrationutils.StopEnvTest(testEnv, cancel)
 })
-
-// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
-// ENVTEST-based tests depend on specific binaries, usually located in paths set by
-// controller-runtime. When running tests directly (e.g., via an IDE) without using
-// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
-//
-// This function streamlines the process by finding the required binaries, similar to
-// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
-// properly set up, run 'make setup-envtest' beforehand.
-func getFirstFoundEnvTestBinaryDir() string {
-	basePath := filepath.Join(getRepoRoot(), "bin", "k8s")
-	entries, err := os.ReadDir(basePath)
-	if err != nil {
-		logf.Log.Error(err, "Failed to read directory", "path", basePath)
-		return ""
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
-		}
-	}
-	return ""
-}
-
-func getRepoRoot() string {
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		logf.Log.Error(fmt.Errorf("cannot determine caller"), "Failed to compute repository root")
-		return "."
-	}
-
-	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", ".."))
-}

--- a/internal/webhook/ingress/v2alpha1/webhook_suite_test.go
+++ b/internal/webhook/ingress/v2alpha1/webhook_suite_test.go
@@ -1,5 +1,7 @@
 /*
-Copyright 2026 The Kubernetes authors.
+This file is part of Astarte.
+
+Copyright 2020-26 SECO Mind Srl.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,30 +23,28 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
+	ingressv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/ingress/v2alpha1"
+	integrationutils "github.com/astarte-platform/astarte-kubernetes-operator/test/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	ingressv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/ingress/v2alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+const Timeout = "30s"
+const Interval = "1s"
 
 var (
 	ctx       context.Context
@@ -56,17 +56,21 @@ var (
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ingress Webhook Suite")
+}
 
-	RunSpecs(t, "Webhook Suite")
+func getRepoRoot() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "."
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", ".."))
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = integrationutils.SetupTestSuite()
 
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	var err error
-	err = ingressv2alpha1.AddToScheme(scheme.Scheme)
+	err := ingressv2alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
@@ -75,19 +79,16 @@ var _ = BeforeSuite(func() {
 	repoRoot := getRepoRoot()
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join(repoRoot, "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
-
+		ErrorIfCRDPathMissing: true,
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join(repoRoot, "config", "webhook")},
 		},
 	}
 
-	// Retrieve the first found binary directory to allow running tests from IDEs
-	if getFirstFoundEnvTestBinaryDir() != "" {
-		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	if binDir := integrationutils.GetFirstFoundEnvTestBinaryDir(filepath.Join(repoRoot, "bin", "k8s")); binDir != "" {
+		testEnv.BinaryAssetsDirectory = binDir
 	}
 
-	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
@@ -96,7 +97,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager.
+	By("starting webhook server")
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
@@ -121,7 +122,6 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -129,48 +129,10 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
-
 		return conn.Close()
 	}).Should(Succeed())
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	integrationutils.StopEnvTest(testEnv, cancel)
 })
-
-// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
-// ENVTEST-based tests depend on specific binaries, usually located in paths set by
-// controller-runtime. When running tests directly (e.g., via an IDE) without using
-// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
-//
-// This function streamlines the process by finding the required binaries, similar to
-// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
-// properly set up, run 'make setup-envtest' beforehand.
-func getFirstFoundEnvTestBinaryDir() string {
-	basePath := filepath.Join(getRepoRoot(), "bin", "k8s")
-	entries, err := os.ReadDir(basePath)
-	if err != nil {
-		logf.Log.Error(err, "Failed to read directory", "path", basePath)
-		return ""
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
-		}
-	}
-	return ""
-}
-
-func getRepoRoot() string {
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		logf.Log.Error(fmt.Errorf("cannot determine caller"), "Failed to compute repository root")
-		return "."
-	}
-
-	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", ".."))
-}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -21,14 +21,16 @@ package e2e
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
 	. "github.com/onsi/gomega"    //nolint:staticcheck
 )
 
-// Run e2e tests using the Ginkgo runner.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
+	SetDefaultEventuallyTimeout(5 * time.Minute)
+	SetDefaultEventuallyPollingInterval(time.Second)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting astarte-kubernetes-operator suite\n")
 	RunSpecs(t, "Astarte Operator e2e suite")
 }

--- a/test/integration/envtest.go
+++ b/test/integration/envtest.go
@@ -1,0 +1,101 @@
+/*
+This file is part of Astarte.
+
+Copyright 2020-26 SECO Mind Srl.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
+	. "github.com/onsi/gomega"    //nolint:staticcheck
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// SetupTestSuite sets up the Ginkgo logger, global Eventually defaults, and a
+// cancellable context to be used across all test suites.
+func SetupTestSuite() (context.Context, context.CancelFunc) {
+	SetDefaultEventuallyTimeout(2 * time.Minute)
+	SetDefaultEventuallyPollingInterval(time.Second)
+
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	return ctx, cancel
+}
+
+// GetFirstFoundEnvTestBinaryDir finds the first subdirectory under basePath.
+// Use it to locate the envtest binaries. Call 'make setup-envtest' first.
+func GetFirstFoundEnvTestBinaryDir(basePath string) string {
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}
+
+// DefaultEnvTestConfig returns an envtest.Environment for the given paths.
+// ErrorIfCRDPathMissing defaults to true.
+func DefaultEnvTestConfig(crdBasePath, binaryBasePath string) *envtest.Environment {
+	env := &envtest.Environment{
+		CRDDirectoryPaths:     []string{crdBasePath},
+		ErrorIfCRDPathMissing: true,
+	}
+	if binDir := GetFirstFoundEnvTestBinaryDir(binaryBasePath); binDir != "" {
+		env.BinaryAssetsDirectory = binDir
+	}
+	return env
+}
+
+// StartEnvTest starts the envtest and returns the generated rest.Config and Client.
+func StartEnvTest(testEnv *envtest.Environment) (*rest.Config, client.Client, error) {
+	cfg, err := testEnv.Start()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cfg, k8sClient, nil
+}
+
+// StopEnvTest cancels the context (if any) and stops the envtest with a timeout.
+func StopEnvTest(testEnv *envtest.Environment, cancel context.CancelFunc) {
+	if cancel != nil {
+		cancel()
+	}
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
+}

--- a/test/integration/integration_utils.go
+++ b/test/integration/integration_utils.go
@@ -16,7 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:lll,goconst
 package integration
 
 import (
@@ -37,6 +36,8 @@ import (
 
 const Timeout string = "30s"
 const Interval string = "1s"
+
+const defaultNamespace = "default"
 
 const AstarteHighPriorityName string = "astarte-high-priority-non-preemptive"
 const AstarteMidPriorityName string = "astarte-mid-priority-non-preemptive"
@@ -103,7 +104,8 @@ func deleteDeploymentsInNamespace(ctx context.Context, k8sClient client.Client, 
 		}, Timeout, Interval).Should(Succeed())
 
 		Eventually(func() error {
-			return k8sClient.Get(context.Background(), client.ObjectKey{Name: d.Name, Namespace: d.Namespace}, &appsv1.Deployment{})
+			return k8sClient.Get(context.Background(),
+				client.ObjectKey{Name: d.Name, Namespace: d.Namespace}, &appsv1.Deployment{})
 		}, Timeout, Interval).ShouldNot(Succeed())
 	}
 }
@@ -119,7 +121,8 @@ func deleteStatefulSetsInNamespace(ctx context.Context, k8sClient client.Client,
 		}, Timeout, Interval).Should(Succeed())
 
 		Eventually(func() error {
-			return k8sClient.Get(context.Background(), client.ObjectKey{Name: s.Name, Namespace: s.Namespace}, &appsv1.StatefulSet{})
+			return k8sClient.Get(context.Background(),
+				client.ObjectKey{Name: s.Name, Namespace: s.Namespace}, &appsv1.StatefulSet{})
 		}, Timeout, Interval).ShouldNot(Succeed())
 	}
 }
@@ -168,7 +171,8 @@ func deletePVCsInNamespace(ctx context.Context, k8sClient client.Client, namespa
 		}, Timeout, Interval).Should(Succeed())
 
 		Eventually(func() error {
-			return k8sClient.Get(context.Background(), client.ObjectKey{Name: p.Name, Namespace: p.Namespace}, &v1.PersistentVolumeClaim{})
+			return k8sClient.Get(context.Background(),
+				client.ObjectKey{Name: p.Name, Namespace: p.Namespace}, &v1.PersistentVolumeClaim{})
 		}, Timeout, Interval).ShouldNot(Succeed())
 	}
 }
@@ -263,7 +267,7 @@ func deletePriorityClasses(k8sClient client.Client) {
 }
 
 func DeleteNamespace(k8sClient client.Client, namespace string) {
-	if namespace != "default" {
+	if namespace != defaultNamespace {
 		// Just give the namespace deletion a try, do not repeat on timeout
 		// as it would return "namespace terminating" errors
 		ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
@@ -272,7 +276,7 @@ func DeleteNamespace(k8sClient client.Client, namespace string) {
 }
 
 func CreateNamespace(k8sClient client.Client, namespace string) {
-	if namespace != "default" {
+	if namespace != defaultNamespace {
 		ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 		Eventually(func() error {
 			err := k8sClient.Create(context.Background(), ns)
@@ -322,10 +326,10 @@ func DeleteCustomResource(ctx context.Context, k8sClient client.Client, cr clien
 // Wrapper around DeployCustomResource for Astarte resources
 func DeployAstarte(k8sClient client.Client, cr client.Object) {
 	if cr.GetNamespace() == "" {
-		cr.SetNamespace("default")
+		cr.SetNamespace(defaultNamespace)
 	}
 
-	if cr.GetNamespace() != "default" {
+	if cr.GetNamespace() != defaultNamespace {
 		CreateNamespace(k8sClient, cr.GetNamespace())
 	}
 


### PR DESCRIPTION
Moved the shared envtest bootstrap and the getFirstFoundEnvTestBinaryDir helper into test/integration/envtest.go instead of copying them into every suite_test.go. Also added global Eventually defaults to avoid repeating timeouts everywhere.

Switched test files from context.Background() to the suite-level ctx and used DeferCleanup in a few spots. Fixed the webhook suites' copyright header and cleaned up a couple of empty test stubs.

With this changes, the overall test environment is more aligned with the standard of Operator SDK.