### PR TITLE
Revert "chore: add artifacthub-repo.yml to Helm Chart"

### DIFF
--- a/charts/astarte-operator/artifacthub-repo.yml
+++ b/charts/astarte-operator/artifacthub-repo.yml
@@ -1,7 +1,0 @@
-# artifacthub-repo.yml
-
-owners:
-  - name: "Luca Marchiori"
-    email: "luca.marchiori@secomind.com"
-  - name: "Guilherme Crocetti"
-    email: "guilherme.crocetti@secomind.com"


### PR DESCRIPTION
Reverts astarte-platform/astarte-kubernetes-operator#599

Yes, this is not the right place for the metadata file. In fact, it must be placed at the root of the Helm Chart repository. See:
- https://github.com/astarte-platform/helm/commit/45b1f1f9f39694b65d90e463588b3ec334efb063
- https://github.com/astarte-platform/helm/commit/701deba5e6d7c0bdbbb042383f5bd951e968fce3