### PR TITLE
chore: prepare v26.7.0-rc.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [26.7.0-rc.3] - 2026-08-04
+
+### Added
+- Add Artifact Hub repository metadata to the Helm chart.
+
 ## [26.7.0-rc.2] - 2026-07-31
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 26.7.0-rc.2
+VERSION ?= 26.7.0-rc.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Astarte Kubernetes Operator
 
-[![Version: 26.7.0-rc.2](https://img.shields.io/badge/Version-26.7.0--rc.2-informational?style=flat-square)](https://github.com/astarte-platform/astarte-kubernetes-operator/releases) [![License](http://img.shields.io/:license-apache-blue.svg?style=flat-square)](http://www.apache.org/licenses/LICENSE-2.0.html) [![Docker Pulls](https://img.shields.io/docker/pulls/astarte/astarte-kubernetes-operator?style=flat-square)](https://hub.docker.com/r/astarte/astarte-kubernetes-operator) 
+[![Version: 26.7.0-rc.3](https://img.shields.io/badge/Version-26.7.0--rc.3-informational?style=flat-square)](https://github.com/astarte-platform/astarte-kubernetes-operator/releases) [![License](http://img.shields.io/:license-apache-blue.svg?style=flat-square)](http://www.apache.org/licenses/LICENSE-2.0.html) [![Docker Pulls](https://img.shields.io/docker/pulls/astarte/astarte-kubernetes-operator?style=flat-square)](https://hub.docker.com/r/astarte/astarte-kubernetes-operator)
 
 <img src="mascotte.svg" align="right" width="160px" />
 Astarte Kubernetes Operator runs and manages an Astarte Cluster in a Kubernetes Cluster. It is meant

--- a/charts/astarte-operator/Chart.yaml
+++ b/charts/astarte-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: astarte-operator
 description: The Astarte Kubernetes Operator Helm Chart.
 type: application
 
-version: "26.7.0-rc.2"
-appVersion: "26.7.0-rc.2"
+version: "26.7.0-rc.3"
+appVersion: "26.7.0-rc.3"
 kubeVersion: ">= 1.19.0-0"
 
 home: https://github.com/astarte-platform/astarte-kubernetes-operator

--- a/charts/astarte-operator/README.md
+++ b/charts/astarte-operator/README.md
@@ -1,6 +1,6 @@
 # astarte-operator
 
-![Version: 26.7.0-rc.2](https://img.shields.io/badge/Version-26.7.0--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.7.0-rc.2](https://img.shields.io/badge/AppVersion-26.7.0--rc.2-informational?style=flat-square)
+![Version: 26.7.0-rc.3](https://img.shields.io/badge/Version-26.7.0--rc.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.7.0-rc.3](https://img.shields.io/badge/AppVersion-26.7.0--rc.3-informational?style=flat-square)
 
 The Astarte Kubernetes Operator Helm Chart.
 
@@ -29,7 +29,7 @@ Kubernetes: `>= 1.24.0-0`
 |-----|------|---------|-------------|
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"astarte/astarte-kubernetes-operator"` |  |
-| image.tag | string | `"26.7.0-rc.2"` | Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"26.7.0-rc.3"` | Overrides the image tag whose default is the chart appVersion. |
 | installCRDs | bool | `true` | Whether or not to install Astarte CRDs. |
 | replicaCount | int | `1` | The number of Astarte Operator replicas in your cluster. |
 | resources | object | `{"limits":{"cpu":"100m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resources to assign to each Astarte Operator instance. |

--- a/charts/astarte-operator/values.yaml
+++ b/charts/astarte-operator/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: astarte/astarte-kubernetes-operator
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "26.7.0-rc.2"
+  tag: "26.7.0-rc.3"
 
 # -- Resources to assign to each Astarte Operator instance.
 resources:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: local-registry/astarte-kubernetes-operator
-  newTag: 26.7.0-rc.2
+  newTag: 26.7.0-rc.3

--- a/docs/documentation/mix.exs
+++ b/docs/documentation/mix.exs
@@ -8,7 +8,7 @@ defmodule Doc.MixProject do
   def project do
     [
       app: :doc,
-      version: "26.7.0-rc.2",
+      version: "26.7.0-rc.3",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// Version is the Operator's version
-	Version = "26.7.0-rc.2"
+	Version = "26.7.0-rc.3"
 
 	// AstarteVersionConstraintString represents the range of supported Astarte versions for this Operator.
 	// If the Astarte version falls out of this range, reconciliation will be immediately aborted.


### PR DESCRIPTION
Although no changes have been made on the operator logic, we performed some upgrades on the Helm Chart for ownership claims (checkout the github.com/astarte-platform/helm repository). Let's trigger a new release to see the new changes applied in Artifact Hub.