### PR TITLE
test(e2e): add OpenBao and rendezvous server for Astarte 1.4 e2e

### DIFF
--- a/api/api/v2alpha1/suite_test.go
+++ b/api/api/v2alpha1/suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	manifestPath := filepath.Join("..", "..", "..", "test", "manifests", "api_v2alpha1_astarte_1.3.yaml")
+	manifestPath := filepath.Join("..", "..", "..", "test", "manifests", "api_v2alpha1_astarte_1.4.yaml")
 	manifestBytes, err := os.ReadFile(manifestPath)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/api/suite_test.go
+++ b/internal/controller/api/suite_test.go
@@ -80,7 +80,7 @@ var _ = BeforeSuite(func() {
 	// don't register the controller with a manager here.
 
 	By("loading the base Astarte manifest")
-	manifestPath := filepath.Join("..", "..", "..", "test", "manifests", "api_v2alpha1_astarte_1.3.yaml")
+	manifestPath := filepath.Join("..", "..", "..", "test", "manifests", "api_v2alpha1_astarte_1.4.yaml")
 	manifestBytes, err := os.ReadFile(manifestPath)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controllerutils/suite_test.go
+++ b/internal/controllerutils/suite_test.go
@@ -80,7 +80,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	manifestPath := filepath.Join("..", "..", "test", "manifests", "api_v2alpha1_astarte_1.3.yaml")
+	manifestPath := filepath.Join("..", "..", "test", "manifests", "api_v2alpha1_astarte_1.4.yaml")
 	manifestBytes, err := os.ReadFile(manifestPath)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/deps/suite_test.go
+++ b/internal/deps/suite_test.go
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	manifestPath := filepath.Join("..", "..", "test", "manifests", "api_v2alpha1_astarte_1.3.yaml")
+	manifestPath := filepath.Join("..", "..", "test", "manifests", "api_v2alpha1_astarte_1.4.yaml")
 	manifestBytes, err := os.ReadFile(manifestPath)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/misc/suite_test.go
+++ b/internal/misc/suite_test.go
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	manifestPath := filepath.Join("..", "..", "test", "manifests", "api_v2alpha1_astarte_1.3.yaml")
+	manifestPath := filepath.Join("..", "..", "test", "manifests", "api_v2alpha1_astarte_1.4.yaml")
 	manifestBytes, err := os.ReadFile(manifestPath)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/reconcile/suite_test.go
+++ b/internal/reconcile/suite_test.go
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	manifestPath := filepath.Join("..", "..", "test", "manifests", "api_v2alpha1_astarte_1.3.yaml")
+	manifestPath := filepath.Join("..", "..", "test", "manifests", "api_v2alpha1_astarte_1.4.yaml")
 	manifestBytes, err := os.ReadFile(manifestPath)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/webhook/api/v2alpha1/webhook_suite_test.go
+++ b/internal/webhook/api/v2alpha1/webhook_suite_test.go
@@ -120,7 +120,7 @@ var _ = BeforeSuite(func() {
 	// +kubebuilder:scaffold:webhook
 
 	By("loading the base Astarte manifest")
-	manifestPath := filepath.Join(repoRoot, "test", "manifests", "api_v2alpha1_astarte_1.3.yaml")
+	manifestPath := filepath.Join(repoRoot, "test", "manifests", "api_v2alpha1_astarte_1.4.yaml")
 	manifestBytes, err := os.ReadFile(manifestPath)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -45,6 +45,12 @@ var _ = Describe("controller", Ordered, func() {
 		By("installing rabbitmq cluster operator")
 		Expect(InstallRabbitMQClusterOperator()).To(Succeed())
 
+		By("installing openbao cluster helm chart")
+		Expect(DeployOpenBao()).To(Succeed())
+
+		By("deploying the rendezvous server")
+		Expect(DeployRendezvousServer()).To(Succeed())
+
 		By("deploying the RabbitMQ cluster")
 		Expect(DeployRabbitMQCluster()).To(Succeed())
 
@@ -81,8 +87,18 @@ var _ = Describe("controller", Ordered, func() {
 		By("uninstalling the cert-manager bundle")
 		UninstallCertManager()
 
+		By("uninstalling OpenBao")
+		cmd := exec.Command("helm", "uninstall", "openbao", "--namespace", "openbao")
+		_, _ = Run(cmd)
+		cmd = exec.Command("kubectl", "delete", "namespace", "openbao")
+		_, _ = Run(cmd)
+
+		By("uninstalling the rendezvous server")
+		cmd = exec.Command("kubectl", "delete", "namespace", rendezvousServerNamespace)
+		_, _ = Run(cmd)
+
 		By("removing astarte operator namespace")
-		cmd := exec.Command("kubectl", "delete", "ns", operatorNamespace)
+		cmd = exec.Command("kubectl", "delete", "ns", operatorNamespace)
 		_, _ = Run(cmd)
 	})
 
@@ -145,7 +161,7 @@ var _ = Describe("controller", Ordered, func() {
 			EventuallyWithOffset(1, verifyControllerUp, DefaultTimeout, DefaultRetryInterval).Should(Succeed())
 
 			targetTestVersions := map[string]string{
-				"1.3": filepath.Join(projectDir, "/test/manifests/api_v2alpha1_astarte_1.3.yaml"),
+				"1.4": filepath.Join(projectDir, "/test/manifests/api_v2alpha1_astarte_1.4.yaml"),
 			}
 
 			for k, v := range targetTestVersions {
@@ -209,6 +225,14 @@ var _ = Describe("controller", Ordered, func() {
 				By("deleting the Scylla connection secret")
 				EventuallyWithOffset(1,
 					DeleteScyllaConnectionSecret,
+					DefaultTimeout,
+					DefaultRetryInterval,
+				).Should(Succeed())
+
+				// Vault connection secret
+				By("deleting the Vault connection secret")
+				EventuallyWithOffset(1,
+					DeleteVaultConnectionSecret,
 					DefaultTimeout,
 					DefaultRetryInterval,
 				).Should(Succeed())

--- a/test/e2e/e2e_utils.go
+++ b/test/e2e/e2e_utils.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -60,10 +61,29 @@ const (
 	scyllaOperatorVersion = "v1.17.1"
 	scyllaOperatorURL     = "https://raw.githubusercontent.com/scylladb/scylla-operator/%s/deploy/operator.yaml"
 	scyllaNamespace       = "scylla"
+
+	rendezvousServerNamespace = "rendezvous-server"
+
+	openbaoVersion = "0.4.0"
 )
 
 func warnError(err error) {
 	_, _ = fmt.Fprintf(GinkgoWriter, "warning: %v\n", err)
+}
+
+func DeployRendezvousServer() error {
+	if err := EnsureNamespaceExists(rendezvousServerNamespace); err != nil {
+		return fmt.Errorf("failed to ensure namespace %s exists: %w", rendezvousServerNamespace, err)
+	}
+
+	projectDir, err := GetProjectDir()
+	if err != nil {
+		return fmt.Errorf("failed to get project directory: %w", err)
+	}
+	cmd := exec.Command("kubectl", "apply", "-n", rendezvousServerNamespace,
+		"-f", filepath.Join(projectDir, "test/manifests/dependencies/rendezvous-server"))
+	_, err = Run(cmd)
+	return err
 }
 
 // InstallPrometheusOperator installs the prometheus Operator to be used to export the enabled metrics.
@@ -211,6 +231,15 @@ func DeleteRabbitMQConnectionSecret() error {
 func DeleteScyllaConnectionSecret() error {
 	cmd := exec.Command("kubectl", "delete", "secret",
 		"scylladb-connection-secret",
+		"-n", astarteNamespace,
+	)
+	_, err := Run(cmd)
+	return err
+}
+
+func DeleteVaultConnectionSecret() error {
+	cmd := exec.Command("kubectl", "delete", "secret",
+		"vault-connection-string",
 		"-n", astarteNamespace,
 	)
 	_, err := Run(cmd)
@@ -386,6 +415,40 @@ func DeployRabbitMQCluster() error {
 
 	if _, err := Run(cmd); err != nil {
 		return fmt.Errorf("failed to wait for RabbitMQ cluster pods to be ready: %w", err)
+	}
+
+	return nil
+}
+
+func DeployOpenBao() error {
+	cmd := exec.Command("helm", "repo", "add", "openbao", "https://openbao.github.io/openbao-helm")
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("failed to add OpenBao Helm repository: %w", err)
+	}
+
+	openbaoNamespace := "openbao"
+
+	cmd = exec.Command("helm", "install", "openbao", "openbao/openbao",
+		"--namespace", openbaoNamespace, "--create-namespace",
+		"--version", openbaoVersion,
+		"--set", "server.dev.enabled=true",
+	)
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("failed to install OpenBao: %w", err)
+	}
+
+	secretData := map[string]string{
+		"connection-string": "root",
+	}
+
+	if err := CreateSecret("vault-connection-string", astarteNamespace, secretData); err != nil {
+		return fmt.Errorf("failed to create Vault connection secret: %w", err)
+	}
+
+	cmd = exec.Command("kubectl", "wait", "--for=condition=Ready", "pod",
+		"-l", "app.kubernetes.io/instance=openbao", "-n", openbaoNamespace, "--timeout", "5m")
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("failed to wait for OpenBao pod to be ready: %w", err)
 	}
 
 	return nil

--- a/test/manifests/api_v2alpha1_astarte_1.4.yaml
+++ b/test/manifests/api_v2alpha1_astarte_1.4.yaml
@@ -8,11 +8,9 @@ metadata:
 spec:
   # This is the most minimal set of reasonable configuration to spin up an Astarte
   # instance with reasonable defaults and enough control over the deployment.
-  version: "1.3"
+  version: "1.4"
   api:
     host: "api.astarte-example.com" # MANDATORY
-  # RabbitMQ can be deployed either in cluster or out of cluster.
-  # What follows is just an in-cluster example.
   rabbitmq:
     connection:
       host: "rabbitmq.rabbitmq.svc.cluster.local"
@@ -28,8 +26,20 @@ spec:
         name: "rabbitmq-connection-secret"
         usernameKey: "username"
         passwordKey: "password"
-  # Cassandra/ScyllaDB can be deployed either in cluster or out of cluster.
-  # What follows is just an in-cluster example.
+  fdo:
+    enable: true
+    rendezvousServer:
+      connection:
+        host: "rendezvous-server.rendezvous-server.svc.cluster.local"
+        port: 8041
+  vault:
+    connection:
+      host: "openbao.openbao.svc.cluster.local"
+      port: 8200
+      connectionStringSecret:
+        name: "vault-connection-string"
+        key: "connection-string"
+
   cassandra:
     astarteSystemKeyspace:
       replicationFactor: 1
@@ -44,21 +54,21 @@ spec:
         passwordKey: "password"
   vernemq:
     host: "broker.astarte-example.com"
-    image: "docker.io/astarte/vernemq:1.3-snapshot"
+    image: "docker.io/astarte/vernemq:1.4-snapshot"
     port: 8883
   components:
     realmManagement:
-      image: "docker.io/astarte/astarte_realm_management:1.3-snapshot"
+      image: "docker.io/astarte/astarte_realm_management:1.4-snapshot"
     dataUpdaterPlant:
-      image: "docker.io/astarte/astarte_data_updater_plant:1.3-snapshot"
+      image: "docker.io/astarte/astarte_data_updater_plant:1.4-snapshot"
     appengineApi:
-      image: "docker.io/astarte/astarte_appengine_api:1.3-snapshot"
+      image: "docker.io/astarte/astarte_appengine_api:1.4-snapshot"
     pairing:
-      image: "docker.io/astarte/astarte_pairing:1.3-snapshot"
+      image: "docker.io/astarte/astarte_pairing:1.4-snapshot"
     triggerEngine:
-      image: "docker.io/astarte/astarte_trigger_engine:1.3-snapshot"
+      image: "docker.io/astarte/astarte_trigger_engine:1.4-snapshot"
     housekeeping:
-      image: "docker.io/astarte/astarte_housekeeping:1.3-snapshot"
+      image: "docker.io/astarte/astarte_housekeeping:1.4-snapshot"
     dashboard:
-      image: "docker.io/astarte/astarte-dashboard:1.2.1-rc.0"
+      image: "docker.io/astarte/astarte-dashboard:1.4-snapshot"
       deploy: true

--- a/test/manifests/dependencies/rendezvous-server/rv-deploy.yaml
+++ b/test/manifests/dependencies/rendezvous-server/rv-deploy.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: rendezvous-server
+  name: rendezvous-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rendezvous-server
+  template:
+    metadata:
+      labels:
+        app: rendezvous-server
+    spec:
+      containers:
+        - command:
+            - /usr/bin/go-fdo-server
+            - --log-level=$(LOG_LEVEL)
+            - rendezvous
+            - 0.0.0.0:8041
+            - --db-type=$(DB_TYPE)
+            - --db-dsn=$(DB_DSN)
+          env:
+            - name: LOG_LEVEL
+              value: info
+            - name: DB_TYPE
+              value: sqlite
+            - name: DB_DSN
+              value: file:/var/lib/rendezvous-server/rendezvous-server.db
+          image: astarte/go-fdo-server:ade68cda47-20251128
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8041
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          name: rendezvous
+          ports:
+            - containerPort: 8041
+              name: http
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8041
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/rendezvous-server
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/test/manifests/dependencies/rendezvous-server/rv-service.yaml
+++ b/test/manifests/dependencies/rendezvous-server/rv-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: rendezvous-server
+  name: rendezvous-server
+spec:
+  ports:
+    - name: http
+      port: 8041
+      protocol: TCP
+      targetPort: 8041
+  selector:
+    app: rendezvous-server
+  type: ClusterIP


### PR DESCRIPTION
Astarte 1.4 requires Vault and a rendezvous server. Deploy OpenBao (Vault-compatible) via Helm and the rendezvous server from local manifests in BeforeAll. Teardown both in AfterAll.

Also switch the target test version from 1.3 to 1.4 now that all prerequisites are in place