### PR TITLE
fix(test): clear inherited Vault config on 1.3 test case

### DIFF
--- a/internal/webhook/api/v2alpha1/astarte_webhook_test.go
+++ b/internal/webhook/api/v2alpha1/astarte_webhook_test.go
@@ -1038,6 +1038,7 @@ var _ = Describe("Astarte Webhook testing", Ordered, Serial, func() {
 
 		It("should succeed when FDO is disabled on Astarte 1.3", func() {
 			cr.Spec.Version = "1.3.0"
+			cr.Spec.Vault = nil
 			cr.Spec.AstarteInstanceID = "coverageid5"
 			cr.Spec.FDO = &apiv2alpha1.AstarteFDOSpec{
 				Enable: false,


### PR DESCRIPTION
Base manifest is 1.4 which includes Vault, but the test sets version to 1.3 where Vault is unsupported. Nil it out so the webhook doesn't reject the spec before reaching the FDO check.