### PR TITLE
Revert "chore: add artifacthub-repo.yml to Helm Chart"

### DIFF
--- a/charts/astarte-operator/artifacthub-repo.yml
+++ b/charts/astarte-operator/artifacthub-repo.yml
@@ -1,7 +1,0 @@
-# artifacthub-repo.yml
-
-owners:
-  - name: "Luca Marchiori"
-    email: "luca.marchiori@secomind.com"
-  - name: "Guilherme Crocetti"
-    email: "guilherme.crocetti@secomind.com"


### PR DESCRIPTION
Reverts astarte-platform/astarte-kubernetes-operator#597

The PR must be based on 26.7 branch.