### PR TITLE
fix(e2e): align e2e tests with operator-sdk/kubebuilder conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
-KIND_CLUSTER ?= memcached-operator-test-e2e
+KIND_CLUSTER ?= astarte-operator-test-e2e
 
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -38,6 +38,13 @@ func TestE2E(t *testing.T) {
 	RunSpecs(t, "Astarte Operator e2e suite")
 }
 
+var _ = ReportAfterEach(func(specReport SpecReport) {
+	if specReport.Failed() {
+		DumpAstarteOperatorDebuggingInfo(operatorNamespace)
+		DumpAstarteDebuggingInfo()
+	}
+})
+
 var _ = BeforeSuite(func() {
 	By("installing prometheus operator")
 	Expect(InstallPrometheusOperator()).To(Succeed())
@@ -104,9 +111,6 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	By("dump Astarte Operator info and logs for debugging")
-	DumpAstarteOperatorDebuggingInfo(operatorNamespace)
-
 	By("undeploying the controller-manager")
 	cmd := exec.Command("make", "undeploy")
 	_, _ = Run(cmd)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -20,11 +20,14 @@ package e2e
 
 import (
 	"fmt"
+	"os/exec"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
 	. "github.com/onsi/gomega"    //nolint:staticcheck
+
+	"github.com/astarte-platform/astarte-kubernetes-operator/internal/version"
 )
 
 func TestE2E(t *testing.T) {
@@ -34,3 +37,113 @@ func TestE2E(t *testing.T) {
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting astarte-kubernetes-operator suite\n")
 	RunSpecs(t, "Astarte Operator e2e suite")
 }
+
+var _ = BeforeSuite(func() {
+	By("installing prometheus operator")
+	Expect(InstallPrometheusOperator()).To(Succeed())
+
+	By("installing the cert-manager")
+	Expect(InstallCertManager()).To(Succeed())
+
+	By("installing rabbitmq cluster operator")
+	Expect(InstallRabbitMQClusterOperator()).To(Succeed())
+
+	By("installing openbao cluster helm chart")
+	Expect(DeployOpenBao()).To(Succeed())
+
+	By("deploying the rendezvous server")
+	Expect(DeployRendezvousServer()).To(Succeed())
+
+	By("deploying the RabbitMQ cluster")
+	Expect(DeployRabbitMQCluster()).To(Succeed())
+
+	By("creating the RabbitMq connection secret")
+	Expect(CreateRabbitMQConnectionSecret()).To(Succeed())
+
+	By("installing scylla operator")
+	Expect(InstallScyllaOperator()).To(Succeed())
+
+	By("deploying the Scylla cluster")
+	Expect(DeployScyllaCluster()).To(Succeed())
+
+	By("creating the Scylla connection secret")
+	Expect(CreateScyllaConnectionSecret()).To(Succeed())
+
+	By("creating astarte operator namespace")
+	cmd := exec.Command("kubectl", "create", "ns", operatorNamespace)
+	_, _ = Run(cmd)
+
+	projectimage := fmt.Sprintf("local-registry/astarte-kubernetes-operator:%s", version.Version)
+
+	By("building the manager(Operator) image")
+	cmd = exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
+	_, err := Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	By("loading the manager(Operator) image on Kind")
+	err = LoadImageToKindClusterWithName(projectimage)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	By("deploying the controller-manager")
+	cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
+	_, err = Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	By("validating that the controller-manager pod is running as expected")
+	EventuallyWithOffset(1, verifyControllerPodRunning, DefaultTimeout, DefaultRetryInterval).Should(Succeed())
+
+	By("waiting for the controller deployment to become available")
+	cmd = exec.Command("kubectl", "wait", "deployment",
+		"--for", "condition=Available",
+		"astarte-kubernetes-operator-controller-manager",
+		"-n", operatorNamespace,
+		"--timeout", "5m",
+	)
+	_, err = Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	By("dump Astarte Operator info and logs for debugging")
+	DumpAstarteOperatorDebuggingInfo(operatorNamespace)
+
+	By("undeploying the controller-manager")
+	cmd := exec.Command("make", "undeploy")
+	_, _ = Run(cmd)
+
+	By("validating that the controller-manager pod is not running")
+	Eventually(verifyControllerPodNotRunning, DefaultTimeout, DefaultRetryInterval).Should(Succeed())
+
+	By("uninstalling CRDs")
+	cmd = exec.Command("make", "uninstall")
+	_, _ = Run(cmd)
+
+	By("uninstalling the Prometheus manager bundle")
+	UninstallPrometheusOperator()
+
+	By("uninstalling rabbitmq cluster")
+	UninstallRabbitMQCluster()
+
+	By("uninstalling rabbitmq cluster operator")
+	UninstallRabbitMQClusterOperator()
+
+	By("uninstalling scylla operator")
+	UninstallScyllaOperator()
+
+	By("uninstalling the cert-manager bundle")
+	UninstallCertManager()
+
+	By("uninstalling OpenBao")
+	cmd = exec.Command("helm", "uninstall", "openbao", "--namespace", "openbao")
+	_, _ = Run(cmd)
+	cmd = exec.Command("kubectl", "delete", "namespace", "openbao")
+	_, _ = Run(cmd)
+
+	By("uninstalling the rendezvous server")
+	cmd = exec.Command("kubectl", "delete", "namespace", rendezvousServerNamespace)
+	_, _ = Run(cmd)
+
+	By("removing astarte operator namespace")
+	cmd = exec.Command("kubectl", "delete", "ns", operatorNamespace)
+	_, _ = Run(cmd)
+})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,42 +27,46 @@ import (
 
 var _ = Describe("Astarte Operator", func() {
 	Context("CR lifecycle", func() {
-		It("should create, verify health, and clean up an Astarte instance", func() {
-			projectDir, _ := GetProjectDir()
+		targetTestVersions := map[string]string{
+			"1.4": "test/manifests/api_v2alpha1_astarte_1.4.yaml",
+		}
 
-			targetTestVersions := map[string]string{
-				"1.4": filepath.Join(projectDir, "/test/manifests/api_v2alpha1_astarte_1.4.yaml"),
-			}
+		for k, v := range targetTestVersions {
+			version := k
+			manifestPath := v
 
-			for k, v := range targetTestVersions {
-				By(fmt.Sprintf("creating an instance of Astarte (CR), version: %s", k))
-				Expect(InstallAstarte(v)).To(Succeed())
+			It("should create, verify health, and clean up an Astarte v"+version+" instance", func() {
+				projectDir, _ := GetProjectDir()
+				manifest := filepath.Join(projectDir, manifestPath)
 
-				By(fmt.Sprintf("ensuring that the Astarte v%s health becomes green", k))
+				By("creating an instance of Astarte (CR)")
+				Expect(InstallAstarte(manifest)).To(Succeed())
+
+				By("ensuring that the Astarte health becomes green")
 				EventuallyWithOffset(1,
 					EnsureAstarteWithInfoDump,
 					DefaultTimeout,
 					DefaultRetryInterval,
 				).Should(Succeed())
 
-				By(fmt.Sprintf("deleting an instance of Astarte (CR), version: %s", k))
-				Expect(UninstallAstarte(v)).To(Succeed())
+				By("deleting an instance of Astarte (CR)")
+				Expect(UninstallAstarte(manifest)).To(Succeed())
 
-				By(fmt.Sprintf("ensuring that every deployment of Astarte v%s is removed", k))
+				By("ensuring that every deployment of Astarte is removed")
 				EventuallyWithOffset(1,
 					EnsureAstarteDeployementsAreRemoved,
 					DefaultTimeout,
 					DefaultRetryInterval,
 				).Should(Succeed())
 
-				By(fmt.Sprintf("ensuring that every statefulset of Astarte v%s is removed", k))
+				By("ensuring that every statefulset of Astarte is removed")
 				EventuallyWithOffset(1,
 					EnsureAstarteStatefulsetsAreRemoved,
 					DefaultTimeout,
 					DefaultRetryInterval,
 				).Should(Succeed())
 
-				By(fmt.Sprintf("ensuring that every configmap of Astarte v%s is removed", k))
+				By("ensuring that every configmap of Astarte is removed")
 				EventuallyWithOffset(1,
 					EnsureAstarteConfigmapsAreRemoved,
 					DefaultTimeout,
@@ -91,20 +94,20 @@ var _ = Describe("Astarte Operator", func() {
 					DefaultRetryInterval,
 				).Should(Succeed())
 
-				By(fmt.Sprintf("ensuring that every secret of Astarte v%s is removed", k))
+				By("ensuring that every secret of Astarte is removed")
 				EventuallyWithOffset(1,
 					EnsureAstarteSecretsAreRemoved,
 					DefaultTimeout,
 					DefaultRetryInterval,
 				).Should(Succeed())
 
-				By(fmt.Sprintf("ensuring that every pvc of Astarte v%s is removed", k))
+				By("ensuring that every pvc of Astarte is removed")
 				EventuallyWithOffset(1,
 					EnsureAstartePvcAreRemoved,
 					DefaultTimeout,
 					DefaultRetryInterval,
 				).Should(Succeed())
-			}
-		})
+			})
+		}
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -20,128 +20,22 @@ package e2e
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/astarte-platform/astarte-kubernetes-operator/internal/version"
 )
 
-const (
-	operatorNamespace = "astarte-kubernetes-operator-system"
-)
-
-var _ = Describe("controller", Ordered, func() {
-	BeforeAll(func() {
-		By("installing prometheus operator")
-		Expect(InstallPrometheusOperator()).To(Succeed())
-
-		By("installing the cert-manager")
-		Expect(InstallCertManager()).To(Succeed())
-
-		By("installing rabbitmq cluster operator")
-		Expect(InstallRabbitMQClusterOperator()).To(Succeed())
-
-		By("installing openbao cluster helm chart")
-		Expect(DeployOpenBao()).To(Succeed())
-
-		By("deploying the rendezvous server")
-		Expect(DeployRendezvousServer()).To(Succeed())
-
-		By("deploying the RabbitMQ cluster")
-		Expect(DeployRabbitMQCluster()).To(Succeed())
-
-		By("creating the RabbitMq connection secret")
-		Expect(CreateRabbitMQConnectionSecret()).To(Succeed())
-
-		By("installing scylla operator")
-		Expect(InstallScyllaOperator()).To(Succeed())
-
-		By("deploying the Scylla cluster")
-		Expect(DeployScyllaCluster()).To(Succeed())
-
-		By("creating the Scylla connection secret")
-		Expect(CreateScyllaConnectionSecret()).To(Succeed())
-
-		By("creating astarte operator namespace")
-		cmd := exec.Command("kubectl", "create", "ns", operatorNamespace)
-		_, _ = Run(cmd)
-	})
-
-	AfterAll(func() {
-		By("uninstalling the Prometheus manager bundle")
-		UninstallPrometheusOperator()
-
-		By("uninstalling rabbitmq cluster")
-		UninstallRabbitMQCluster()
-
-		By("uninstalling rabbitmq cluster operator")
-		UninstallRabbitMQClusterOperator()
-
-		By("uninstalling scylla operator")
-		UninstallScyllaOperator()
-
-		By("uninstalling the cert-manager bundle")
-		UninstallCertManager()
-
-		By("uninstalling OpenBao")
-		cmd := exec.Command("helm", "uninstall", "openbao", "--namespace", "openbao")
-		_, _ = Run(cmd)
-		cmd = exec.Command("kubectl", "delete", "namespace", "openbao")
-		_, _ = Run(cmd)
-
-		By("uninstalling the rendezvous server")
-		cmd = exec.Command("kubectl", "delete", "namespace", rendezvousServerNamespace)
-		_, _ = Run(cmd)
-
-		By("removing astarte operator namespace")
-		cmd = exec.Command("kubectl", "delete", "ns", operatorNamespace)
-		_, _ = Run(cmd)
-	})
-
-	Context("Astarte Operator", func() {
-		It("should run successfully", func() {
-			var err error
+var _ = Describe("Astarte Operator", func() {
+	Context("CR lifecycle", func() {
+		It("should create, verify health, and clean up an Astarte instance", func() {
 			projectDir, _ := GetProjectDir()
-
-			// projectimage stores the name of the image used in the example
-			var projectimage = fmt.Sprintf("local-registry/astarte-kubernetes-operator:%s", version.Version)
-
-			By("building the manager(Operator) image")
-			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
-			_, err = Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("loading the the manager(Operator) image on Kind")
-			err = LoadImageToKindClusterWithName(projectimage)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("deploying the controller-manager")
-			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
-			_, err = Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("validating that the controller-manager pod is running as expected")
-			EventuallyWithOffset(1, verifyControllerPodRunning, DefaultTimeout, DefaultRetryInterval).Should(Succeed())
-
-			By("waiting for the controller deployment to become available")
-			cmd = exec.Command("kubectl", "wait", "deployment",
-				"--for", "condition=Available",
-				"astarte-kubernetes-operator-controller-manager",
-				"-n", operatorNamespace,
-				"--timeout", "5m",
-			)
-			_, err = Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			targetTestVersions := map[string]string{
 				"1.4": filepath.Join(projectDir, "/test/manifests/api_v2alpha1_astarte_1.4.yaml"),
 			}
 
 			for k, v := range targetTestVersions {
-
 				By(fmt.Sprintf("creating an instance of Astarte (CR), version: %s", k))
 				Expect(InstallAstarte(v)).To(Succeed())
 
@@ -155,7 +49,6 @@ var _ = Describe("controller", Ordered, func() {
 				By(fmt.Sprintf("deleting an instance of Astarte (CR), version: %s", k))
 				Expect(UninstallAstarte(v)).To(Succeed())
 
-				// deployments
 				By(fmt.Sprintf("ensuring that every deployment of Astarte v%s is removed", k))
 				EventuallyWithOffset(1,
 					EnsureAstarteDeployementsAreRemoved,
@@ -163,7 +56,6 @@ var _ = Describe("controller", Ordered, func() {
 					DefaultRetryInterval,
 				).Should(Succeed())
 
-				// statefulsets
 				By(fmt.Sprintf("ensuring that every statefulset of Astarte v%s is removed", k))
 				EventuallyWithOffset(1,
 					EnsureAstarteStatefulsetsAreRemoved,
@@ -171,7 +63,6 @@ var _ = Describe("controller", Ordered, func() {
 					DefaultRetryInterval,
 				).Should(Succeed())
 
-				// configmaps
 				By(fmt.Sprintf("ensuring that every configmap of Astarte v%s is removed", k))
 				EventuallyWithOffset(1,
 					EnsureAstarteConfigmapsAreRemoved,
@@ -179,7 +70,6 @@ var _ = Describe("controller", Ordered, func() {
 					DefaultRetryInterval,
 				).Should(Succeed())
 
-				// RabbitMq connections secrets
 				By("deleting the RabbitMq connection secret")
 				EventuallyWithOffset(1,
 					DeleteRabbitMQConnectionSecret,
@@ -187,7 +77,6 @@ var _ = Describe("controller", Ordered, func() {
 					DefaultRetryInterval,
 				).Should(Succeed())
 
-				// Scylla connection secret
 				By("deleting the Scylla connection secret")
 				EventuallyWithOffset(1,
 					DeleteScyllaConnectionSecret,
@@ -195,7 +84,6 @@ var _ = Describe("controller", Ordered, func() {
 					DefaultRetryInterval,
 				).Should(Succeed())
 
-				// Vault connection secret
 				By("deleting the Vault connection secret")
 				EventuallyWithOffset(1,
 					DeleteVaultConnectionSecret,
@@ -203,7 +91,6 @@ var _ = Describe("controller", Ordered, func() {
 					DefaultRetryInterval,
 				).Should(Succeed())
 
-				// secrets
 				By(fmt.Sprintf("ensuring that every secret of Astarte v%s is removed", k))
 				EventuallyWithOffset(1,
 					EnsureAstarteSecretsAreRemoved,
@@ -211,7 +98,6 @@ var _ = Describe("controller", Ordered, func() {
 					DefaultRetryInterval,
 				).Should(Succeed())
 
-				// pvc
 				By(fmt.Sprintf("ensuring that every pvc of Astarte v%s is removed", k))
 				EventuallyWithOffset(1,
 					EnsureAstartePvcAreRemoved,
@@ -219,42 +105,6 @@ var _ = Describe("controller", Ordered, func() {
 					DefaultRetryInterval,
 				).Should(Succeed())
 			}
-
-			By("dump Astarte Operator info and logs for debugging")
-			DumpAstarteOperatorDebuggingInfo(operatorNamespace)
-
-			By("undeploying the controller-manager")
-			cmd = exec.Command("make", "undeploy")
-			_, err = Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("validating that the controller-manager pod is not running")
-			verifyControllerDown := func() error {
-				// Get pod name
-				cmd = exec.Command("kubectl", "get",
-					"pods", "-l", "control-plane=controller-manager",
-					"-o", "go-template={{ range .items }}"+
-						"{{ if not .metadata.deletionTimestamp }}"+
-						"{{ .metadata.name }}"+
-						"{{ \"\\n\" }}{{ end }}{{ end }}",
-					"-n", operatorNamespace,
-				)
-
-				podOutput, err := Run(cmd)
-				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				podNames := GetNonEmptyLines(string(podOutput))
-				if len(podNames) != 0 {
-					return fmt.Errorf("expect 0 controller pods running, but got %d", len(podNames))
-				}
-
-				return nil
-			}
-			EventuallyWithOffset(1, verifyControllerDown, DefaultTimeout, DefaultRetryInterval).Should(Succeed())
-
-			By("uninstalling CRDs")
-			cmd = exec.Command("make", "uninstall")
-			_, err = Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -136,11 +136,7 @@ var _ = Describe("controller", Ordered, func() {
 				time.Sleep(4 * time.Second)
 
 				By(fmt.Sprintf("creating an instance of Astarte (CR), version: %s", k))
-				EventuallyWithOffset(1,
-					InstallAstarte,
-					DefaultTimeout,
-					DefaultRetryInterval,
-				).WithArguments(v).Should(Succeed())
+				Expect(InstallAstarte(v)).To(Succeed())
 
 				By(fmt.Sprintf("ensuring that the Astarte v%s health becomes green", k))
 				EventuallyWithOffset(1,
@@ -150,11 +146,7 @@ var _ = Describe("controller", Ordered, func() {
 				).Should(Succeed())
 
 				By(fmt.Sprintf("deleting an instance of Astarte (CR), version: %s", k))
-				EventuallyWithOffset(1,
-					UninstallAstarte,
-					DefaultTimeout,
-					DefaultRetryInterval,
-				).WithArguments(v).Should(Succeed())
+				Expect(UninstallAstarte(v)).To(Succeed())
 
 				// deployments
 				By(fmt.Sprintf("ensuring that every deployment of Astarte v%s is removed", k))

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -104,7 +104,6 @@ var _ = Describe("controller", Ordered, func() {
 
 	Context("Astarte Operator", func() {
 		It("should run successfully", func() {
-			var controllerPodName string
 			var err error
 			projectDir, _ := GetProjectDir()
 
@@ -126,39 +125,7 @@ var _ = Describe("controller", Ordered, func() {
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("validating that the controller-manager pod is running as expected")
-			verifyControllerUp := func() error {
-				// Get pod name
-				cmd = exec.Command("kubectl", "get",
-					"pods", "-l", "control-plane=controller-manager",
-					"-o", "go-template={{ range .items }}"+
-						"{{ if not .metadata.deletionTimestamp }}"+
-						"{{ .metadata.name }}"+
-						"{{ \"\\n\" }}{{ end }}{{ end }}",
-					"-n", operatorNamespace,
-				)
-
-				podOutput, err := Run(cmd)
-				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				podNames := GetNonEmptyLines(string(podOutput))
-				if len(podNames) != 1 {
-					return fmt.Errorf("expect 1 controller pods running, but got %d", len(podNames))
-				}
-				controllerPodName = podNames[0]
-				ExpectWithOffset(2, controllerPodName).Should(ContainSubstring("controller-manager"))
-
-				// Validate pod status
-				cmd = exec.Command("kubectl", "get",
-					"pods", controllerPodName, "-o", "jsonpath={.status.phase}",
-					"-n", operatorNamespace,
-				)
-				status, err := Run(cmd)
-				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				if string(status) != "Running" {
-					return fmt.Errorf("controller pod in %s status", status)
-				}
-				return nil
-			}
-			EventuallyWithOffset(1, verifyControllerUp, DefaultTimeout, DefaultRetryInterval).Should(Succeed())
+			EventuallyWithOffset(1, verifyControllerPodRunning, DefaultTimeout, DefaultRetryInterval).Should(Succeed())
 
 			targetTestVersions := map[string]string{
 				"1.4": filepath.Join(projectDir, "/test/manifests/api_v2alpha1_astarte_1.4.yaml"),

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -127,13 +126,21 @@ var _ = Describe("controller", Ordered, func() {
 			By("validating that the controller-manager pod is running as expected")
 			EventuallyWithOffset(1, verifyControllerPodRunning, DefaultTimeout, DefaultRetryInterval).Should(Succeed())
 
+			By("waiting for the controller deployment to become available")
+			cmd = exec.Command("kubectl", "wait", "deployment",
+				"--for", "condition=Available",
+				"astarte-kubernetes-operator-controller-manager",
+				"-n", operatorNamespace,
+				"--timeout", "5m",
+			)
+			_, err = Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
 			targetTestVersions := map[string]string{
 				"1.4": filepath.Join(projectDir, "/test/manifests/api_v2alpha1_astarte_1.4.yaml"),
 			}
 
 			for k, v := range targetTestVersions {
-				// let's wait a few seconds to ensure the webhook becomes available
-				time.Sleep(4 * time.Second)
 
 				By(fmt.Sprintf("creating an instance of Astarte (CR), version: %s", k))
 				Expect(InstallAstarte(v)).To(Succeed())

--- a/test/e2e/e2e_utils.go
+++ b/test/e2e/e2e_utils.go
@@ -45,6 +45,8 @@ const (
 	astarteName      = "example-astarte"
 	astarteNamespace = "example-astarte-ns"
 
+	operatorNamespace = "astarte-kubernetes-operator-system"
+
 	// DefaultRetryInterval applied to all tests
 	DefaultRetryInterval time.Duration = time.Second * 10
 	// DefaultTimeout applied to all tests
@@ -87,6 +89,26 @@ func verifyControllerPodRunning() error {
 	}
 	if !strings.Contains(podNames[0], "controller-manager") {
 		return fmt.Errorf("unexpected pod name: %s", podNames[0])
+	}
+	return nil
+}
+
+func verifyControllerPodNotRunning() error {
+	cmd := exec.Command("kubectl", "get",
+		"pods", "-l", "control-plane=controller-manager",
+		"-o", "go-template={{ range .items }}"+
+			"{{ if not .metadata.deletionTimestamp }}"+
+			"{{ .metadata.name }}"+
+			"{{\"\\n\"}}{{ end }}{{ end }}",
+		"-n", operatorNamespace,
+	)
+	output, err := Run(cmd)
+	if err != nil {
+		return err
+	}
+	podNames := GetNonEmptyLines(string(output))
+	if len(podNames) != 0 {
+		return fmt.Errorf("expect 0 controller pods running, but got %d", len(podNames))
 	}
 	return nil
 }

--- a/test/e2e/e2e_utils.go
+++ b/test/e2e/e2e_utils.go
@@ -230,7 +230,9 @@ func EnsureAstarteHealthGreen() error {
 
 func EnsureAstarteWithInfoDump() error {
 	err := EnsureAstarteHealthGreen()
-	DumpAstarteDebuggingInfo()
+	if err != nil {
+		DumpAstarteDebuggingInfo()
+	}
 	return err
 }
 

--- a/test/e2e/e2e_utils.go
+++ b/test/e2e/e2e_utils.go
@@ -71,6 +71,26 @@ func warnError(err error) {
 	_, _ = fmt.Fprintf(GinkgoWriter, "warning: %v\n", err)
 }
 
+func verifyControllerPodRunning() error {
+	cmd := exec.Command("kubectl", "get",
+		"pods", "-l", "control-plane=controller-manager",
+		"-o", "jsonpath={.items[?(@.status.phase=='Running')].metadata.name}",
+		"-n", operatorNamespace,
+	)
+	output, err := Run(cmd)
+	if err != nil {
+		return err
+	}
+	podNames := GetNonEmptyLines(string(output))
+	if len(podNames) != 1 {
+		return fmt.Errorf("expect 1 running controller pod, got %d", len(podNames))
+	}
+	if !strings.Contains(podNames[0], "controller-manager") {
+		return fmt.Errorf("unexpected pod name: %s", podNames[0])
+	}
+	return nil
+}
+
 func DeployRendezvousServer() error {
 	if err := EnsureNamespaceExists(rendezvousServerNamespace); err != nil {
 		return fmt.Errorf("failed to ensure namespace %s exists: %w", rendezvousServerNamespace, err)

--- a/test/e2e/e2e_utils.go
+++ b/test/e2e/e2e_utils.go
@@ -98,11 +98,6 @@ func InstallPrometheusOperator() error {
 func Run(cmd *exec.Cmd) ([]byte, error) {
 	dir, _ := GetProjectDir()
 	cmd.Dir = dir
-
-	if err := os.Chdir(cmd.Dir); err != nil {
-		_, _ = fmt.Fprintf(GinkgoWriter, "chdir dir: %s\n", err)
-	}
-
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	command := strings.Join(cmd.Args, " ")
 	_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)


### PR DESCRIPTION
General refactor of end-to-end tests:
- Moved setup/teardown out of BeforeAll/AfterAll and into BeforeSuite/AfterSuite
- Split the single It block into one per Astarte version so failures point at the right test
- Replaced the hardcoded time.Sleep for webhook readiness with kubectl wait on the deployment
- Expect instead of Eventually for one-shot kubectl apply/delete
- Debug info in EnsureAstarteWithInfoDump only writes on failure now
- Added ReportAfterEach to dump operator/CR state automatically when a spec fails
- Fixed stale kubebuilder scaffold names and comments in the Makefile