### PR TITLE
chore: remove deprecated goreportcard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Astarte Kubernetes Operator
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/astarte-platform/astarte-kubernetes-operator)](https://goreportcard.com/report/github.com/astarte-platform/astarte-kubernetes-operator)
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 ![Docker Pulls](https://img.shields.io/docker/pulls/astarte/astarte-kubernetes-operator)
 


### PR DESCRIPTION
Thank you for these years together. Goodbye!

See: https://github.com/gojp/goreportcard/commit/176744ca23b40aa64c55b390161a3c78982e91b8