### PR TITLE
fix: improve ssl redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [26.7.0-rc.1] - Unreleased
+
+## Fixed
+- Fix HTTP to HTTPS redirect on port 443 instead of 8443
+
+
 ## [26.7.0-rc.0] - 2026-07-13
 
 ### Added

--- a/internal/defaultingress/common.go
+++ b/internal/defaultingress/common.go
@@ -116,6 +116,7 @@ func getCommonIngressAnnotations(cr *ingressv2alpha1.AstarteDefaultIngress, pare
 	annotations = map[string]string{
 		"haproxy.org/backend-config-snippet": getHAProxyBackendConfig(parent),
 		"haproxy.org/ssl-redirect":           strconv.FormatBool(apiSslRedirect),
+		"haproxy.org/ssl-redirect-port":      "443",
 		"haproxy.org/response-set-header": "\n" +
 			"Content-Security-Policy " + buildContentSecurityPolicy(cr, parent) + "\n" +
 			"X-Content-Type-Options nosniff\n" +

--- a/internal/fdoingress/fdo_ingress.go
+++ b/internal/fdoingress/fdo_ingress.go
@@ -3,6 +3,7 @@ package fdoingress
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	apiv2alpha1 "github.com/astarte-platform/astarte-kubernetes-operator/api/api/v2alpha1"
 	"github.com/astarte-platform/astarte-kubernetes-operator/internal/misc"
@@ -31,7 +32,7 @@ func EnsureFDOIngress(cr *fdoingress.AstarteFDOIngress, parent *apiv2alpha1.Asta
 			return e
 		}
 
-		ingress.SetAnnotations(getHAProxyIngressAnnotations())
+		ingress.SetAnnotations(getHAProxyIngressAnnotations(parent))
 		ingress.Spec = getFDOIngressSpec(cr, parent)
 
 		return nil
@@ -55,9 +56,10 @@ func getFDOIngressSpec(cr *fdoingress.AstarteFDOIngress, parent *apiv2alpha1.Ast
 	return ingressSpec
 }
 
-func getHAProxyIngressAnnotations() map[string]string {
+func getHAProxyIngressAnnotations(parent *apiv2alpha1.Astarte) map[string]string {
 	annotations := map[string]string{
 		"haproxy.org/backend-config-snippet": getHAProxyBackendConfig(),
+		"haproxy.org/ssl-redirect":           strconv.FormatBool(pointy.BoolValue(parent.Spec.API.SSL, true)),
 		"haproxy.org/ssl-redirect-port":      "443",
 	}
 	return annotations

--- a/internal/fdoingress/fdo_ingress.go
+++ b/internal/fdoingress/fdo_ingress.go
@@ -58,6 +58,7 @@ func getFDOIngressSpec(cr *fdoingress.AstarteFDOIngress, parent *apiv2alpha1.Ast
 func getHAProxyIngressAnnotations() map[string]string {
 	annotations := map[string]string{
 		"haproxy.org/backend-config-snippet": getHAProxyBackendConfig(),
+		"haproxy.org/ssl-redirect-port":      "443",
 	}
 	return annotations
 }


### PR DESCRIPTION
Two fixes for the HAProxy ingress controller configuration:

1. The `ssl-redirect-port` annotation was missing from both default    and FDO ingresses, causing redirects to go to the wrong port (8443). Now explicitly set to `443`.

2. The FDO ingress was missing the `ssl-redirect` annotation entirely. The annotation is now set based on the API SSL config (`parent.Spec.API.SSL`), mirroring the behavior of the default ingress.