### PR TITLE
fix: support prerelease versions in capability and version checks

### DIFF
--- a/internal/version/capabilities.go
+++ b/internal/version/capabilities.go
@@ -71,11 +71,14 @@ func mustParseConstraint(c string) *semver.Constraints {
 }
 
 // Supports evaluates if the configured version satisfies the feature's constraint.
+// The prerelease suffix is stripped before checking, so that e.g. 1.4.0-rc.0
+// has the same capabilities as 1.4.0.
 func (c *Checker) Supports(f Feature) bool {
 	constraint, exists := matrix[f]
 	if !exists {
-		// Default to false if a feature isn't in the matrix
 		return false
 	}
-	return constraint.Check(c.version)
+	stripped := *c.version
+	stripped, _ = stripped.SetPrerelease("")
+	return constraint.Check(&stripped)
 }

--- a/internal/version/capabilities.go
+++ b/internal/version/capabilities.go
@@ -42,8 +42,6 @@ type Checker struct {
 }
 
 // NewChecker safely parses the Astarte version and returns a Checker.
-// It uses the same version handling as the rest of the operator, including
-// support for the "snapshot" version string and prerelease stripping.
 func NewChecker(versionStr string) (*Checker, error) {
 	v, err := GetAstarteSemanticVersionFrom(versionStr)
 	if err != nil {
@@ -54,10 +52,10 @@ func NewChecker(versionStr string) (*Checker, error) {
 
 func init() {
 	matrix = map[Feature]*semver.Constraints{
-		// Vault is supported strictly in 1.4.0 and above
-		Vault: mustParseConstraint(">= 1.4.0"),
-		// FDO is optional (can be disabled) only for versions < 1.4.0
-		OptionalFDO: mustParseConstraint("< 1.4.0"),
+		// Vault is supported strictly in 1.4.0 and above (including prereleases)
+		Vault: mustParseConstraint(">= 1.4.0-0"),
+		// FDO is optional (can be disabled) only for versions < 1.4.0 (excluding prereleases)
+		OptionalFDO: mustParseConstraint("< 1.4.0-0"),
 	}
 }
 
@@ -71,14 +69,10 @@ func mustParseConstraint(c string) *semver.Constraints {
 }
 
 // Supports evaluates if the configured version satisfies the feature's constraint.
-// The prerelease suffix is stripped before checking, so that e.g. 1.4.0-rc.0
-// has the same capabilities as 1.4.0.
 func (c *Checker) Supports(f Feature) bool {
 	constraint, exists := matrix[f]
 	if !exists {
 		return false
 	}
-	stripped := *c.version
-	stripped, _ = stripped.SetPrerelease("")
-	return constraint.Check(&stripped)
+	return constraint.Check(c.version)
 }

--- a/internal/version/checks.go
+++ b/internal/version/checks.go
@@ -29,18 +29,15 @@ var (
 	ErrConstraintNotSatisfied = errors.New("constraint not satisfied")
 )
 
-// CheckConstraintAgainstAstarteVersion validates a given Astarte version against a given constraint. Returns nil if
-// the constraint is satisfied, an error otherwise
+// CheckConstraintAgainstAstarteVersion validates a given Astarte version against a given constraint.
+// The constraint should use the -0 suffix pattern (e.g. ">= 1.4.0-0") to include prerelease versions.
+// Returns nil if the constraint is satisfied, an error otherwise.
 func CheckConstraintAgainstAstarteVersion(constraint, v string) error {
 	c, err := semver.NewConstraint(constraint)
 	if err != nil {
 		return err
 	}
 	semVer, err := GetAstarteSemanticVersionFrom(v)
-	if err != nil {
-		return err
-	}
-	*semVer, err = semVer.SetPrerelease("")
 	if err != nil {
 		return err
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -29,7 +29,7 @@ const (
 
 	// AstarteVersionConstraintString represents the range of supported Astarte versions for this Operator.
 	// If the Astarte version falls out of this range, reconciliation will be immediately aborted.
-	AstarteVersionConstraintString = ">= 1.3.0, < 1.5.0"
+	AstarteVersionConstraintString = ">= 1.3.0-0, < 1.5.0-0"
 
 	// SnapshotVersion represents the name of the master/snapshot version, which can or cannot be installed
 	// by this cluster
@@ -57,9 +57,6 @@ func CanManageVersion(v string) bool {
 	if err != nil {
 		return false
 	}
-
-	// Strip the prerelease
-	*targetVersion, _ = targetVersion.SetPrerelease("")
 
 	c, _ := semver.NewConstraint(AstarteVersionConstraintString)
 


### PR DESCRIPTION
Masterminds/semver treats prereleases as below the release (1.4.0-rc.0 < 1.4.0), so constraints like >= 1.4.0 wrongly excluded 1.4.0-rc.0 from Vault support and included it in OptionalFDO.

Replace runtime SetPrerelease("") stripping with the idiomatic -0 constraint suffix (>= 1.4.0-0), which tells the library to include all prereleases starting from the lowest one. Applied consistently across capabilities.go, version.go, and checks.go.