### PR TITLE
feat: enforce FDO mandatory on Astarte 1.4+ via webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `AstarteFDOIngress` (v1alpha1) resource in the `ingress.astarte-platform.org` group to handle the ingress dedicated to Astarte FDO pairing requests.
 - Add configurable metrics endpoint in the Helm chart. Metrics are disabled by default (`metrics.enable: false`). When enabled (`metrics.enable: true`), metrics are served on the configured port (`metrics.port`, default `8443`) over HTTPS by default (`metrics.secure: true`). Set `metrics.secure: false` to use HTTP instead.
 - Add support for Astarte v1.4.0.
+- Enforce FDO as mandatory starting from Astarte 1.4.0.
 - Add support for Vault configuration in the Astarte CR. Vault configuration is now required for Astarte 1.4 and above and ignored for Astarte 1.3.
 
 ## [26.5.1] - 2026-05-03

--- a/internal/reconcile/utils.go
+++ b/internal/reconcile/utils.go
@@ -413,6 +413,17 @@ func appendAstarteRendezvousServerEnvVars(ret []v1.EnvVar, cr *apiv2alpha1.Astar
 func appendAstarteFDOEnvVars(ret []v1.EnvVar, cr *apiv2alpha1.Astarte) []v1.EnvVar {
 	fdoEnabled := cr.Spec.FDO != nil && cr.Spec.FDO.Enable
 
+	// In Astarte >= 1.4, FDO is mandatory and cannot be disabled.
+	// The webhook prevents reaching this state, but CRs created before the webhook was
+	// active may still have FDO disabled on a version that requires it. Here we force it.
+	if !fdoEnabled {
+		if checker, err := version.NewChecker(cr.Spec.Version); err == nil && !checker.Supports(version.OptionalFDO) {
+			log.Info("FDO is disabled but Astarte version >= 1.4 requires it. Forcing FDO enable.",
+				"version", cr.Spec.Version)
+			fdoEnabled = true
+		}
+	}
+
 	ret = append(ret, v1.EnvVar{Name: "PAIRING_ENABLE_FDO", Value: strconv.FormatBool(fdoEnabled)})
 
 	if fdoEnabled {

--- a/internal/version/capabilities.go
+++ b/internal/version/capabilities.go
@@ -27,6 +27,10 @@ type Feature string
 const (
 	// Vault represents the HashiCorp Vault support
 	Vault Feature = "Vault"
+	// OptionalFDO represents that FDO can be optionally disabled. FDO is a feature
+	// available since Astarte 1.3 as an opt-in, and becomes mandatory from 1.4 onwards.
+	// Versions that support OptionalFDO (i.e. < 1.4.0) allow disabling FDO.
+	OptionalFDO Feature = "OptionalFDO"
 )
 
 // matrix stores the pre-compiled semver constraints for each feature
@@ -52,6 +56,8 @@ func init() {
 	matrix = map[Feature]*semver.Constraints{
 		// Vault is supported strictly in 1.4.0 and above
 		Vault: mustParseConstraint(">= 1.4.0"),
+		// FDO is optional (can be disabled) only for versions < 1.4.0
+		OptionalFDO: mustParseConstraint("< 1.4.0"),
 	}
 }
 

--- a/internal/webhook/api/v2alpha1/astarte_webhook.go
+++ b/internal/webhook/api/v2alpha1/astarte_webhook.go
@@ -103,7 +103,32 @@ func (d *AstarteCustomDefaulter) Default(_ context.Context, obj runtime.Object) 
 	}
 
 	astartelog.Info("Defaulting for Astarte", "name", astarte.GetName())
+
+	defaultFDO(astarte)
+
 	return nil
+}
+
+// defaultFDO enables FDO by default on Astarte versions >= 1.4, where FDO is mandatory and
+// cannot be disabled. It only applies when spec.fdo is entirely unset (nil); an explicit
+// spec.fdo.enable=false is left untouched and will be caught by the validating webhook.
+func defaultFDO(r *apiv2alpha1.Astarte) {
+	if r.Spec.FDO != nil {
+		return
+	}
+
+	checker, err := version.NewChecker(r.Spec.Version)
+	if err != nil {
+		return
+	}
+
+	if !checker.Supports(version.OptionalFDO) {
+		astartelog.Info("FDO is not optional for this Astarte version. Defaulting FDO to enabled.",
+			"name", r.GetName(), "version", r.Spec.Version)
+		r.Spec.FDO = &apiv2alpha1.AstarteFDOSpec{
+			Enable: true,
+		}
+	}
 }
 
 /*
@@ -262,9 +287,29 @@ func validateAstarte(r *apiv2alpha1.Astarte) field.ErrorList {
 }
 
 func validateFDOConfiguration(r *apiv2alpha1.Astarte) *field.Error {
+	checker, err := version.NewChecker(r.Spec.Version)
+	if err != nil {
+		return nil
+	}
+
+	fdoOptional := checker.Supports(version.OptionalFDO)
+
+	if !fdoOptional && r.Spec.FDO != nil && !r.Spec.FDO.Enable {
+		fldPath := field.NewPath("spec").Child("fdo").Child("enable")
+		err := errors.New("FDO must be enabled for Astarte version 1.4.0 and above")
+		astartelog.Info("FDO validation rejected: explicitly disabled on Astarte >= 1.4",
+			"name", r.GetName(), "version", r.Spec.Version)
+		return field.Invalid(fldPath, r.Spec.FDO.Enable, err.Error())
+	}
+
 	if r.Spec.FDO != nil && r.Spec.FDO.Enable && r.Spec.FDO.RendezvousServer == nil {
 		fldPath := field.NewPath("spec").Child("fdo").Child("rendezvousServer")
-		err := errors.New("must be set when fdo.enable is true")
+		var err error
+		if fdoOptional {
+			err = errors.New("must be set when fdo.enable is true")
+		} else {
+			err = errors.New("must be set for Astarte version 1.4.0 and above (FDO is always enabled)")
+		}
 		astartelog.Info(err.Error())
 		return field.Required(fldPath, err.Error())
 	}

--- a/internal/webhook/api/v2alpha1/astarte_webhook_test.go
+++ b/internal/webhook/api/v2alpha1/astarte_webhook_test.go
@@ -666,6 +666,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 	Describe("TestValidateFDOConfiguration", func() {
 		BeforeEach(func() {
 			cr.Spec.FDO = nil
+			cr.Spec.Version = "1.3.0"
 		})
 
 		It("should not return an error when FDO is not configured", func() {
@@ -703,6 +704,96 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 
 			err := validateFDOConfiguration(cr)
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return an error when FDO is disabled on Astarte >= 1.4", func() {
+			cr.Spec.Version = "1.4.0"
+			cr.Spec.FDO = &apiv2alpha1.AstarteFDOSpec{
+				Enable:           false,
+				RendezvousServer: &apiv2alpha1.AstarteRendezvousServerSpec{},
+			}
+			err := validateFDOConfiguration(cr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Field).To(Equal("spec.fdo.enable"))
+			Expect(err.Type).To(Equal(field.ErrorTypeInvalid))
+		})
+
+		It("should return an error when FDO is disabled on Astarte > 1.4", func() {
+			cr.Spec.Version = "1.4.5"
+			cr.Spec.FDO = &apiv2alpha1.AstarteFDOSpec{
+				Enable:           false,
+				RendezvousServer: &apiv2alpha1.AstarteRendezvousServerSpec{},
+			}
+			err := validateFDOConfiguration(cr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Field).To(Equal("spec.fdo.enable"))
+		})
+
+		It("should not return an error when FDO is disabled on Astarte 1.3", func() {
+			cr.Spec.Version = "1.3.0"
+			cr.Spec.FDO = &apiv2alpha1.AstarteFDOSpec{
+				Enable: false,
+			}
+			err := validateFDOConfiguration(cr)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return an error when FDO is enabled and rendezvousServer is unset on Astarte >= 1.4", func() {
+			cr.Spec.Version = "1.4.0"
+			cr.Spec.FDO = &apiv2alpha1.AstarteFDOSpec{
+				Enable:           true,
+				RendezvousServer: nil,
+			}
+			err := validateFDOConfiguration(cr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Field).To(Equal("spec.fdo.rendezvousServer"))
+			Expect(err.Type).To(Equal(field.ErrorTypeRequired))
+		})
+
+		It("should handle invalid version strings gracefully", func() {
+			cr.Spec.Version = "invalid"
+			cr.Spec.FDO = &apiv2alpha1.AstarteFDOSpec{
+				Enable:           false,
+				RendezvousServer: nil,
+			}
+			err := validateFDOConfiguration(cr)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("TestDefaultFDO", func() {
+		BeforeEach(func() {
+			cr.Spec.FDO = nil
+			cr.Spec.Version = "1.3.0"
+		})
+
+		It("should set FDO to enabled when unset on Astarte >= 1.4", func() {
+			cr.Spec.Version = "1.4.0"
+			cr.Spec.FDO = nil
+			defaultFDO(cr)
+			Expect(cr.Spec.FDO).ToNot(BeNil())
+			Expect(cr.Spec.FDO.Enable).To(BeTrue())
+		})
+
+		It("should not modify FDO when already set on Astarte >= 1.4", func() {
+			cr.Spec.Version = "1.4.0"
+			cr.Spec.FDO = &apiv2alpha1.AstarteFDOSpec{Enable: false}
+			defaultFDO(cr)
+			Expect(cr.Spec.FDO.Enable).To(BeFalse())
+		})
+
+		It("should not set FDO when unset on Astarte 1.3", func() {
+			cr.Spec.Version = "1.3.0"
+			cr.Spec.FDO = nil
+			defaultFDO(cr)
+			Expect(cr.Spec.FDO).To(BeNil())
+		})
+
+		It("should handle invalid version strings gracefully", func() {
+			cr.Spec.Version = "invalid"
+			cr.Spec.FDO = nil
+			defaultFDO(cr)
+			Expect(cr.Spec.FDO).To(BeNil())
 		})
 	})
 
@@ -929,6 +1020,32 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 			Expect(w).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsInvalid(err)).To(BeTrue())
+		})
+
+		It("should return invalid when FDO is explicitly disabled on Astarte >= 1.4", func() {
+			cr.Spec.Version = "1.4.0"
+			cr.Spec.AstarteInstanceID = "coverageid4"
+			cr.Spec.FDO = &apiv2alpha1.AstarteFDOSpec{
+				Enable:           false,
+				RendezvousServer: &apiv2alpha1.AstarteRendezvousServerSpec{},
+			}
+			validator := &AstarteCustomValidator{}
+			w, err := validator.ValidateCreate(ctx, cr)
+			Expect(w).To(BeNil())
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err)).To(BeTrue())
+		})
+
+		It("should succeed when FDO is disabled on Astarte 1.3", func() {
+			cr.Spec.Version = "1.3.0"
+			cr.Spec.AstarteInstanceID = "coverageid5"
+			cr.Spec.FDO = &apiv2alpha1.AstarteFDOSpec{
+				Enable: false,
+			}
+			validator := &AstarteCustomValidator{}
+			w, err := validator.ValidateCreate(ctx, cr)
+			Expect(w).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
In Astarte 1.3 FDO was an opt-in feature flag (spec.fdo.enable), but from 1.4 onwards it is always enabled. The CR field is kept for backward compatibility and webhooks have been implemented to enforce the usage of FDO on Astarte 1.4:

- Defaulting webhook enables FDO when unset on version >= 1.4
- Validating webhook rejects explicit fdo.enable=false on >= 1.4
- Controller forces FDO on at reconcile time as a safety net

Add OptionalFDO capability constraint (< 1.4.0) to the version matrix following the same pattern as the Vault feature.