### PR TITLE
docs: document Astarte 1.4.0 prerequisites and v26.7 upgrade path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add configurable metrics endpoint in the Helm chart. Metrics are disabled by default (`metrics.enable: false`). When enabled (`metrics.enable: true`), metrics are served on the configured port (`metrics.port`, default `8443`) over HTTPS by default (`metrics.secure: true`). Set `metrics.secure: false` to use HTTP instead.
 - Add support for Astarte v1.4.0.
 - Add support for Vault configuration in the Astarte CR. Vault configuration is now required for Astarte 1.4 and above and ignored for Astarte 1.3.
+- Add upgrade documentation for the v26.5 to v26.7 upgrade path.
 
 ## [26.5.1] - 2026-05-03
 

--- a/docs/documentation/pages/administrator/020-prerequisites.md
+++ b/docs/documentation/pages/administrator/020-prerequisites.md
@@ -1,26 +1,19 @@
 # Prerequisites
 
-As much as Astarte's Operator is capable of creating a completely self-contained installation,
-there's a number of prerequisites to be fulfilled depending on the use case.
+As much as Astarte's Operator is capable of creating a completely self-contained installation, there's a number of prerequisites to be fulfilled depending on the use case.
 
 ## On your machine
 
 The following tools are required within your local machine:
 
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/): must be compatible with your
-  target Kubernetes version,
-- [astartectl](https://github.com/astarte-platform/astartectl): your version must be the same of the
-  Astarte Operator running in your cluster,
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/): must be compatible with your target Kubernetes version,
+- [astartectl](https://github.com/astarte-platform/astartectl): your version must be the same of the Astarte Operator running in your cluster,
 - [helm](https://helm.sh/): v3 is required.
 
 ## HAProxy
-Astarte Operator is capable of interacting with HAProxy Ingress Controller through its dedicated `AstarteDefaultIngress` resource,
-as long as an [HAProxy ingress controller](https://www.haproxy.com/documentation/kubernetes-ingress/) is installed. 
+Astarte Operator is capable of interacting with HAProxy Ingress Controller through its dedicated `AstarteDefaultIngress` resource, as long as an [HAProxy ingress controller](https://www.haproxy.com/documentation/kubernetes-ingress/) is installed. 
 
-Please, be aware that trying to deploy multiple ingress controllers in your cluster may result in all
-of them trying simultaneously to handle the Astarte ingress resource. Consider using ingress classes
-for avoiding confusing situations as outlined
-[here](https://kubernetes.github.io/ingress-nginx/user-guide/multiple-ingress/).
+Please, be aware that trying to deploy multiple ingress controllers in your cluster may result in all of them trying simultaneously to handle the Astarte ingress resource. Consider using ingress classes for avoiding confusing situations as outlined [here](https://kubernetes.github.io/ingress-nginx/user-guide/multiple-ingress/).
 
 ** Helm installation via CLI **
 Installing the ingress controller is as simple as running a few `helm` commands:
@@ -53,19 +46,11 @@ Depending on the value of this annotation, the Operator will create Ingress reso
 
 ## cert-manager
 
-Astarte requires [`cert-manager`](https://cert-manager.io/) to be installed in the cluster in its
-default configuration (installed in namespace `cert-manager` as `cert-manager`). If you are using
-`cert-manager` in your cluster already you don't need to take any action - otherwise, you will need
-to install it.
+Astarte requires [`cert-manager`](https://cert-manager.io/) to be installed in the cluster in its default configuration (installed in namespace `cert-manager` as `cert-manager`). If you are using `cert-manager` in your cluster already you don't need to take any action - otherwise, you will need to install it.
 
-Astarte is actively tested with `cert-manager` 1.16.3, but should work with any 1.0+ releases of
-`cert-manager`. If your `cert-manager` release is outdated, please consider upgrading to a newer
-version according to [this guide](https://cert-manager.io/docs/installation/upgrading/).
+Astarte is actively tested with `cert-manager` 1.16.3, but should work with any 1.0+ releases of `cert-manager`. If your `cert-manager` release is outdated, please consider upgrading to a newer version according to [this guide](https://cert-manager.io/docs/installation/upgrading/).
 
-[`cert-manager` documentation](https://cert-manager.io/docs/installation/) details all needed steps
-to have a working instance on your cluster. However, in case you won't be using `cert-manager` for
-other components beyond Astarte or, in general, if you don't have very specific requirements, it is
-advised to install it through its Helm chart. To do so, run the following commands:
+[`cert-manager` documentation](https://cert-manager.io/docs/installation/) details all needed steps to have a working instance on your cluster. However, in case you won't be using `cert-manager` for other components beyond Astarte or, in general, if you don't have very specific requirements, it is advised to install it through its Helm chart. To do so, run the following commands:
 
 ```bash
 $ helm repo add jetstack https://charts.jetstack.io
@@ -82,24 +67,31 @@ This will install `cert-manager` and its CRDs in the cluster.
 
 ## External RabbitMQ
 
-Starting from Astarte Operator `v26.5.x`, RabbitMQ is no longer deployed by the Astarte Operator.
-If you previously relied on a RabbitMQ instance managed by the Astarte Operator, upgrading shall be preceded by provisioning an external RabbitMQ instance, otherwise, after the upgrade you will end up without any AMQP broker in place.
-Consider using RabbitMQ deployed by the [RabbitMQ Cluster Operator](https://www.rabbitmq.com/kubernetes/operator/operator-overview) or any other managed solution that you prefer.
+Astarte needs a RabbitMQ instance to work. The Astarte Operator does **not** deploy a RabbitMQ instance: you must provision one before installing Astarte, then configure the connection details in the Astarte CR under the `spec.rabbitmq` section.
+
+Tested RabbitMQ instances include:
+- [CloudAMQP](https://www.cloudamqp.com/) managed RabbitMQ instance 
+- [RabbitMQ Cluster Operator](https://www.rabbitmq.com/kubernetes/operator/operator-overview)
 
 ## External Cassandra / Scylla
 
-Starting from Astarte Operator `v26.5.x`, Cassandra / Scylla is no longer deployed by the Astarte Operator.
-If you previously relied on a Cassandra instance managed by the Astarte Operator, you shall provision an external instance before upgrading, otherwise the upgrade will leave you without any database backing Astarte.
-It is strongly advised to deploy a separate Cassandra cluster, a VM-based installation or a managed solution.
+Astarte relies on a Cassandra / Scylla database to work. The Astarte Operator does **not** deploy a Scylla DB instance: you must provision one before installing Astarte, then configure the connection details in the Astarte CR under the `spec.cassandra` section.
+
+Refer to the [Astarte Database documentation](https://docs.astarte-platform.org/astarte/1.4/090-database.html) for further details.
+
+## External Hashicorp Vault / OpenBao
+
+Astarte `1.4+` requires an external [Hashicorp Vault](https://www.hashicorp.com/en/products/vault) or [OpenBao](https://openbao.org/) instance to safely handle secrets. The Astarte Operator does **not** deploy a Hashicorp Vault or OpenBao instance: you must provision one before installing Astarte, then configure the connection details in the Astarte CR under the `spec.vault` section.
+
+The configuration of a Vault is not supported when the selected Astarte version is `1.3.x`
+
+## External FDO Rendezvous Server
+
+Astarte `1.4+` requires an external Rendezvous Server (RV) to provide the [FDO (FIDO Device Onboard)](https://fidoalliance.org/device-onboarding-overview/) feature. The Astarte Operator does **not** deploy a Rendezvous Server instance.
+If you plan to use FDO (optional on Astarte `1.3.x`, mandatory on Astarte `1.4+`), ensure to configure the Rendezvous Server instance connection details under `spec.rendezvousServer` on the Astarte CR.
 
 ## Kubernetes and external components
 
-When deploying external components, it is important to take in consideration how Kubernetes behaves
-with the underlying infrastructure. Most modern Cloud Providers have a concept of Virtual Private
-Cloud, by which the internal Kubernetes Network stack directly integrates with their Network stack.
-This, in short, enables deploying Pods in a shared private network, in which other components (such
-as Virtual Machines) can be deployed.
+When deploying external components, it is important to take in consideration how Kubernetes behaves with the underlying infrastructure. Most modern Cloud Providers have a concept of Virtual Private Cloud, by which the internal Kubernetes Network stack directly integrates with their Network stack. This, in short, enables deploying Pods in a shared private network, in which other components (such as Virtual Machines) can be deployed.
 
-This is the preferred, advised and supported configuration. In this scenario, there's literally no
-difference between interacting with a VM or a Pod, enabling a hybrid infrastructure without having
-to pay the performance cost.
+This is the preferred, advised and supported configuration. In this scenario, there's literally no difference between interacting with a VM or a Pod, enabling a hybrid infrastructure without having to pay the performance cost.

--- a/docs/documentation/pages/upgrade/000-upgrade_index.md
+++ b/docs/documentation/pages/upgrade/000-upgrade_index.md
@@ -16,3 +16,5 @@ Find below the upgrade guides for your Astarte cluster:
 + to upgrade from v1.0.x to v22.11, click [here](040-upgrade_10x_2211.html)
 + to upgrade from v22.11.x to v23.5, click [here](050-upgrade_2211_235.html)
 + to upgrade from v23.5.x to v24.5, click [here](060-upgrade_235_245.html)
++ to upgrade from v24.5.x to v26.5, click [here](070-upgrade_245_265.html)
++ to upgrade from v26.5.x to v26.7, click [here](080-upgrade_265_267.html)

--- a/docs/documentation/pages/upgrade/080-upgrade_265_267.md
+++ b/docs/documentation/pages/upgrade/080-upgrade_265_267.md
@@ -1,0 +1,48 @@
+# Upgrade v26.5.x-v26.7.x
+
+This page describes the required steps to upgrade your Astarte cluster from `v26.5.x` to `v26.7.x`. The Astarte Operator v26.7.x introduces support for Astarte 1.4.0, which includes mandatory FDO and Vault configuration. See the [Astarte CHANGELOG](https://github.com/astarte-platform/astarte/blob/release-1.4/CHANGELOG.md) to inspect what's changed in Astarte itself.
+
+> [!WARNING]
+> To use Astarte `v1.4.x`, you must upgrade your Astarte Operator to `v26.7.x`.
+
+- Starting from Astarte `v1.4.0`, FDO (FIDO Device Onboard) is mandatory and can no longer be disabled. If your Astarte CR explicitly sets `spec.fdo.enable: false`, you must remove or change it before upgrading.
+- Starting from Astarte `v1.4.0`, a Vault configuration must be provided through the `spec.vault` field in the Astarte CR.
+
+## FDO mandatory enforcement
+
+In Astarte 1.3, FDO was an opt-in feature controlled via the `spec.fdo.enable` field. Starting from Astarte 1.4.0, FDO is always enabled and cannot be turned off.
+
+The operator enforces this requirement through multiple layers, ensuring no Astarte 1.4+ instance runs without FDO:
+
+- **Defaulting webhook**: when `spec.fdo` is not set at all on an Astarte version >= 1.4.0, the mutating webhook automatically sets `spec.fdo.enable: true`. If you leave the field unset, the operator handles it for you.
+- **Validating webhook**: explicitly setting `spec.fdo.enable: false` on an Astarte version >= 1.4.0 is rejected at admission time. You will see an error like *"FDO must be enabled for Astarte version 1.4.0 and above"* when applying the CR.
+
+The `spec.fdo.enable` field is kept for backward compatibility with Astarte 1.3.x, where FDO remains optional. If you are running Astarte 1.4.0 or later, simply ensure the field is either unset or explicitly set to `true`.
+
+Along with FDO, a `spec.fdo.rendezvousServer` block is now required. The webhook validates this at admission time and will reject a CR that enables FDO without providing rendezvous server configuration.
+
+> [!WARNING]
+> The Rendezvous Servers is now an external prerequisites. Its deployment is NOT handled by the Astarte Operator itself.
+
+## Vault configuration requirement
+
+Starting from Astarte 1.4.0, the `spec.vault` field is required in the Astarte CR. The validating webhook rejects any CR with version >= 1.4.0 that does not include a Vault configuration block. Ensure you have a HashiCorp Vault or OpenBao instance running and provide the connection details in your Astarte CR before upgrading to v1.4.x.
+
+> [!WARNING]
+> An HashiCorp Vault or OpenBao instance is now an external prerequisites. Its deployment is NOT handled by the Astarte Operator itself.
+
+## Metrics configuration support
+
+Starting from Astarte Operator v26.7.0, the operator can expose Prometheus metrics. Metrics are disabled by default and can be enabled through Helm values:
+
+- `metrics.enable`: set to `true` to enable the metrics endpoint (default `false`).
+- `metrics.port`: the port to expose metrics on (default `8443`).
+- `metrics.secure`: whether to serve metrics over HTTPS (default `true`). Set to `false` to use HTTP.
+
+When metrics are enabled, the operator exposes a `/metrics` endpoint on the configured port, ready to be scraped by Prometheus.
+
+## Upgrade Astarte Operator
+
+The Astarte Operator upgrade procedure is handled by Helm.
+
+The current section assumes that the Operator's chart landing version is `v26.7.x`. It is **your responsibility** referencing the proper `v26.7.x` chart using the `--version` flag when running `helm` commands.


### PR DESCRIPTION
Add requirements for external Vault/OpenBao and FDO Rendezvous Server. Restructure RabbitMQ and Cassandra sections. Add upgrade guide for v26.5.x to v26.7.x.